### PR TITLE
Add missing Tautulli OCIRepository for deployment

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
@@ -18,4 +18,5 @@ resources:
   - radarr-helmrepository.yaml
   - sabnzbd-helmrepository.yaml
   - sonarr-helmrepository.yaml
+  - tautulli-helmrepository.yaml
   - sealed-secrets-helmrepository.yaml

--- a/clusters/vollminlab-cluster/flux-system/repositories/tautulli-helmrepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/tautulli-helmrepository.yaml
@@ -1,0 +1,14 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: tautulli-repo
+  namespace: flux-system
+  labels:
+    app: tautulli
+    env: production
+    category: apps
+spec:
+  url: oci://tccr.io/truecharts/tautulli
+  interval: 5m
+  ref:
+    tag: 2.14.15


### PR DESCRIPTION
🚀 Deploy Tautulli:
- Create tautulli-helmrepository.yaml using TrueCharts OCI registry
- Use version 2.14.15 (latest stable Tautulli version)
- Add to flux-system repositories kustomization
- This completes the Tautulli deployment setup that was missing the OCIRepository

✅ Tautulli should now deploy successfully via Flux CD