### PR TITLE
fix: restore CI workflows to vollminlab self-hosted runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ env:
 jobs:
   validate-changes:
     name: Validate Kubernetes Manifests
-    runs-on: ubuntu-latest
+    runs-on: vollminlab
     timeout-minutes: 5
     outputs:
       changed: ${{ steps.get-changed-files.outputs.changed }}
@@ -333,7 +333,7 @@ jobs:
 
   integration-test:
     name: Integration Test
-    runs-on: ubuntu-latest
+    runs-on: vollminlab
     needs: [validate-changes]
     if: needs.validate-changes.result == 'success'
     env:
@@ -926,7 +926,7 @@ jobs:
 
   security-scan:
     name: Security Scan
-    runs-on: ubuntu-latest
+    runs-on: vollminlab
     needs: [validate-changes]
     if: needs.validate-changes.result == 'success'
     timeout-minutes: 15
@@ -1152,7 +1152,7 @@ jobs:
 
   policy-validation:
     name: Kyverno Policy Validation
-    runs-on: ubuntu-latest
+    runs-on: vollminlab
     needs: [validate-changes]
     if: needs.validate-changes.result == 'success'
     timeout-minutes: 5
@@ -1344,7 +1344,7 @@ jobs:
 
   notify-success:
     name: Notify Success
-    runs-on: ubuntu-latest
+    runs-on: vollminlab
     needs: [validate-changes, integration-test, security-scan, policy-validation]
     if: success()
     steps:
@@ -1356,7 +1356,7 @@ jobs:
 
   notify-failure:
     name: Notify Failure
-    runs-on: ubuntu-latest
+    runs-on: vollminlab
     needs: [validate-changes, integration-test, security-scan, policy-validation]
     if: failure()
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ env:
 jobs:
   validate-changes:
     name: Validate Kubernetes Manifests
-    runs-on: vollminlab
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       changed: ${{ steps.get-changed-files.outputs.changed }}
@@ -333,7 +333,7 @@ jobs:
 
   integration-test:
     name: Integration Test
-    runs-on: vollminlab
+    runs-on: ubuntu-latest
     needs: [validate-changes]
     if: needs.validate-changes.result == 'success'
     env:
@@ -926,7 +926,7 @@ jobs:
 
   security-scan:
     name: Security Scan
-    runs-on: vollminlab
+    runs-on: ubuntu-latest
     needs: [validate-changes]
     if: needs.validate-changes.result == 'success'
     timeout-minutes: 15
@@ -1152,7 +1152,7 @@ jobs:
 
   policy-validation:
     name: Kyverno Policy Validation
-    runs-on: vollminlab
+    runs-on: ubuntu-latest
     needs: [validate-changes]
     if: needs.validate-changes.result == 'success'
     timeout-minutes: 5
@@ -1344,7 +1344,7 @@ jobs:
 
   notify-success:
     name: Notify Success
-    runs-on: vollminlab
+    runs-on: ubuntu-latest
     needs: [validate-changes, integration-test, security-scan, policy-validation]
     if: success()
     steps:
@@ -1356,7 +1356,7 @@ jobs:
 
   notify-failure:
     name: Notify Failure
-    runs-on: vollminlab
+    runs-on: ubuntu-latest
     needs: [validate-changes, integration-test, security-scan, policy-validation]
     if: failure()
     steps:

--- a/.github/workflows/secret-scanning.yaml
+++ b/.github/workflows/secret-scanning.yaml
@@ -22,7 +22,7 @@ defaults:
 jobs:
   secret-scanning:
     name: Secret Scanning
-    runs-on: ubuntu-latest
+    runs-on: vollminlab
     timeout-minutes: 5
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Reverts temporary `ubuntu-latest` fallback from PR #291
- Self-hosted runners now re-registering at repo scope after ARC config fix

## Test plan
- [ ] CI runs on `vollminlab` runners
- [ ] All checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)