### PR TITLE
chore: bump masters-league to v1.1.0 (scorecard feature)

### DIFF
--- a/clusters/vollminlab-cluster/dmz/masters-league/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/dmz/masters-league/app/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: masters-league
-          image: harbor.vollminlab.com/homelab/masters-league:v1.0.0
+          image: harbor.vollminlab.com/homelab/masters-league:v1.1.0
           imagePullPolicy: Always
           ports:
             - containerPort: 8000


### PR DESCRIPTION
## Summary
- Bumps `masters-league` image from `v1.0.0` → `v1.1.0`
- v1.1.0 adds the hole-by-hole scorecard inline expand feature (click any golfer to see per-hole scores with golf symbols, round tabs, front/back 9 layout)

## Test plan
- [ ] Merge and confirm Flux reconciles within 1 minute
- [ ] Visit https://mastersleague.vollminlab.com and click a golfer row to verify scorecard expands inline
- [ ] Check round tabs (R1, R2, etc.) switch correctly
- [ ] Verify double-ring symbols for eagle render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)