### PR TITLE
feat: Add Bazarr deployment to mediastack

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/bazarr-helmrepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/bazarr-helmrepository.yaml
@@ -1,0 +1,14 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: bazarr-repo
+  namespace: flux-system
+  labels:
+    app: bazarr
+    env: production
+    category: apps
+spec:
+  url: oci://tccr.io/truecharts/bazarr
+  interval: 5m
+  ref:
+    tag: 22.8.1

--- a/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
@@ -8,6 +8,7 @@ metadata:
     category: system
 resources:
   - arc-helmrepository.yaml
+  - bazarr-helmrepository.yaml
   - bitnami-helmrepository.yaml
   - capacitor-helmrepository.yaml
   - elastic-helmrepository.yaml

--- a/clusters/vollminlab-cluster/mediastack/bazarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr/app/configmap.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bazarr-values
+  namespace: mediastack
+  labels:
+    app: bazarr
+    env: production
+    category: media
+data:
+  values.yaml: |
+    persistence:
+      config:
+        enabled: true
+        existingClaim: pvc-bazarr-config
+        mountPath: /config
+      downloads:
+        enabled: true
+        existingClaim: pvc-completed-downloads
+        mountPath: /downloads
+      tv:
+        enabled: true
+        existingClaim: pvc-tv
+        mountPath: /tv
+      movies:
+        enabled: true
+        existingClaim: pvc-movies
+        mountPath: /movies
+    podLabels:
+      app: bazarr
+      env: production
+      category: media
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 200m
+        memory: 512Mi

--- a/clusters/vollminlab-cluster/mediastack/bazarr/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr/app/helmrelease.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bazarr
+  namespace: mediastack
+  labels:
+    app: bazarr
+    env: production
+    category: media
+spec:
+  interval: 5m
+  chartRef:
+    kind: OCIRepository
+    name: bazarr-repo
+    namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: bazarr-values
+      valuesKey: values.yaml

--- a/clusters/vollminlab-cluster/mediastack/bazarr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr/app/ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: bazarr-ingress
+  namespace: mediastack
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  labels:
+    app: bazarr
+    env: production
+    category: media
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: bazarr.vollminlab.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: bazarr
+                port:
+                  number: 6767
+  tls:
+    - hosts:
+        - bazarr.vollminlab.com
+      secretName: wildcard-tls

--- a/clusters/vollminlab-cluster/mediastack/bazarr/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr/app/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: bazarr-app
+resources:
+  - configmap.yaml
+  - helmrelease.yaml
+  - ingress.yaml
+  - pvc-bazarr-config.yaml

--- a/clusters/vollminlab-cluster/mediastack/bazarr/app/pvc-bazarr-config.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr/app/pvc-bazarr-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-bazarr-config
+  namespace: mediastack
+  labels:
+    app: bazarr
+    env: production
+    category: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/clusters/vollminlab-cluster/mediastack/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/kustomization.yaml
@@ -5,6 +5,7 @@ metadata:
 resources:
   - namespace.yaml
   - ./secrets
+  - ./bazarr/app
   - ./overseerr/app
   - ./prowlarr/app
   - ./radarr/app


### PR DESCRIPTION
- Add Bazarr HelmRelease using TrueCharts chart (v22.8.1)
- Configure persistent storage for config, downloads, TV, and movies
- Set up ingress at bazarr.vollminlab.com with SSL
- Add OCIRepository for TrueCharts Bazarr chart
- Update kustomizations to include Bazarr deployment
- Follow same structure as existing Sonarr/Radarr deployments