### PR TITLE
Remove broken Overseerr widget due to API permission limitations

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -26,12 +26,6 @@ data:
                 description: Media request management
                 href: https://overseerr.vollminlab.com
                 icon: overseerr.png
-                namespace: mediastack
-                app: overseerr
-                widget:
-                  type: overseerr
-                  url: https://overseerr.vollminlab.com
-                  key: "{{HOMEPAGE_VAR_OVERSEERR_API_KEY}}"
             - Sonarr:
                 description: TV show collection manager
                 href: https://sonarr.vollminlab.com


### PR DESCRIPTION
- Overseerr global API key lacks permissions for request endpoints
- Widget was returning 403 Forbidden errors
- Removed widget configuration, kept working link
- This is a known limitation with Overseerr's API design