### PR TITLE
fix: update PolicyException API version and add Flux controller exemptions

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/flux-exception.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/flux-exception.yaml
@@ -1,19 +1,24 @@
-apiVersion: kyverno.io/v1alpha2
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: ignore-flux-core
   namespace: kyverno
 spec:
+  match:
+    any:
+      - resources:
+          kinds: ["GitRepository", "OCIRepository", "HelmRepository"]
+          namespaces: ["flux-system"]
+      - resources:
+          kinds: ["Kustomization"]
+          namespaces: ["flux-system"]
+      - resources:
+          kinds: ["HelmRelease"]
+          namespaces: ["kyverno"]
+      - resources:
+          kinds: ["Deployment"]
+          namespaces: ["flux-system"]
+          names: ["helm-controller", "kustomize-controller", "notification-controller", "source-controller"]
   exceptions:
     - policyName: '*'
       ruleNames: ['*']
-      resources:
-        - apiGroups: ["source.toolkit.fluxcd.io"]
-          kinds: ["GitRepository", "OCIRepository", "HelmRepository"]
-          namespaces: ["flux-system"]
-        - apiGroups: ["kustomize.toolkit.fluxcd.io"]
-          kinds: ["Kustomization"]
-          namespaces: ["flux-system"]
-        - apiGroups: ["helm.toolkit.fluxcd.io"]
-          kinds: ["HelmRelease"]
-          namespaces: ["kyverno"]

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/flux-exception.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/flux-exception.yaml
@@ -22,3 +22,4 @@ spec:
   exceptions:
     - policyName: '*'
       ruleNames: ['*']
+# test comment


### PR DESCRIPTION
## Summary
This PR fixes the Capacitor drift detection error by updating the PolicyException resource configuration.

## Changes
- Update PolicyException API version from v1alpha2 to v2beta1 for Kyverno 3.4.1 compatibility
- Add match section to specify which resources the exception applies to
- Exempt Flux controller deployments (helm-controller, kustomize-controller, notification-controller, source-controller) from Kyverno policies

## Fixes
- Resolves Capacitor drift detection error with PolicyException resource
- Ensures Flux core infrastructure is properly exempted from Kyverno policy enforcement

## Testing
- [ ] Verify PolicyException is recognized by Kyverno
- [ ] Confirm Capacitor no longer reports PolicyException errors
- [ ] Ensure Flux controllers are exempted from policies
- [ ] Verify applications like Capacitor are still subject to policies