### PR TITLE
docs: add Longhorn storage capacity rules

### DIFF
--- a/.claude/rules/storage.md
+++ b/.claude/rules/storage.md
@@ -42,3 +42,11 @@ If a PVC turns out to be too small after the fact, Longhorn supports online expa
 2. Longhorn expands the volume without downtime.
 
 **Start conservative. Expand later. Never provision speculatively large.**
+
+## Multipath must be blacklisted on all worker nodes
+
+Longhorn iSCSI volumes conflict with `multipathd` on Ubuntu 24.04 (multipath is enabled by default). This causes `exit status 32` stale mount failures. Every worker node — including DMZ workers — must have Longhorn devices blacklisted in `/etc/multipath.conf`.
+
+**Apply this to every new worker node before it joins the cluster.**
+
+Full procedure: `docs/runbooks/longhorn-multipath-blacklist.md`

--- a/.claude/rules/storage.md
+++ b/.claude/rules/storage.md
@@ -1,0 +1,44 @@
+# Storage Rules
+
+## HARD CONSTRAINT — verify Longhorn capacity before setting PVC sizes
+
+**Before committing any PVC size in a new app, check that Longhorn can actually schedule it.**
+
+Longhorn uses replica-based storage. The default replica count is **3**. This means a 50Gi PVC requires ~150Gi of free space across the cluster (spread across replica nodes). A PVC that appears small can be unschedulable if free space is fragmented or insufficient.
+
+**Never set a PVC size based on defaults or what "seems reasonable" without verifying.**
+
+### How to check available capacity
+
+```bash
+# Check schedulable space per node (look at "schedulable" column)
+kubectl get nodes -o custom-columns=\
+'NAME:.metadata.name,SCHEDULABLE:.metadata.annotations.node\.longhorn\.io/longhorn-schedulable-storage'
+
+# Or check in the Longhorn UI: Storage → Nodes → available column
+# Each node must have free space >= PVC size for a replica to land there
+# With 3 replicas, need 3 nodes each with >= PVC size free
+```
+
+### What happened on 2026-04-09
+
+Harbor was provisioned with a 50Gi registry PVC (chart default). The cluster did not have 150Gi of free Longhorn space (50Gi × 3 replicas). The PVC sat Pending, which cascaded into stale iSCSI mount errors on k8sworker01 and blocked Harbor, Radarr, and other pods for hours.
+
+Fix: reduced to 25Gi (PR #293). Always size PVCs based on actual need + available capacity, not chart defaults.
+
+### Sizing guidelines for this cluster
+
+| Use case | Reasonable size |
+|----------|----------------|
+| App config/data (arr stack, small apps) | 1–5Gi |
+| Database (CNPG) | 5–20Gi |
+| Container registry (Harbor) | 25Gi (expand via Longhorn online resize if needed) |
+| Media/download staging | check free space first |
+
+### Longhorn online resize
+
+If a PVC turns out to be too small after the fact, Longhorn supports online expansion:
+1. Edit the PVC: `kubectl patch pvc <name> -n <ns> --type=merge -p '{"spec":{"resources":{"requests":{"storage":"<new-size>"}}}}'`
+2. Longhorn expands the volume without downtime.
+
+**Start conservative. Expand later. Never provision speculatively large.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ GitOps-managed Kubernetes cluster using Flux CD. All workloads are Helm-based Fl
 - `.claude/rules/homepage.md` — auto-discovery via ingress annotations, widget support, credentials
 - `.claude/rules/external-dns.md` — Pi-hole constraint: policy: upsert-only only, DNS restore procedure
 - `.claude/rules/incidents.md` — when to write postmortems, format, existing incident index
+- `.claude/rules/storage.md` — Longhorn capacity check before PVC sizing, replica math, online resize
 
 ## Hard constraints
 

--- a/docs/runbooks/longhorn-multipath-blacklist.md
+++ b/docs/runbooks/longhorn-multipath-blacklist.md
@@ -1,0 +1,134 @@
+# Runbook: Longhorn iSCSI Multipath Blacklist
+
+## Why this is required
+
+Longhorn uses iSCSI internally to expose block devices to pods. Ubuntu 24.04 ships with `multipathd` enabled by default. When multipath is active, it intercepts the same SCSI devices Longhorn manages and creates `/dev/mapper/mpathX` entries alongside Longhorn's `/dev/longhorn/<pvc>` symlinks. This causes the kernel to report the device as "already mounted or mount point busy" when Longhorn tries to mount it, producing:
+
+```
+MountVolume.MountDevice failed: exit status 32
+/dev/longhorn/pvc-xxx already mounted or mount point busy
+```
+
+These stale mount errors were the root cause of recurring pod failures on k8sworker01 (and intermittently other workers) in April 2026. The fix is to blacklist all SCSI block devices from multipath so that multipathd ignores Longhorn's iSCSI volumes entirely.
+
+**This must be applied to every worker node in the cluster, including DMZ workers, and to any new worker nodes added in the future.**
+
+---
+
+## Nodes to apply this to
+
+| Node | Role | IP |
+|------|------|----|
+| k8sworker01 | worker | 192.168.152.11 |
+| k8sworker02 | worker | 192.168.152.12 |
+| k8sworker03 | worker | 192.168.152.13 |
+| k8sworker04 | worker | 192.168.152.14 |
+| k8sworker05 | dmz, worker | 192.168.152.15 |
+| k8sworker06 | dmz, worker | 192.168.152.16 |
+
+Control plane nodes (k8scp01–03) do not run Longhorn workloads and do not require this change.
+
+---
+
+## Procedure (per node)
+
+Perform one node at a time. There is no need to cordon or drain — `multipathd` restart is non-disruptive to running pods that are already mounted.
+
+### 1. SSH into the node
+
+```bash
+ssh k8sworker0X
+```
+
+### 2. Check current multipath state
+
+```bash
+sudo multipath -ll
+# If output is empty or shows no devices, multipath is already not managing any volumes.
+# If it shows mpathX entries, those are the devices causing conflicts.
+```
+
+### 3. Create or update `/etc/multipath.conf`
+
+Check if the file exists:
+
+```bash
+sudo cat /etc/multipath.conf 2>/dev/null || echo "file does not exist"
+```
+
+**If the file does not exist**, create it:
+
+```bash
+sudo tee /etc/multipath.conf <<'EOF'
+defaults {
+    user_friendly_names yes
+}
+
+blacklist {
+    devnode "^sd[a-z0-9]+"
+}
+EOF
+```
+
+**If the file already exists**, add the blacklist section. Ensure it contains at minimum:
+
+```
+blacklist {
+    devnode "^sd[a-z0-9]+"
+}
+```
+
+Do not remove any existing content — just append or merge the blacklist block.
+
+### 4. Restart multipathd
+
+```bash
+sudo systemctl restart multipathd.service
+```
+
+### 5. Verify
+
+```bash
+# Should return empty or show no sd* devices being managed
+sudo multipath -ll
+
+# Confirm the blacklist is active
+sudo multipath -t | grep -A5 blacklist
+```
+
+### 6. Confirm no new stale mount events
+
+After completing all nodes, check Longhorn-related pod events for any residual errors:
+
+```bash
+kubectl get events -A --sort-by=.lastTimestamp | grep -i "exit status 32\|already mounted\|mount point busy" | tail -20
+# Expected: no new events after the restart
+```
+
+---
+
+## For new worker nodes
+
+When provisioning a new worker node, apply this configuration **before** joining it to the cluster or before any Longhorn volumes are scheduled to it. Add it to the node provisioning checklist in `homelab-infrastructure`.
+
+Steps are identical to the procedure above. The node does not need to be in the cluster yet — SSH in and apply it as part of OS baseline configuration.
+
+---
+
+## Reverting
+
+If for any reason you need to revert (not recommended):
+
+```bash
+sudo rm /etc/multipath.conf
+sudo systemctl restart multipathd.service
+```
+
+Do not revert while Longhorn volumes are active on the node — it will immediately cause stale mount conflicts.
+
+---
+
+## References
+
+- [Longhorn KB: Troubleshooting MountVolume.SetUp failed due to multipathd](https://longhorn.io/kb/troubleshooting-volume-with-multipath/)
+- Incident: `docs/incidents/` — April 2026 stale mount cascade


### PR DESCRIPTION
## Summary
- Adds `.claude/rules/storage.md` with a hard constraint to check Longhorn schedulable capacity before setting PVC sizes
- Root cause of today's outage: Harbor provisioned with 50Gi registry PVC (chart default); cluster needed 150Gi (50Gi × 3 replicas) and didn't have it — PVC sat Pending, cascading into stale iSCSI mount errors on k8sworker01 blocking Harbor, Radarr, and others for hours
- Rule covers: replica math, capacity check commands, sizing guidelines, online resize procedure

## Test plan
- [ ] Rules file is present and linked from CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)