### PR TITLE
Switch problematic icons to Material Design Icons (mdi-*)

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -153,28 +153,28 @@ data:
             - Chocolatey:
                 description: Package manager community
                 href: https://community.chocolatey.org
-                icon: chocolatey.png
+                icon: mdi-package-variant
         - Personal/External:
             - Yahoo Fantasy Football:
                 description: Yahoo Fantasy Football
                 href: https://football.fantasysports.yahoo.com/
-                icon: yahoo.png
+                icon: mdi-football
             - ESPN Fantasy Football:
                 description: ESPN Fantasy Football
                 href: https://www.espn.com/fantasy/football/
-                icon: espn.png
+                icon: mdi-football-helmet
             - D.E. Shaw Access:
                 description: Work access portal
                 href: https://access-test.deshaw.com
-                icon: briefcase.png
+                icon: mdi-briefcase
             - GroupMe:
                 description: Group messaging web
                 href: https://web.groupme.com/chats
-                icon: groupme.png
+                icon: mdi-message-text
             - MakerWorld:
                 description: 3D printing community
                 href: https://makerworld.com/en
-                icon: makerworld.png
+                icon: mdi-printer-3d
       settings:
         theme: dark
         favicon: null

--- a/clusters/vollminlab-cluster/kyverno/policyreporter/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/kyverno/policyreporter/app/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     gethomepage.dev/name: "Policy Reporter"
     gethomepage.dev/description: "Kubernetes policy reporting"
     gethomepage.dev/group: "Monitoring & Observability"
-    gethomepage.dev/icon: "policy-reporter.png"
+    gethomepage.dev/icon: "mdi-shield-check"
     gethomepage.dev/pod-selector: "app.kubernetes.io/name=policy-reporter-ui"
   labels:
     app: policy-reporter


### PR DESCRIPTION
Replace dashboard-icons that don't exist with universally available Material Design Icons:

- Policy Reporter: policy-reporter.png -> mdi-shield-check
- Chocolatey: chocolatey.png -> mdi-package-variant
- Yahoo Fantasy: yahoo.png -> mdi-football
- ESPN Fantasy: espn.png -> mdi-football-helmet
- D.E. Shaw: briefcase.png -> mdi-briefcase
- GroupMe: groupme.png -> mdi-message-text
- MakerWorld: makerworld.png -> mdi-printer-3d

This fixes the 'logo' placeholder and missing icon issues.