### PR TITLE
Fix Tautulli chart version to correct version 11.3.1

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/tautulli/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/mediastack/tautulli/app/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   chart:
     spec:
       chart: tautulli
-      version: "12.0.0"
+      version: "11.3.1"
       sourceRef:
         kind: HelmRepository
         name: tautulli-repo


### PR DESCRIPTION
- Change from non-existent versions (12.0.0, 15.5.3) to actual version 11.3.1
- Version 11.3.1 is the actual available version from k8s-at-home repository
- This should resolve the 'chart version not found' error

The issue was that we were guessing at versions instead of checking what's actually available in the repository.