### PR TITLE
chore: bump shlink-ingress-controller to 0.3.5

### DIFF
--- a/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     spec:
       chart: shlink-ingress-controller
-      version: 0.3.4
+      version: 0.3.5
       sourceRef:
         kind: HelmRepository
         name: vollminlab-oci


### PR DESCRIPTION
## Summary

- Bumps `shlink-ingress-controller` HelmRelease from `0.3.4` → `0.3.5`
- v0.3.5 fixes the Secret cache scope bug: controller-runtime was trying to watch Secrets cluster-wide; the service account only had a namespace Role, causing a continuous RBAC error that prevented the API key from being read — short URL creation was silently broken since v0.3.0

## Test plan

- [ ] Flux reconciles and pod rolls to new image
- [ ] Controller logs show `"created short URL"` for `homepage/homepage-ingress` (annotated with `shlink.vollminlab.com/slug: test`)
- [ ] `curl https://go.vollminlab.com/test` redirects to `homepage.vollminlab.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)