### PR TITLE
chore: update masters-league image to vollminlab Harbor project

### DIFF
--- a/clusters/vollminlab-cluster/dmz/masters-league/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/dmz/masters-league/app/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: masters-league
-          image: harbor.vollminlab.com/homelab/masters-league:v1.1.1
+          image: harbor.vollminlab.com/vollminlab/masters-league:v1.1.1
           imagePullPolicy: Always
           ports:
             - containerPort: 8000


### PR DESCRIPTION
## Summary

Updates the masters-league deployment image from `homelab/masters-league:v1.1.1` to `vollminlab/masters-league:v1.1.1` following the Harbor project consolidation.

All three image tags (v1.0.0, v1.1.0, v1.1.1) have already been pushed to the `vollminlab` project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)