### PR TITLE
feat: enable ephemeral mode for GitHub Actions runners

### DIFF
--- a/clusters/vollminlab-cluster/actions-runner-system/actions-runner-controller/app/runnerdeployment.yaml
+++ b/clusters/vollminlab-cluster/actions-runner-system/actions-runner-controller/app/runnerdeployment.yaml
@@ -34,7 +34,7 @@ spec:
         - name: RUNNER_WAIT_FOR_DOCKERD_SECONDS
           value: "120"
         - name: RUNNER_EPHEMERAL
-          value: "false"
+          value: "true"
 ---
 apiVersion: actions.summerwind.dev/v1alpha1
 kind: RunnerDeployment
@@ -72,7 +72,7 @@ spec:
         - name: RUNNER_WAIT_FOR_DOCKERD_SECONDS
           value: "120"
         - name: RUNNER_EPHEMERAL
-          value: "false"
+          value: "true"
 ---
 apiVersion: actions.summerwind.dev/v1alpha1
 kind: RunnerDeployment
@@ -110,4 +110,4 @@ spec:
         - name: RUNNER_WAIT_FOR_DOCKERD_SECONDS
           value: "120"
         - name: RUNNER_EPHEMERAL
-          value: "false"
+          value: "true"


### PR DESCRIPTION
- Switch all 3 runner pools (vollminlab-1, vollminlab-2, vollminlab-3) to ephemeral mode
- Ephemeral runners provide faster job pickup and better isolation
- Each runner pod will terminate after completing a job, eliminating cleanup delays
- Expected improvement: reduce job pickup time from ~10 minutes to ~30-60 seconds

Benefits:
- Fresh runner for each job (no state pollution)
- Automatic cleanup after job completion
- No 'stuck in busy state' issues
- Better resource utilization