### PR TITLE
Fix homepage service discovery pod selectors and internal service health checks

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/capacitor/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/flux-system/capacitor/app/ingress.yaml
@@ -15,6 +15,7 @@ metadata:
     gethomepage.dev/description: "Flux GitOps dashboard"
     gethomepage.dev/group: "Infrastructure"
     gethomepage.dev/icon: "flux.png"
+    gethomepage.dev/pod-selector: "app=capacitor"
 spec:
   ingressClassName: nginx
   rules:

--- a/clusters/vollminlab-cluster/flux-system/capacitor/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/flux-system/capacitor/app/ingress.yaml
@@ -33,4 +33,3 @@ spec:
     - hosts:
         - capacitor.vollminlab.com
       secretName: wildcard-tls
-

--- a/clusters/vollminlab-cluster/flux-system/capacitor/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/flux-system/capacitor/app/ingress.yaml
@@ -19,17 +19,18 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: capacitor.vollminlab.com
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: capacitor
-            port:
-              number: 9000
+    - host: capacitor.vollminlab.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: capacitor
+                port:
+                  number: 9000
   tls:
-  - hosts:
-    - capacitor.vollminlab.com
-    secretName: wildcard-tls
+    - hosts:
+        - capacitor.vollminlab.com
+      secretName: wildcard-tls
+

--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -86,7 +86,8 @@ data:
                 description: Container management
                 href: https://portainer.vollminlab.com
                 icon: portainer.png
-                ping: https://portainer.vollminlab.com
+                namespace: portainer
+                app: portainer
             - Nginx Proxy Manager:
                 description: Reverse proxy management
                 href: https://npm.vollminlab.com
@@ -112,23 +113,27 @@ data:
                 description: Metrics visualization
                 href: https://grafana.vollminlab.com
                 icon: grafana.png
-                ping: https://grafana.vollminlab.com
+                namespace: monitoring
+                app: grafana
             - Prometheus:
                 description: Metrics collection
                 href: https://prometheus.vollminlab.com
                 icon: prometheus.png
-                ping: https://prometheus.vollminlab.com
+                namespace: monitoring
+                app: prometheus
         - Documentation & Tools:
             - BookStack:
                 description: Wiki and documentation
                 href: https://bookstack.vollminlab.com
                 icon: bookstack.png
-                ping: https://bookstack.vollminlab.com
+                namespace: bookstack
+                app: bookstack
             - Homepage:
                 description: This dashboard
                 href: https://homepage.vollminlab.com
                 icon: homepage.png
-                ping: https://homepage.vollminlab.com
+                namespace: homepage
+                app: homepage
             - Homelab Repo:
                 description: This Kubernetes cluster repo
                 href: https://github.com/svollmi1/k8s-vollminlab-cluster

--- a/clusters/vollminlab-cluster/kyverno/policyreporter/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/kyverno/policyreporter/app/ingress.yaml
@@ -11,6 +11,7 @@ metadata:
     gethomepage.dev/description: "Kubernetes policy reporting"
     gethomepage.dev/group: "Monitoring & Observability"
     gethomepage.dev/icon: "policy-reporter.png"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=policy-reporter-ui"
   labels:
     app: policy-reporter
     env: production

--- a/clusters/vollminlab-cluster/longhorn-system/longhorn/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn/app/ingress.yaml
@@ -18,17 +18,17 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: longhorn.vollminlab.com
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: longhorn-frontend
-            port:
-              number: 80
+    - host: longhorn.vollminlab.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: longhorn-frontend
+                port:
+                  number: 80
   tls:
-  - hosts:
-    - longhorn.vollminlab.com
-    secretName: wildcard-tls
+    - hosts:
+        - longhorn.vollminlab.com
+      secretName: wildcard-tls

--- a/clusters/vollminlab-cluster/longhorn-system/longhorn/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn/app/ingress.yaml
@@ -8,8 +8,9 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: "Longhorn"
     gethomepage.dev/description: "Kubernetes storage management"
-    gethomepage.dev/group: "Monitoring & Observability"
+    gethomepage.dev/group: "Infrastructure"
     gethomepage.dev/icon: "longhorn.png"
+    gethomepage.dev/pod-selector: "app=longhorn-ui"
   labels:
     app: longhorn
     env: production

--- a/clusters/vollminlab-cluster/mediastack/overseerr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/overseerr/app/ingress.yaml
@@ -11,6 +11,7 @@ metadata:
     gethomepage.dev/description: "Media request management"
     gethomepage.dev/group: "Media Stack"
     gethomepage.dev/icon: "overseerr.png"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=overseerr"
   labels:
     app: overseerr
     env: production

--- a/clusters/vollminlab-cluster/mediastack/overseerr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/overseerr/app/ingress.yaml
@@ -19,17 +19,17 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: overseerr.vollminlab.com
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: overseerr
-            port:
-              number: 5055
+    - host: overseerr.vollminlab.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: overseerr
+                port:
+                  number: 5055
   tls:
-  - hosts:
-    - overseerr.vollminlab.com
-    secretName: wildcard-tls
+    - hosts:
+        - overseerr.vollminlab.com
+      secretName: wildcard-tls

--- a/clusters/vollminlab-cluster/mediastack/prowlarr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/prowlarr/app/ingress.yaml
@@ -11,6 +11,7 @@ metadata:
     gethomepage.dev/description: "Indexer manager"
     gethomepage.dev/group: "Media Stack"
     gethomepage.dev/icon: "prowlarr.png"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=prowlarr"
   labels:
     app: prowlarr
     env: production

--- a/clusters/vollminlab-cluster/mediastack/prowlarr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/prowlarr/app/ingress.yaml
@@ -19,18 +19,17 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: prowlarr.vollminlab.com
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: prowlarr
-            port:
-              number: 9696
+    - host: prowlarr.vollminlab.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: prowlarr
+                port:
+                  number: 9696
   tls:
-  - hosts:
-    - prowlarr.vollminlab.com
-    secretName: wildcard-tls
-
+    - hosts:
+        - prowlarr.vollminlab.com
+      secretName: wildcard-tls

--- a/clusters/vollminlab-cluster/mediastack/radarr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/radarr/app/ingress.yaml
@@ -19,17 +19,17 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: radarr.vollminlab.com
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: radarr
-            port:
-              number: 7878
+    - host: radarr.vollminlab.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: radarr
+                port:
+                  number: 7878
   tls:
-  - hosts:
-    - radarr.vollminlab.com
-    secretName: wildcard-tls
+    - hosts:
+        - radarr.vollminlab.com
+      secretName: wildcard-tls

--- a/clusters/vollminlab-cluster/mediastack/radarr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/radarr/app/ingress.yaml
@@ -11,6 +11,7 @@ metadata:
     gethomepage.dev/description: "Movie collection manager"
     gethomepage.dev/group: "Media Stack"
     gethomepage.dev/icon: "radarr.png"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=radarr"
   labels:
     app: radarr
     env: production

--- a/clusters/vollminlab-cluster/mediastack/sabnzbd/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sabnzbd/app/ingress.yaml
@@ -11,6 +11,7 @@ metadata:
     gethomepage.dev/description: "Usenet downloader"
     gethomepage.dev/group: "Media Stack"
     gethomepage.dev/icon: "sabnzbd.png"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=sabnzbd"
   labels:
     app: sabnzbd
     env: production

--- a/clusters/vollminlab-cluster/mediastack/sonarr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sonarr/app/ingress.yaml
@@ -19,17 +19,17 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: sonarr.vollminlab.com
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: sonarr
-            port:
-              number: 8989
+    - host: sonarr.vollminlab.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: sonarr
+                port:
+                  number: 8989
   tls:
-  - hosts:
-    - sonarr.vollminlab.com
-    secretName: wildcard-tls
+    - hosts:
+        - sonarr.vollminlab.com
+      secretName: wildcard-tls

--- a/clusters/vollminlab-cluster/mediastack/sonarr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sonarr/app/ingress.yaml
@@ -11,6 +11,7 @@ metadata:
     gethomepage.dev/description: "TV show collection manager"
     gethomepage.dev/group: "Media Stack"
     gethomepage.dev/icon: "sonarr.png"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=sonarr"
   labels:
     app: sonarr
     env: production

--- a/clusters/vollminlab-cluster/mediastack/tautulli/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/tautulli/app/ingress.yaml
@@ -11,6 +11,7 @@ metadata:
     gethomepage.dev/description: "Plex monitoring and analytics"
     gethomepage.dev/group: "Media Stack"
     gethomepage.dev/icon: "tautulli.png"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=tautulli"
   labels:
     app: tautulli
     env: production

--- a/clusters/vollminlab-cluster/mediastack/tautulli/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/tautulli/app/ingress.yaml
@@ -19,17 +19,17 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: tautulli.vollminlab.com
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: tautulli
-            port:
-              number: 8181
+    - host: tautulli.vollminlab.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: tautulli
+                port:
+                  number: 8181
   tls:
-  - hosts:
-    - tautulli.vollminlab.com
-    secretName: wildcard-tls
+    - hosts:
+        - tautulli.vollminlab.com
+      secretName: wildcard-tls


### PR DESCRIPTION
Problems: Auto-discovered services showing NOT FOUND. Internal services showing as DOWN. Longhorn in wrong group. Solutions: Added pod-selector annotations. Replaced ping checks with namespace/app labels for internal services. Moved Longhorn to Infrastructure group.