### PR TITLE
Fix Tautulli configuration for k8s-at-home chart format

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/tautulli/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/tautulli/app/configmap.yaml
@@ -9,15 +9,31 @@ metadata:
     category: media
 data:
   values.yaml: |
+    env:
+      - name: PUID
+        value: "1000"
+      - name: PGID
+        value: "1000"
+      - name: TZ
+        value: "UTC"
+    
     persistence:
       config:
         enabled: true
         existingClaim: pvc-tautulli-config
         mountPath: /config
+    
     podLabels:
       app: tautulli
       env: production
       category: media
+    
+    podSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      fsGroupChangePolicy: "OnRootMismatch"
+    
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
- Add proper environment variables (PUID, PGID, TZ)
- Add podSecurityContext with fsGroupChangePolicy
- Fix permissions issue with /config directory