### PR TITLE
Fix Tautulli HelmRelease configuration and add CI validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -555,6 +555,22 @@ jobs:
             fi
           done
           
+          # Validate HelmRelease status after deployment
+          if [[ "${FLUX_CRDS_AVAILABLE}" == "true" ]]; then
+            echo "🔍 Validating HelmRelease status..."
+            kubectl wait --for=condition=Ready --timeout=300s helmreleases.helm.toolkit.fluxcd.io --all -n "$TEST_NAMESPACE" || {
+              echo "❌ HelmRelease validation failed - this would break production deployment"
+              echo "🔍 Checking HelmRelease status:"
+              kubectl get helmreleases -n "$TEST_NAMESPACE" -o wide
+              echo "📋 HelmRelease events:"
+              kubectl get events -n "$TEST_NAMESPACE" --field-selector involvedObject.kind=HelmRelease --sort-by='.lastTimestamp'
+              echo "📋 Detailed HelmRelease status:"
+              kubectl describe helmreleases -n "$TEST_NAMESPACE"
+              exit 1
+            }
+            echo "✅ All HelmReleases are ready and valid"
+          fi
+          
           # Third pass: Deploy other namespaced resources (skip cluster-scoped and Flux resources)
           for file in $CHANGED_FILES; do
             if [[ -f "$file" ]] && yq eval '.kind' "$file" | grep -q .; then

--- a/clusters/vollminlab-cluster/mediastack/tautulli/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/mediastack/tautulli/app/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: tautulli
@@ -9,14 +9,14 @@ metadata:
     category: apps
 spec:
   interval: 5m
-  chartRef:
-    kind: HelmRepository
-    name: tautulli-repo
-    namespace: flux-system
   chart:
     spec:
       chart: tautulli
       version: "15.5.3"
+      sourceRef:
+        kind: HelmRepository
+        name: tautulli-repo
+        namespace: flux-system
   valuesFrom:
     - kind: ConfigMap
       name: tautulli-values


### PR DESCRIPTION
- Fix Tautulli HelmRelease to use v2 API with correct sourceRef syntax
- Add HelmRelease status validation to CI pipeline
- Ensure similar issues are caught in future CI runs

The Tautulli HelmRelease was using deprecated v2beta2 API with invalid chartRef configuration that should have been caught by CI. This change fixes both the configuration issue and adds proper validation to prevent similar issues in the future.