### PR TITLE
chore: add shlink slug annotation to all ingresses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ GitOps-managed Kubernetes cluster using Flux CD. All workloads are Helm-based Fl
 - Never use `:latest` image or chart version tags. Kyverno blocks them.
 - All pods require `app`, `env`, and `category` labels. Kyverno enforces in enforce mode.
 - Never set `policy: sync` in external-dns — shared Pi-hole backend, `upsert-only` only. `policy: sync` wiped all infrastructure DNS records on 2026-04-05.
+- Every new Ingress must include `shlink.vollminlab.com/slug: <service-name>` — the shlink-ingress-controller uses this to auto-create a `vollm.in/<slug>` short URL. Use the service name from the hostname (e.g. `radarr.vollminlab.com` → slug `radarr`). See `clusters/vollminlab-cluster/homepage/homepage/app/ingress.yaml` as the canonical example.
 
 ## Bootstrap / DR
 

--- a/clusters/vollminlab-cluster/flux-system/capacitor/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/flux-system/capacitor/app/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
     gethomepage.dev/group: "Infrastructure"
     gethomepage.dev/icon: "flux-cd.png"
     gethomepage.dev/pod-selector: "app=capacitor"
+    shlink.vollminlab.com/slug: capacitor
 spec:
   ingressClassName: nginx
   rules:

--- a/clusters/vollminlab-cluster/harbor/harbor/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor/app/ingress.yaml
@@ -12,6 +12,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
+    shlink.vollminlab.com/slug: harbor
 spec:
   ingressClassName: nginx
   tls:

--- a/clusters/vollminlab-cluster/kyverno/policyreporter/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/kyverno/policyreporter/app/ingress.yaml
@@ -12,6 +12,7 @@ metadata:
     gethomepage.dev/group: "Monitoring & Observability"
     gethomepage.dev/icon: "mdi-shield-check"
     gethomepage.dev/pod-selector: "app.kubernetes.io/name=policy-reporter-ui"
+    shlink.vollminlab.com/slug: policyreporter
   labels:
     app: policy-reporter
     env: production

--- a/clusters/vollminlab-cluster/longhorn-system/longhorn/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn/app/ingress.yaml
@@ -11,6 +11,7 @@ metadata:
     gethomepage.dev/group: "Infrastructure"
     gethomepage.dev/icon: "longhorn.png"
     gethomepage.dev/pod-selector: "app=longhorn-ui"
+    shlink.vollminlab.com/slug: longhorn
   labels:
     app: longhorn
     env: production

--- a/clusters/vollminlab-cluster/mediastack/bazarr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr/app/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    shlink.vollminlab.com/slug: bazarr
   labels:
     app: bazarr
     env: production

--- a/clusters/vollminlab-cluster/mediastack/overseerr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/overseerr/app/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    shlink.vollminlab.com/slug: overseerr
   labels:
     app: overseerr
     env: production

--- a/clusters/vollminlab-cluster/mediastack/prowlarr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/prowlarr/app/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    shlink.vollminlab.com/slug: prowlarr
   labels:
     app: prowlarr
     env: production

--- a/clusters/vollminlab-cluster/mediastack/radarr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/radarr/app/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    shlink.vollminlab.com/slug: radarr
   labels:
     app: radarr
     env: production

--- a/clusters/vollminlab-cluster/mediastack/sabnzbd/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sabnzbd/app/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    shlink.vollminlab.com/slug: sabnzbd
   labels:
     app: sabnzbd
     env: production

--- a/clusters/vollminlab-cluster/mediastack/sonarr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sonarr/app/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    shlink.vollminlab.com/slug: sonarr
   labels:
     app: sonarr
     env: production

--- a/clusters/vollminlab-cluster/mediastack/tautulli/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/tautulli/app/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    shlink.vollminlab.com/slug: tautulli
   labels:
     app: tautulli
     env: production

--- a/clusters/vollminlab-cluster/minio/minio/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/minio/minio/app/ingress.yaml
@@ -12,6 +12,7 @@ metadata:
     gethomepage.dev/group: "Infrastructure"
     gethomepage.dev/icon: "minio.png"
     gethomepage.dev/pod-selector: "app=minio"
+    shlink.vollminlab.com/slug: minio
   labels:
     app: minio
     env: production

--- a/clusters/vollminlab-cluster/portainer/portainer/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/portainer/portainer/app/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /
+    shlink.vollminlab.com/slug: portainer
 spec:
   ingressClassName: nginx
   tls:

--- a/clusters/vollminlab-cluster/shlink/shlink-web/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink-web/app/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     category: apps
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    shlink.vollminlab.com/slug: shlink
 spec:
   ingressClassName: nginx
   tls:


### PR DESCRIPTION
## Summary
- Adds `shlink.vollminlab.com/slug: <service>` to all 14 Ingress resources in the repo
- The shlink-ingress-controller will auto-create `vollm.in/<slug>` short URLs on Flux sync
- Slugs match the service name from the hostname (e.g. `radarr.vollminlab.com` → `radarr`)
- Skipped: `minio/ingress-s3.yaml` (S3 API endpoint) and `shlink/shlink/app/ingress.yaml` (the redirect service itself with multiple hosts)
- Documents the requirement in `CLAUDE.md` — all future ingresses must include this annotation

## Test plan
- [ ] Merge and confirm Flux reconciles all affected namespaces
- [ ] Verify `vollm.in/<slug>` resolves correctly for a sample of services

🤖 Generated with [Claude Code](https://claude.com/claude-code)