### PR TITLE
fix: update HelmRepository to charts/ path, pin image tag to v0.3.3

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/vollminlab-oci-helmrepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/vollminlab-oci-helmrepository.yaml
@@ -10,4 +10,4 @@ metadata:
 spec:
   type: oci
   interval: 1h
-  url: oci://harbor.vollminlab.com/vollminlab/charts
+  url: oci://harbor.vollminlab.com/vollminlab

--- a/clusters/vollminlab-cluster/flux-system/repositories/vollminlab-oci-helmrepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/vollminlab-oci-helmrepository.yaml
@@ -10,4 +10,4 @@ metadata:
 spec:
   type: oci
   interval: 1h
-  url: oci://harbor.vollminlab.com/vollminlab
+  url: oci://harbor.vollminlab.com/vollminlab/charts

--- a/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/configmap.yaml
@@ -14,6 +14,9 @@ data:
       env: production
       category: apps
 
+    image:
+      tag: v0.3.3
+
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
## Summary

- Updates `vollminlab-oci` HelmRepository URL from `vollminlab/` to `vollminlab/charts/` to match the corrected helm push path in the build pipeline (vollminlab/shlink-ingress-controller#11)
- Pins `image.tag: v0.3.3` in the ConfigMap as an interim fix — the v-prefixed Docker tag was not overwritten by the helm push and contains the correct image
- Once v0.3.4 is released with the corrected pipeline, the image tag pin can be removed and the HelmRelease bumped to 0.3.4

## Test plan

- [ ] CI passes
- [ ] Merge → Flux reconciles HelmRepository and HelmRelease
- [ ] `kubectl get pods -n shlink` shows `shlink-ingress-controller` Running
- [ ] Smoke test: annotate an Ingress with `shlink.vollminlab.com/slug` and verify short URL appears in Shlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)