### PR TITLE
fix: route harbor ingress to harbor nginx service

### DIFF
--- a/clusters/vollminlab-cluster/harbor/harbor/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor/app/ingress.yaml
@@ -26,6 +26,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: harbor-core
+                name: harbor
                 port:
                   number: 80


### PR DESCRIPTION
## Summary
- Fixes 404 on https://harbor.vollminlab.com
- Ingress was pointing at `harbor-core:80` (API only) — should be `harbor:80` (the nginx proxy that routes to core/portal/registry)

## Test plan
- [ ] https://harbor.vollminlab.com loads Harbor UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)