### PR TITLE
Remove conflicting TRUENAS_API_KEY environment variable

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -236,11 +236,6 @@ data:
           secretKeyRef:
             name: homepage-env-vars
             key: PROWLARR_API_KEY
-      - name: TRUENAS_API_KEY
-        valueFrom:
-          secretKeyRef:
-            name: homepage-env-vars
-            key: TRUENAS_API_KEY
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
Remove conflicting TRUENAS_API_KEY environment variable

- Remove TRUENAS_API_KEY env var that was conflicting with username/password auth
- TrueNAS widget should now use username/password authentication only
- This should resolve the 401 authentication errors

Root cause identified:
- TrueNAS widget was trying to use both API key and username/password methods
- Having both TRUENAS_API_KEY and username/password config caused conflicts
- Homepage was preferring the API key method which doesn't work with TrueNAS

Fix:
- Remove TRUENAS_API_KEY environment variable entirely
- Keep only username/password authentication for TrueNAS widget
- This should resolve the 401 authentication errors