### PR TITLE
chore: finalize shlink-ingress-controller 0.3.4 with correct chart path

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/vollminlab-oci-helmrepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/vollminlab-oci-helmrepository.yaml
@@ -10,4 +10,4 @@ metadata:
 spec:
   type: oci
   interval: 1h
-  url: oci://harbor.vollminlab.com/vollminlab
+  url: oci://harbor.vollminlab.com/vollminlab/charts

--- a/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/configmap.yaml
@@ -14,9 +14,6 @@ data:
       env: production
       category: apps
 
-    image:
-      tag: v0.3.3
-
     resources:
       requests:
         cpu: 50m

--- a/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     spec:
       chart: shlink-ingress-controller
-      version: 0.3.3
+      version: 0.3.4
       sourceRef:
         kind: HelmRepository
         name: vollminlab-oci


### PR DESCRIPTION
## Summary

- Updates `vollminlab-oci` HelmRepository URL to `oci://harbor.vollminlab.com/vollminlab/charts` — charts and Docker images now live in separate Harbor repos, no more tag collision
- Bumps HelmRelease to `0.3.4` (first clean release: Docker image at `vollminlab/shlink-ingress-controller:0.3.4`, Helm chart at `vollminlab/charts/shlink-ingress-controller:0.3.4`)
- Removes the `image.tag: v0.3.3` interim pin — no longer needed

## Test plan

- [ ] CI passes
- [ ] Merge → Flux upgrades HelmRelease to 0.3.4
- [ ] Controller pod stays Running on the new image
- [ ] Smoke test: annotate an Ingress with `shlink.vollminlab.com/slug` and verify short URL appears in Shlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)