### PR TITLE
Remove homepage self-discovery annotations

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/ingress.yaml
@@ -6,11 +6,6 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    gethomepage.dev/enabled: "true"
-    gethomepage.dev/name: "Homepage"
-    gethomepage.dev/description: "Dynamically Detected Homepage"
-    gethomepage.dev/group: "Dynamic"
-    gethomepage.dev/icon: "homepage.png"
   labels:
     app: homepage
     env: production


### PR DESCRIPTION
- Remove gethomepage.dev annotations from homepage ingress
- Prevents homepage from discovering itself and appearing in Dynamic section
- Maintains cluster mode for other services while keeping homepage manual
- Fixes duplicate homepage entry in dashboard