### PR TITLE
fix: replace bitnami/kubectl:latest with alpine/k8s:1.30.3 in disk-cl…

### DIFF
--- a/clusters/vollminlab-cluster/clusterwide/disk-cleanup-cronjob.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/disk-cleanup-cronjob.yaml
@@ -20,54 +20,54 @@ spec:
         spec:
           serviceAccountName: disk-cleanup
           containers:
-          - name: disk-cleanup
-            image: alpine/k8s:1.30.3
-            command:
-            - /bin/sh
-            - -c
-            - |
-              #!/bin/sh
-              set -e
-              
-              echo "Starting scheduled disk cleanup"
-              
-              # Clean up evicted pods
-              echo "Cleaning up evicted pods..."
-              kubectl get pods --all-namespaces --field-selector=status.phase=Evicted -o name | xargs -r kubectl delete || true
-              
-              # Clean up completed pods older than 1 hour
-              echo "Cleaning up old completed pods..."
-              kubectl get pods --all-namespaces --field-selector=status.phase=Succeeded -o json | \
-              jq -r '.items[] | select((.status.startTime | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime) < (now - 3600)) | "\(.metadata.namespace) \(.metadata.name)"' | \
-              while read namespace name; do
-                kubectl delete pod -n "$namespace" "$name" || true
-              done
-              
-              # Clean up failed pods older than 1 hour
-              echo "Cleaning up old failed pods..."
-              kubectl get pods --all-namespaces --field-selector=status.phase=Failed -o json | \
-              jq -r '.items[] | select((.status.startTime | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime) < (now - 3600)) | "\(.metadata.namespace) \(.metadata.name)"' | \
-              while read namespace name; do
-                kubectl delete pod -n "$namespace" "$name" || true
-              done
-              
-              # Show current pod status
-              echo "Current pod status:"
-              kubectl get pods --all-namespaces | grep -E "(Evicted|Completed|Failed)" || echo "No problematic pods found"
-              
-              echo "Scheduled disk cleanup completed"
-            securityContext:
-              runAsNonRoot: true
-              runAsUser: 1000
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-            resources:
-              requests:
-                cpu: 50m
-                memory: 64Mi
-              limits:
-                cpu: 200m
-                memory: 128Mi
+            - name: disk-cleanup
+              image: alpine/k8s:1.30.3
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  #!/bin/sh
+                  set -e
+
+                  echo "Starting scheduled disk cleanup"
+
+                  # Clean up evicted pods
+                  echo "Cleaning up evicted pods..."
+                  kubectl get pods --all-namespaces --field-selector=status.phase=Evicted -o name | xargs -r kubectl delete || true
+
+                  # Clean up completed pods older than 1 hour
+                  echo "Cleaning up old completed pods..."
+                  kubectl get pods --all-namespaces --field-selector=status.phase=Succeeded -o json | \
+                  jq -r '.items[] | select((.status.startTime | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime) < (now - 3600)) | "\(.metadata.namespace) \(.metadata.name)"' | \
+                  while read namespace name; do
+                    kubectl delete pod -n "$namespace" "$name" || true
+                  done
+
+                  # Clean up failed pods older than 1 hour
+                  echo "Cleaning up old failed pods..."
+                  kubectl get pods --all-namespaces --field-selector=status.phase=Failed -o json | \
+                  jq -r '.items[] | select((.status.startTime | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime) < (now - 3600)) | "\(.metadata.namespace) \(.metadata.name)"' | \
+                  while read namespace name; do
+                    kubectl delete pod -n "$namespace" "$name" || true
+                  done
+
+                  # Show current pod status
+                  echo "Current pod status:"
+                  kubectl get pods --all-namespaces | grep -E "(Evicted|Completed|Failed)" || echo "No problematic pods found"
+
+                  echo "Scheduled disk cleanup completed"
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 200m
+                  memory: 128Mi
           restartPolicy: OnFailure
       backoffLimit: 3
   successfulJobsHistoryLimit: 3

--- a/clusters/vollminlab-cluster/clusterwide/disk-cleanup-cronjob.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/disk-cleanup-cronjob.yaml
@@ -21,12 +21,12 @@ spec:
           serviceAccountName: disk-cleanup
           containers:
           - name: disk-cleanup
-            image: bitnami/kubectl:latest
+            image: alpine/k8s:1.30.3
             command:
-            - /bin/bash
+            - /bin/sh
             - -c
             - |
-              #!/bin/bash
+              #!/bin/sh
               set -e
               
               echo "Starting scheduled disk cleanup"


### PR DESCRIPTION
…eanup cronjob

- Fixes ImagePullBackOff error caused by non-existent bitnami/kubectl image
- Changes from :latest tag to pinned version (1.30.3)
- Switches from /bin/bash to /bin/sh for alpine compatibility
- Tested and verified: cleanup job now runs successfully