### PR TITLE
chore: annotate homepage-ingress with shlink slug

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    shlink.vollminlab.com/slug: homepage
   labels:
     app: homepage
     env: production


### PR DESCRIPTION
## Summary

Adds `shlink.vollminlab.com/slug: homepage` to `homepage-ingress` as a smoke test for the shlink-ingress-controller.

The slug already exists in Shlink pointing to the correct URL (`https://homepage.vollminlab.com`), so the controller will take the "already exists, skipping" path and add its finalizer. This confirms the controller can read the API key and communicate with Shlink successfully.

If this works, all remaining Ingresses will get annotated in a follow-up PR.

## Verification

After Flux applies:
```sh
kubectl logs -n shlink -l app.kubernetes.io/name=shlink-ingress-controller --since=2m
# expect: "short URL already exists, skipping" for slug=homepage

kubectl get ingress homepage-ingress -n homepage -o jsonpath='{.metadata.finalizers}'
# expect: ["shlink.vollminlab.com/finalizer"]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)