### PR TITLE
chore: bump masters-league to v1.1.1

### DIFF
--- a/clusters/vollminlab-cluster/dmz/masters-league/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/dmz/masters-league/app/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: masters-league
-          image: harbor.vollminlab.com/homelab/masters-league:v1.1.0
+          image: harbor.vollminlab.com/homelab/masters-league:v1.1.1
           imagePullPolicy: Always
           ports:
             - containerPort: 8000


### PR DESCRIPTION
## Summary
- Bumps `masters-league` image from `v1.1.0` → `v1.1.1`
- v1.1.1 makes cut/WD player rows clickable so their scorecards can be viewed

## Test plan
- [ ] Merge and wait for Flux reconciliation
- [ ] Verify cut/WD players are clickable in the dashboard and scorecard opens