### PR TITLE
fix: reduce Harbor registry PVC from 50Gi to 25Gi

### DIFF
--- a/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
@@ -42,7 +42,7 @@ data:
         registry:
           storageClass: longhorn
           accessMode: ReadWriteOnce
-          size: 50Gi
+          size: 25Gi
         jobservice:
           jobLog:
             storageClass: longhorn


### PR DESCRIPTION
## Summary
- Reduces `registry` PVC from 50Gi to 25Gi in Harbor Helm values
- Cluster lacks the free Longhorn capacity for 50Gi, blocking the Harbor HelmRelease from completing install
- 25Gi is sufficient for a homelab registry; Longhorn supports online expansion if needed later

## Test plan
- [ ] Flux reconciles Harbor HelmRelease after merge
- [ ] `flux get helmrelease harbor -n harbor` → READY=True
- [ ] Harbor UI accessible at https://harbor.vollminlab.com
- [ ] **If 50Gi PVC exists in Pending state:** delete it manually so Harbor recreates at 25Gi (`kubectl delete pvc -n harbor <pvc-name>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)