### PR TITLE
chore: remove imagePullSecrets from masters-league deployment

### DIFF
--- a/clusters/vollminlab-cluster/dmz/masters-league/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/dmz/masters-league/app/deployment.yaml
@@ -19,8 +19,6 @@ spec:
         env: production
         category: apps
     spec:
-      imagePullSecrets:
-        - name: harbor-pull-secret
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000


### PR DESCRIPTION
The \`vollminlab\` Harbor project is public, so image pulls don't require authentication. Removes the stale \`imagePullSecrets\` reference (the sealed secret was never committed anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)