### PR TITLE
Fix duplicate widget configurations causing 'Missing' errors

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -202,26 +202,6 @@ data:
             longitude: "{{HOMEPAGE_VAR_WEATHER_LONGITUDE}}"
             units: imperial
             cache: 5
-        - overseerr:
-            url: https://overseerr.vollminlab.com
-            key: "{{HOMEPAGE_VAR_OVERSEERR_API_KEY}}"
-            cache: 30
-        - sonarr:
-            url: https://sonarr.vollminlab.com
-            key: "{{HOMEPAGE_VAR_SONARR_API_KEY}}"
-            cache: 30
-        - radarr:
-            url: https://radarr.vollminlab.com
-            key: "{{HOMEPAGE_VAR_RADARR_API_KEY}}"
-            cache: 30
-        - prowlarr:
-            url: https://prowlarr.vollminlab.com
-            key: "{{HOMEPAGE_VAR_PROWLARR_API_KEY}}"
-            cache: 30
-        - sabnzbd:
-            url: https://sabnzbd.vollminlab.com
-            key: "{{HOMEPAGE_VAR_SABNZBD_API_KEY}}"
-            cache: 30
       enableRbac: true
     serviceAccount:
       create: true


### PR DESCRIPTION
Fix the 'Missing' errors appearing for media stack services by removing duplicate widget configurations.

**Problem:**
- Services like Overseerr, Sonarr, Radarr, Prowlarr, and SABnzbd were showing both working data AND 'Missing' errors
- This was caused by having duplicate widget definitions:
  1. Individual service widgets in the services section (working correctly)
  2. Global widgets in the widgets section (causing 'Missing' errors)

**Solution:**
- Remove duplicate global widgets for media stack services
- Keep individual service widgets in services section for proper functionality
- Keep only OpenWeatherMap as global widget in top bar
- This eliminates the 'Missing' errors while maintaining all service functionality

**Result:**
- No more 'Missing' error messages
- All media stack services continue to work properly
- Cleaner, more maintainable configuration