### PR TITLE
Fix Homepage icon names to use correct icon library names

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/capacitor/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/flux-system/capacitor/app/ingress.yaml
@@ -14,7 +14,7 @@ metadata:
     gethomepage.dev/name: "Capacitor"
     gethomepage.dev/description: "Flux GitOps dashboard"
     gethomepage.dev/group: "Infrastructure"
-    gethomepage.dev/icon: "flux.png"
+    gethomepage.dev/icon: "flux-cd.png"
     gethomepage.dev/pod-selector: "app=capacitor"
 spec:
   ingressClassName: nginx

--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -84,7 +84,7 @@ data:
             - vCenter:
                 description: VMware vCenter Server
                 href: https://vcenter.vollminlab.com
-                icon: vmware.png
+                icon: vmware-esxi.png
                 ping: https://vcenter.vollminlab.com
             - Portainer:
                 description: Container management
@@ -100,7 +100,7 @@ data:
             - Pi-hole:
                 description: DNS Sinkhole
                 href: https://pihole.vollminlab.com/admin
-                icon: pihole.png
+                icon: pi-hole.png
                 ping: https://pihole.vollminlab.com/admin
             - UDM:
                 description: UniFi Dream Machine
@@ -153,28 +153,28 @@ data:
             - Chocolatey:
                 description: Package manager community
                 href: https://community.chocolatey.org
-                icon: chocolatey.png
+                icon: si-chocolatey.png
         - Personal/External:
             - Yahoo Fantasy Football:
                 description: Yahoo Fantasy Football
                 href: https://football.fantasysports.yahoo.com/
-                icon: yahoo.png
+                icon: yahoo-fantasy-sports.png
             - ESPN Fantasy Football:
                 description: ESPN Fantasy Football
                 href: https://www.espn.com/fantasy/football/
-                icon: espn.png
+                icon: espn-fantasy-sports.png
             - D.E. Shaw Access:
                 description: Work access portal
                 href: https://access-test.deshaw.com
-                icon: briefcase.png
+                icon: si-briefcase.png
             - GroupMe:
                 description: Group messaging web
                 href: https://web.groupme.com/chats
-                icon: groupme.png
+                icon: si-groupme.png
             - MakerWorld:
                 description: 3D printing community
                 href: https://makerworld.com/en
-                icon: makerworld.png
+                icon: bambulab.png
       settings:
         theme: dark
         favicon: null

--- a/clusters/vollminlab-cluster/kyverno/policyreporter/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/kyverno/policyreporter/app/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     gethomepage.dev/name: "Policy Reporter"
     gethomepage.dev/description: "Kubernetes policy reporting"
     gethomepage.dev/group: "Monitoring & Observability"
-    gethomepage.dev/icon: "policy-reporter.png"
+    gethomepage.dev/icon: "kyverno.png"
     gethomepage.dev/pod-selector: "app.kubernetes.io/name=policy-reporter-ui"
   labels:
     app: policy-reporter


### PR DESCRIPTION
- Update Capacitor icon from 'flux.png' to 'flux-cd.png'
- Update Policy Reporter icon from 'policy-reporter.png' to 'kyverno.png'
- Update vCenter icon from 'vmware.png' to 'vmware-esxi.png'
- Update Pi-hole icon from 'pihole.png' to 'pi-hole.png'
- Update Yahoo Fantasy icon from 'yahoo.png' to 'yahoo-fantasy-sports.png'
- Update ESPN Fantasy icon from 'espn.png' to 'espn-fantasy-sports.png'
- Update D.E. Shaw Access icon from 'briefcase.png' to 'si-briefcase.png'
- Update MakerWorld icon from 'makerworld.png' to 'bambulab.png'
- Update Chocolatey icon from 'chocolatey.png' to 'si-chocolatey.png'
- Update GroupMe icon from 'groupme.png' to 'si-groupme.png'

This resolves the 'logo' placeholder issue for services with invalid icon names.