### PR TITLE
Remove Pi-hole widget due to v6 API compatibility issues

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -95,11 +95,6 @@ data:
                 description: DNS Sinkhole
                 href: https://pihole.vollminlab.com/admin
                 icon: pihole.png
-                widget:
-                  type: pihole
-                  url: https://pihole.vollminlab.com
-                  key: "{{HOMEPAGE_VAR_PIHOLE_API_KEY}}"
-                  version: 6
             - UDM:
                 description: UniFi Dream Machine
                 href: https://udm.vollminlab.com
@@ -241,11 +236,6 @@ data:
           secretKeyRef:
             name: homepage-env-vars
             key: TRUENAS_PASSWORD
-      - name: HOMEPAGE_VAR_PIHOLE_API_KEY
-        valueFrom:
-          secretKeyRef:
-            name: homepage-env-vars
-            key: PIHOLE_API_KEY
       - name: HOMEPAGE_VAR_OVERSEERR_API_KEY
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
## Summary

Removes the Pi-hole widget from the homepage configuration due to compatibility issues with Pi-hole v6's new authentication system.

## Changes

- Removed widget configuration from Pi-hole service
- Removed \HOMEPAGE_VAR_PIHOLE_API_KEY\ environment variable  
- Pi-hole service now functions as a simple bookmark only

## Background

The Pi-hole widget was failing with 401 authentication errors because Pi-hole v6 changed from simple API key authentication to session-based authentication. The homepage widget hasn't been updated to support the new authentication method.

## Testing

- Pi-hole service will still appear in the homepage as a bookmark
- No more 401 authentication errors in homepage logs
- Widget can be re-added once homepage supports Pi-hole v6 API

## Related Issues

- Pi-hole v6 API authentication changes
- Homepage widget compatibility with Pi-hole v6