### PR TITLE
Fix PiHole widget URL to use /admin path

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -97,7 +97,7 @@ data:
                 icon: pihole.png
                 widget:
                   type: pihole
-                  url: https://pihole.vollminlab.com
+                  url: https://pihole.vollminlab.com/admin
                   key: "{{HOMEPAGE_VAR_PIHOLE_API_KEY}}"
                   version: 6
             - UDM:


### PR DESCRIPTION
Fix PiHole widget authentication issues by correcting the API URL.

**Problem:**
- PiHole widget was showing 401 authentication errors
- API calls were failing because the widget was pointing to the wrong base URL

**Root Cause:**
- PiHole widget was configured with URL: https://pihole.vollminlab.com
- PiHole API endpoints are actually under: https://pihole.vollminlab.com/admin

**Solution:**
- Update PiHole widget URL from https://pihole.vollminlab.com to https://pihole.vollminlab.com/admin
- This ensures API calls hit the correct endpoint path

**Expected Result:**
- PiHole widget should now authenticate properly
- DNS statistics and blocking data should display correctly