### PR TITLE
chore: bump shlink-ingress-controller to 0.3.3

### DIFF
--- a/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     spec:
       chart: shlink-ingress-controller
-      version: 0.3.2
+      version: 0.3.3
       sourceRef:
         kind: HelmRepository
         name: vollminlab-oci


### PR DESCRIPTION
## Summary

- Bumps `shlink-ingress-controller` chart version from `0.3.2` → `0.3.3`
- v0.3.3 fixes the image tag mismatch: the CI now pushes both `:v0.3.3` and `:0.3.3` to Harbor so the chart's `appVersion` default resolves to a real image

## Test plan

- [ ] CI passes
- [ ] Merge → Flux reconciles the HelmRelease
- [ ] `kubectl get pods -n shlink` shows `shlink-ingress-controller` Running
- [ ] Smoke test: annotate an Ingress with `shlink.vollminlab.com/slug` and verify short URL appears in Shlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)