### PR TITLE
feat: add DinD sidecar to ARC runner pod template

### DIFF
--- a/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/configmap.yaml
@@ -33,10 +33,28 @@ data:
           - name: runner
             image: ghcr.io/actions/actions-runner:2.332.0
             command: ["/home/runner/run.sh"]
+            env:
+              - name: DOCKER_HOST
+                value: tcp://localhost:2375
             resources:
               requests:
                 cpu: 500m
                 memory: 512Mi
+              limits:
+                cpu: 2000m
+                memory: 2Gi
+          - name: dind
+            image: docker:26-dind
+            securityContext:
+              privileged: true
+            env:
+              - name: DOCKER_TLS_CERTDIR
+                value: ""
+            args: ["--host=tcp://0.0.0.0:2375"]
+            resources:
+              requests:
+                cpu: 200m
+                memory: 256Mi
               limits:
                 cpu: 2000m
                 memory: 2Gi


### PR DESCRIPTION
## Summary

Adds a `docker:26-dind` privileged sidecar container to every ARC runner pod. The runner container connects to it via `DOCKER_HOST=tcp://localhost:2375` (TLS disabled).

This unblocks Docker-based CI steps (`docker/build-push-action`, `docker/login-action`, etc.) without requiring a Docker socket on the node or any per-repo workflow workarounds.

## Why

Nodes use containerd, not Docker. Previous attempts to use Kaniko as an extracted binary all failed because kaniko has a hardcoded `/kaniko` path requirement that can't be overridden without root access.

## Impact

All runner pods get the DinD sidecar on next Flux reconcile. Existing workflows that don't use Docker are unaffected — the sidecar idles at ~200m CPU / 256Mi memory.

## Test plan

- [ ] PR merged, Flux reconciles ARC HelmRelease
- [ ] New runner pods have `dind` sidecar container
- [ ] `v0.3.0` tag re-pushed on shlink-ingress-controller triggers successful build and push to Harbor

🤖 Generated with [Claude Code](https://claude.com/claude-code)