### PR TITLE
feat: deploy shlink-ingress-controller via Flux

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
@@ -38,3 +38,4 @@ resources:
   - shlink-helmrepository.yaml
   - velero-helmrepository.yaml
   - harbor-helmrepository.yaml
+  - vollminlab-oci-helmrepository.yaml

--- a/clusters/vollminlab-cluster/flux-system/repositories/vollminlab-oci-helmrepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/vollminlab-oci-helmrepository.yaml
@@ -1,0 +1,13 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: vollminlab-oci
+  namespace: flux-system
+  labels:
+    app: vollminlab-oci
+    env: production
+    category: system
+spec:
+  type: oci
+  interval: 1h
+  url: oci://harbor.vollminlab.com/vollminlab

--- a/clusters/vollminlab-cluster/shlink/kustomization.yaml
+++ b/clusters/vollminlab-cluster/shlink/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - shlink/app
   - shlink-web/app
   - shlink-db/app
+  - shlink-ingress-controller/app

--- a/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shlink-ingress-controller-values
+  namespace: shlink
+  labels:
+    app: shlink-ingress-controller
+    env: production
+    category: apps
+data:
+  values.yaml: |
+    podLabels:
+      app: shlink-ingress-controller
+      env: production
+      category: apps
+
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi

--- a/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/helmrelease.yaml
@@ -1,0 +1,23 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: shlink-ingress-controller
+  namespace: shlink
+  labels:
+    app: shlink-ingress-controller
+    env: production
+    category: apps
+spec:
+  interval: 10m
+  timeout: 10m
+  chart:
+    spec:
+      chart: shlink-ingress-controller
+      version: 0.3.2
+      sourceRef:
+        kind: HelmRepository
+        name: vollminlab-oci
+        namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: shlink-ingress-controller-values

--- a/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - configmap.yaml


### PR DESCRIPTION
## Summary

- Add `vollminlab-oci` HelmRepository (OCI type) pointing at `harbor.vollminlab.com/vollminlab`
- Deploy `shlink-ingress-controller` v0.3.2 into the `shlink` namespace via HelmRelease
- Resource limits: 50m/64Mi requests, 200m/128Mi limits
- Uses existing `shlink-credentials` secret (no new secrets needed)

## Test plan

- [ ] Flux reconciles without errors (`flux get helmreleases -n shlink`)
- [ ] Controller pod running in shlink namespace
- [ ] Add `shlink.vollminlab.com/short-url: "test"` annotation to an Ingress and verify a short URL is created in Shlink

🤖 Generated with [Claude Code](https://claude.ai/claude-code)