### PR TITLE
fix: run kyverno webhook patch job on control plane, discover webhooks dynamically

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/patches/webhooks-postrender-patch.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/patches/webhooks-postrender-patch.yaml
@@ -21,6 +21,12 @@ spec:
           restartPolicy: OnFailure
           serviceAccountName: kyverno-webhook-patch
           terminationGracePeriodSeconds: 10
+          tolerations:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+              effect: NoSchedule
+          nodeSelector:
+            node-role.kubernetes.io/control-plane: ""
           containers:
             - name: kubectl
               image: docker.io/alpine/kubectl:1.33.4
@@ -66,16 +72,16 @@ spec:
                     fi
                   }
 
-                  # Patch all webhooks
-                  patch_webhook "validatingwebhookconfiguration" \
-                    "kyverno-policy-validating-webhook-cfg"
-                  patch_webhook "validatingwebhookconfiguration" \
-                    "kyverno-cleanup-validating-webhook-cfg"
-                  patch_webhook "validatingwebhookconfiguration" \
-                    "kyverno-ttl-validating-webhook-cfg"
-                  patch_webhook "validatingwebhookconfiguration" \
-                    "kyverno-resource-validating-webhook-cfg"
-                  patch_webhook "mutatingwebhookconfiguration" \
-                    "kyverno-policy-mutating-webhook-cfg"
+                  # Patch all Kyverno validating webhooks
+                  for name in $(kubectl get validatingwebhookconfigurations \
+                      -l webhook.kyverno.io/managed-by=kyverno -o name 2>/dev/null); do
+                    patch_webhook "validatingwebhookconfiguration" "${name#*/}"
+                  done
+
+                  # Patch all Kyverno mutating webhooks
+                  for name in $(kubectl get mutatingwebhookconfigurations \
+                      -l webhook.kyverno.io/managed-by=kyverno -o name 2>/dev/null); do
+                    patch_webhook "mutatingwebhookconfiguration" "${name#*/}"
+                  done
 
                   echo "All webhooks patched successfully"


### PR DESCRIPTION
## Summary

- Pins the `patch-kyverno-webhooks` CronJob to control plane nodes via `nodeSelector` + toleration, so it runs as long as the API server is reachable — even during worker node outages
- Replaces the hardcoded list of 5 webhook names with a dynamic label selector (`webhook.kyverno.io/managed-by=kyverno`), covering all 10 Kyverno webhook configurations instead of the previous 5

## Motivation

During a VMware management vmkernel adapter misconfiguration that took down several worker nodes, the CronJob pod was on a downed node and couldn't run. Kyverno re-registered its webhooks with `failurePolicy: Fail` and blocked all cluster operations including pod deletion, triggering a cascade that required manual webhook deletion to resolve.

## Test plan

- [ ] Verify next CronJob run schedules on a control plane node
- [ ] Check CronJob logs show all 10 webhooks patched successfully
- [ ] Confirm `kubectl get validatingwebhookconfigurations,mutatingwebhookconfigurations | grep kyverno` shows `failurePolicy: Ignore` after next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)