### PR TITLE
Fix Pi-hole widget for v6 compatibility

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -88,6 +88,7 @@ data:
                 widget:
                   type: pihole
                   url: https://pihole.vollminlab.com
+                  version: 6
                   key: "{{HOMEPAGE_VAR_PIHOLE_API_KEY}}"
             - TrueNAS:
                 description: Network attached storage


### PR DESCRIPTION
- Add version: 6 to Pi-hole widget configuration
- Enables proper API communication with Pi-hole v6
- Fixes 'API Error: Bad request' by using correct v6 API endpoints
- Based on Homepage documentation for Pi-hole v6 support