### PR TITLE
Implement SARIF upload retry mechanism with timeouts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -980,21 +980,64 @@ jobs:
           echo '{"version": "2.1.0", "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json", "runs": [{"tool": {"driver": {"name": "Trivy", "version": "no-changes"}}, "results": []}]}' > trivy-results.sarif
           echo '{"version": "2.1.0", "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json", "runs": [{"tool": {"driver": {"name": "Trivy", "version": "no-changes"}}, "results": []}]}' > trivy-config-results.sarif
 
-      - name: Upload Trivy filesystem SARIF results
-        uses: github/codeql-action/upload-sarif@v3
-        timeout-minutes: 2
-        continue-on-error: true
-        with:
-          sarif_file: 'trivy-results.sarif'
-          category: 'trivy-fs'
+      - name: Upload Trivy SARIF results with retry
+        run: |
+          set -euo pipefail
+          echo "🔄 Uploading SARIF results with retry mechanism..."
           
-      - name: Upload Trivy IaC SARIF results
-        uses: github/codeql-action/upload-sarif@v3
-        timeout-minutes: 2
+          # Function to try upload with timeout
+          upload_with_timeout() {
+            local file=$1
+            local category=$2
+            local attempt=$3
+            
+            echo "📤 Attempt $attempt: Uploading $file (category: $category)"
+            timeout 60s gh api -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "/repos/${{ github.repository }}/code-scanning/sarifs" \
+              -f "commit_sha=${{ github.sha }}" \
+              -f "ref=${{ github.ref_name }}" \
+              -f "sarif=@$file" \
+              -f "category=$category" || return 1
+          }
+          
+          # Try filesystem SARIF upload with retries
+          echo "🔄 Uploading filesystem SARIF results..."
+          for attempt in 1 2 3; do
+            if upload_with_timeout "trivy-results.sarif" "trivy-fs" "$attempt"; then
+              echo "✅ Filesystem SARIF uploaded successfully on attempt $attempt"
+              break
+            else
+              echo "⚠️ Filesystem SARIF upload attempt $attempt failed or timed out"
+              if [ $attempt -eq 3 ]; then
+                echo "❌ All filesystem SARIF upload attempts failed, continuing..."
+              else
+                echo "🔄 Retrying in 2 seconds..."
+                sleep 2
+              fi
+            fi
+          done
+          
+          # Try IaC SARIF upload with retries
+          echo "🔄 Uploading IaC SARIF results..."
+          for attempt in 1 2 3; do
+            if upload_with_timeout "trivy-config-results.sarif" "trivy-config" "$attempt"; then
+              echo "✅ IaC SARIF uploaded successfully on attempt $attempt"
+              break
+            else
+              echo "⚠️ IaC SARIF upload attempt $attempt failed or timed out"
+              if [ $attempt -eq 3 ]; then
+                echo "❌ All IaC SARIF upload attempts failed, continuing..."
+              else
+                echo "🔄 Retrying in 2 seconds..."
+                sleep 2
+              fi
+            fi
+          done
+          
+          echo "✅ SARIF upload process completed"
         continue-on-error: true
-        with:
-          sarif_file: 'trivy-config-results.sarif'
-          category: 'trivy-config'
 
   policy-validation:
     name: Kyverno Policy Validation


### PR DESCRIPTION
- Replace slow SARIF upload actions with retry logic
- 60-second timeout per attempt with 3 retries max
- Uses GitHub CLI instead of actions for better reliability
- Total max time: ~3 minutes instead of hanging indefinitely
- Continues on failure to not block workflow