### PR TITLE
feat: add pihole-watchdog CronJob to homepage namespace

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ingress.yaml
   - homepage-env-vars-sealedsecret.yaml
   - rbac.yaml
+  - pihole-watchdog-cronjob.yaml

--- a/clusters/vollminlab-cluster/homepage/homepage/app/pihole-watchdog-cronjob.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/pihole-watchdog-cronjob.yaml
@@ -1,0 +1,178 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pihole-watchdog
+  namespace: homepage
+  labels:
+    app: homepage
+    env: production
+    category: apps
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pihole-watchdog
+  namespace: homepage
+  labels:
+    app: homepage
+    env: production
+    category: apps
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pihole-watchdog
+  namespace: homepage
+  labels:
+    app: homepage
+    env: production
+    category: apps
+subjects:
+  - kind: ServiceAccount
+    name: pihole-watchdog
+    namespace: homepage
+roleRef:
+  kind: Role
+  name: pihole-watchdog
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pihole-watchdog-script
+  namespace: homepage
+  labels:
+    app: homepage
+    env: production
+    category: apps
+data:
+  watchdog.sh: |
+    #!/bin/sh
+    set -e
+
+    NAMESPACE="homepage"
+    DEPLOYMENT="homepage"
+    PIHOLE_URL="http://192.168.100.4:80"
+    WINDOW_SECONDS=300
+    POST_RESTART_WAIT=60
+
+    log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+
+    # Find homepage pod
+    POD=$(kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/name=homepage \
+      --field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+
+    if [ -z "$POD" ]; then
+      log "No running homepage pod found — skipping"
+      exit 0
+    fi
+
+    # Check for 401s in the last 5 minutes
+    SINCE=$(date -u -d "@$(($(date +%s) - WINDOW_SECONDS))" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+      || date -u -r "$(($(date +%s) - WINDOW_SECONDS))" +%Y-%m-%dT%H:%M:%SZ)
+
+    COUNT=$(kubectl logs -n "$NAMESPACE" "$POD" --since="${WINDOW_SECONDS}s" 2>/dev/null \
+      | grep -c "401" || true)
+
+    if [ "$COUNT" -eq 0 ]; then
+      log "No 401 errors in last ${WINDOW_SECONDS}s — all good"
+      exit 0
+    fi
+
+    log "Found ${COUNT} 401 error(s) in last ${WINDOW_SECONDS}s — validating Pi-hole reachability"
+
+    # Validate Pi-hole is actually reachable before restarting
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+      --max-time 10 "${PIHOLE_URL}/api/auth" \
+      -H "Content-Type: application/json" \
+      -d "{\"password\":\"${PIHOLE_API_KEY}\"}" 2>/dev/null || echo "000")
+
+    if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "401" ]; then
+      log "Pi-hole unreachable (HTTP ${HTTP_CODE}) — skipping restart, not a session issue"
+      exit 0
+    fi
+
+    log "Pi-hole reachable (HTTP ${HTTP_CODE}) — restarting homepage deployment"
+
+    # Restart by patching the deployment annotation (triggers rollout without changing spec)
+    kubectl patch deployment "$DEPLOYMENT" -n "$NAMESPACE" \
+      -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"kubectl.kubernetes.io/restartedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}}}}"
+
+    log "Restart triggered — waiting ${POST_RESTART_WAIT}s for rollout"
+    sleep "$POST_RESTART_WAIT"
+
+    # Wait for rollout to complete
+    kubectl rollout status deployment/"$DEPLOYMENT" -n "$NAMESPACE" --timeout=120s
+
+    # Post-restart validation: check logs for 401s since restart
+    NEW_COUNT=$(kubectl logs -n "$NAMESPACE" \
+      -l app.kubernetes.io/name=homepage \
+      --since="${POST_RESTART_WAIT}s" 2>/dev/null \
+      | grep -c "401" || true)
+
+    if [ "$NEW_COUNT" -eq 0 ]; then
+      log "Post-restart validation passed — no 401 errors"
+    else
+      log "WARNING: ${NEW_COUNT} 401 error(s) still present after restart — may need investigation"
+    fi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: pihole-watchdog
+  namespace: homepage
+  labels:
+    app: homepage
+    env: production
+    category: apps
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: homepage
+            env: production
+            category: apps
+        spec:
+          serviceAccountName: pihole-watchdog
+          restartPolicy: Never
+          containers:
+            - name: watchdog
+              image: docker.io/bitnami/kubectl:1.32
+              command: ["/bin/sh", "/scripts/watchdog.sh"]
+              env:
+                - name: PIHOLE_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: homepage-env-vars
+                      key: PIHOLE_API_KEY
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+          volumes:
+            - name: script
+              configMap:
+                name: pihole-watchdog-script
+                defaultMode: 0755

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -39,18 +39,9 @@ All updates require manual review (no automerge). Dependency Dashboard issue mai
 ---
 
 ### 1.4 Kyverno Policy Violations Cleanup
-**Status:** `in-progress` ← **NEXT ACTION**
-**Priority:** Complete before resuming chart updates
+**Status:** `done`
 
-Fix all outstanding Kyverno policy violations to establish a clean baseline. Known violations from audit on 2026-04-04:
-
-- `sonarr`, `sabnzbd`, `radarr`, `prowlarr` Deployments — missing `category` label on pod templates (TrueCharts charts don't inject custom labels onto pods; fix via chart values `podLabels`)
-- Flux Kustomization CRs — 25/27 missing `app`, `env`, `category` labels
-- `shlink` and `shlink-web` Ingress resources — missing all labels
-- `portainer` Namespace — non-standard label format
-- Verify `actions-runner-system` and `mediastack` Namespace categories are correct after adding `ci` and `media` to valid list
-
-Branch: `chore/fix-kyverno-violations`
+Fixed all outstanding Kyverno policy violations to establish a clean baseline (PRs #221, #229, 2026-04-04). Label injection via mutate policies, autogen disabled to prevent webhook breakage.
 
 ---
 
@@ -66,26 +57,32 @@ Renovate now covers OCI image tag updates via the `flux` manager on `OCIReposito
 **Goal:** Build a production-grade SRE observability platform to upskill and to support everything that follows (Istio, Chaos Mesh, SLOs).
 
 ### 2.1 Prometheus + Grafana (kube-prometheus-stack)
+
 **Status:** `planned`
 
 Deploy `kube-prometheus-stack` to a new `monitoring` namespace:
+
 - Prometheus for metrics scraping
 - Grafana for dashboards (behind Authentik SSO once available)
 - Alertmanager → delivery target TBD (Ntfy, PushOver, or email)
 - ServiceMonitors for existing apps (ingress-nginx, Longhorn, Flux, etc.)
 
 ### 2.2 Loki + Promtail
+
 **Status:** `planned`
 
 Log aggregation stack:
+
 - Loki for log storage (S3-backed via MinIO once backup stack is deployed)
 - Promtail DaemonSet for log shipping from all nodes
 - Grafana Loki data source (integrated with 2.1)
 
 ### 2.3 OpenTelemetry Collector
+
 **Status:** `planned`
 
 Deploy the OpenTelemetry Operator + a collector pipeline:
+
 - Receive OTLP traces from instrumented apps
 - Export to Jaeger or Tempo (Grafana Tempo preferred for Grafana integration)
 - Foundation for Istio distributed tracing
@@ -95,11 +92,13 @@ Deploy the OpenTelemetry Operator + a collector pipeline:
 ## Phase 3 — Security & Access
 
 ### 3.0 PKI — Automated Certificate Lifecycle
+
 **Status:** `deferred`
 
 Control plane certs issued by kubeadm expire annually and require manual renewal on each control plane node. This became an incident on 2026-04-14 when all certs expired simultaneously.
 
 **Interim:** Next expiry is **2027-04-14**. Until a proper solution is in place, renew manually on each control plane node when prompted:
+
 ```bash
 sudo kubeadm certs renew all
 sudo systemctl restart kubelet
@@ -117,9 +116,11 @@ sudo cp /etc/kubernetes/admin.conf ~/.kube/config && sudo chown $(id -u):$(id -g
 ---
 
 ### 3.1 Authentik — SSO / Identity Provider
+
 **Status:** `planned`
 
 Deploy Authentik as the central IdP:
+
 - OIDC/OAuth2 for all web UIs (Grafana, Longhorn, Capacitor, Homepage, etc.)
 - LDAP outpost for apps that don't support OIDC natively
 - Forward Auth proxy for apps with no built-in auth
@@ -127,9 +128,30 @@ Deploy Authentik as the central IdP:
 
 ---
 
-## Phase 4 — Service Mesh
+## Phase 4 — Infrastructure Diagrams
 
-### 4.1 Istio
+**Goal:** Create living architecture diagrams for every repo in the org once observability and security are settled — so diagrams reflect a stable system and don't need immediate revision.
+
+### 4.0 Diagram Creation — All Repos
+
+**Status:** `planned`
+
+Create an Excalidraw-based `diagrams/` folder in each repo with architecture diagrams covering the full system as it exists at that point. Scope:
+
+- `k8s-vollminlab-cluster` — cluster topology (nodes, namespaces, networking), Flux reconciliation flow, storage layout (Longhorn, MinIO), backup data path (Velero → B2), DMZ isolation
+- `homelab-infrastructure` — Terraform resource graph, network topology, VM/node inventory
+- `github-admin` — repo/branch protection structure
+- Any other repos as they exist
+
+**Format:** `.excalidraw` files (JSON, committable to Git and viewable in VS Code via Excalidraw extension or on excalidraw.com). Optionally export `.svg` alongside for quick previewing in GitHub.
+
+**Maintenance:** diagrams live in `<repo>/diagrams/` and are updated as the system changes — not generated, hand-authored.
+
+---
+
+## Phase 5 — Service Mesh
+
+### 5.1 Istio
 **Status:** `planned` (depends on Phase 2 observability being in place)
 
 Deploy Istio via the Helm-based install (not `istioctl`):
@@ -142,9 +164,9 @@ Note: Istio's sidecar injection will interact with Kyverno policies — review `
 
 ---
 
-## Phase 5 — SRE Practice
+## Phase 6 — SRE Practice
 
-### 5.1 SLOTH — SLO-based Alerting
+### 6.1 SLOTH — SLO-based Alerting
 **Status:** `planned` (depends on Phase 2.1 Prometheus)
 
 Use SLOTH to generate SLO alert rules from a declarative YAML spec:
@@ -152,7 +174,7 @@ Use SLOTH to generate SLO alert rules from a declarative YAML spec:
 - SLOTH generates Prometheus recording rules + multi-burn-rate alerts
 - Dashboards in Grafana
 
-### 5.2 Chaos Mesh
+### 6.2 Chaos Mesh
 **Status:** `planned` (depends on Phase 2 observability)
 
 Controlled fault injection for resilience testing:
@@ -162,7 +184,7 @@ Controlled fault injection for resilience testing:
 
 ---
 
-## Phase 6 — Node Maintenance Window
+## Phase 7 — Node Maintenance Window
 
 **Status:** `planned` (depends on Phase 2 observability being in place for monitoring during maintenance)
 **Risk:** Medium — rolling node reboots; cluster should stay available if done one node at a time
@@ -192,10 +214,10 @@ Do not bundle this with the Cilium migration — they should be separate mainten
 
 ---
 
-## Phase 7 — CNI Migration (Calico → Cilium)
+## Phase 8 — CNI Migration (Calico → Cilium)
 
 **Status:** `planned`
-**Depends on:** 1.1 test restore validated, 1.3 Renovate, 1.4 Flux Image Automation, Phase 2 observability (2.1 + 2.2 minimum), Phase 6 node maintenance complete
+**Depends on:** 1.1 test restore validated, Phase 2 observability (2.1 + 2.2 minimum), Phase 7 node maintenance complete
 **Risk:** High — CNI replacement requires a full cluster maintenance window
 
 Cilium offers significant advantages over Calico for this use case:
@@ -207,7 +229,7 @@ Cilium offers significant advantages over Calico for this use case:
 Migration approach:
 1. Confirm Velero backups are healthy and a test restore has been validated
 2. Confirm Phase 2 observability is in place (Prometheus + Loki at minimum)
-3. Confirm all nodes are on current, normalized versions (Phase 6)
+3. Confirm all nodes are on current, normalized versions (Phase 7)
 4. Plan a maintenance window
 5. Drain nodes, uninstall Calico, install Cilium
 6. Validate network policies and DMZ rules (especially DMZ namespace on k8sworker05)
@@ -232,6 +254,8 @@ This is a cluster rebuild risk event — do not attempt without working backups.
 
 | Item | PR / Notes |
 |---|---|
+| Kyverno policy violations cleanup | PRs #221, #229 — label injection via mutate policies, autogen disabled |
+| Shlink Ingress Controller | Custom Go controller: Ingress annotation → auto-create `vollm.in/<slug>` via Shlink API |
 | Shlink short link service | Deployed with `vollm.in`, `go.vollminlab.com`, `vl.vollminlab.com` |
 | Internal CA issuer | 10-year cert, `internal-ca` ClusterIssuer |
 | ARC runner pool cleanup | Removed pool-2, pool-1 bumped to 3 replicas |

--- a/docs/superpowers/specs/2026-04-17-observability-stack-design.md
+++ b/docs/superpowers/specs/2026-04-17-observability-stack-design.md
@@ -1,0 +1,207 @@
+# Observability Stack Design
+
+**Date:** 2026-04-17
+**Phase:** 2 (Roadmap)
+**Status:** Approved — pending implementation
+
+---
+
+## Summary
+
+Deploy a production-grade observability stack in the existing `monitoring` namespace:
+
+- **kube-prometheus-stack** — Prometheus + Grafana + Alertmanager
+- **Loki** — log storage (S3-backed via MinIO)
+- **Promtail** — log shipping DaemonSet on all nodes
+- **OTel Collector** — deferred until Istio (Phase 5)
+
+ECK (eck-operator) is removed in a follow-up PR after Loki is confirmed healthy.
+
+---
+
+## Architecture
+
+```text
+pods → Promtail (DaemonSet, all nodes) → Loki (SingleBinary) → Grafana
+cluster components → Prometheus → Grafana
+                               → Alertmanager → PushOver
+```
+
+All components run in the `monitoring` namespace. Loki uses MinIO (`loki` bucket) as its S3-compatible object store. Grafana is the single UI for both metrics and logs.
+
+---
+
+## Section 1 — kube-prometheus-stack
+
+**Source:** `kind: HelmRepository`, `https://prometheus-community.github.io/helm-charts`
+
+**Components deployed by this one HelmRelease:**
+
+| Component | Config |
+|---|---|
+| Prometheus | 30s scrape interval, 15-day retention, 5Gi Longhorn PVC |
+| Grafana | Ingress at `grafana.vollminlab.com`, TLS via `internal-ca`, Loki data source pre-wired |
+| Alertmanager | PushOver receiver via SealedSecret, 1Gi Longhorn PVC |
+| Node exporter | DaemonSet — toleration: `dmz=true:NoSchedule` + control-plane |
+| kube-state-metrics | Default config, general workers |
+
+**ServiceMonitors enabled out of the box:** ingress-nginx, Longhorn, Flux, CoreDNS, kube-state-metrics.
+
+**Resource requests (conservative):**
+
+| Component | CPU req | Memory req | CPU limit | Memory limit |
+|---|---|---|---|---|
+| Prometheus | 250m | 512Mi | 1000m | 1Gi |
+| Grafana | 100m | 128Mi | 500m | 256Mi |
+| Alertmanager | 50m | 64Mi | 200m | 128Mi |
+
+**Alertmanager SealedSecret** — contains PushOver app token + user key. Single route: all alerts → PushOver.
+
+**Ingress:**
+- Host: `grafana.vollminlab.com`
+- TLS: `internal-ca` ClusterIssuer
+- Shlink annotation: `shlink.vollminlab.com/slug: grafana`
+- Labels: `app: grafana`, `env: production`, `category: observability`
+
+---
+
+## Section 2 — Loki
+
+**Source:** `kind: HelmRepository`, `https://grafana.github.io/helm-charts` (shared with Promtail)
+
+**Deployment mode:** SingleBinary — single pod, simplest for homelab scale.
+
+**Storage:**
+
+| Backend | Detail |
+|---|---|
+| Object store | MinIO, bucket `loki`, endpoint `http://minio.minio.svc.cluster.local:9000` |
+| Credentials | SealedSecret (`loki-minio-credentials`) in `monitoring` namespace — contains MinIO root username/password (SealedSecrets are namespace-scoped, so this is a separate seal of the same values from `minio-credentials`) |
+| WAL PVC | 2Gi Longhorn (write-ahead log only — log data goes to MinIO) |
+
+**Retention:** 30 days (`limits_config.retention_period`).
+
+**No Ingress** — Grafana accesses Loki via in-cluster service at `http://loki.monitoring.svc.cluster.local:3100`.
+
+**Grafana data source** (pre-configured in kube-prometheus-stack values):
+
+```yaml
+additionalDataSources:
+  - name: Loki
+    type: loki
+    url: http://loki.monitoring.svc.cluster.local:3100
+    access: proxy
+```
+
+---
+
+## Section 3 — Promtail
+
+**Source:** same `grafana` HelmRepository as Loki.
+
+**Deployment:** DaemonSet on all nodes.
+
+**Tolerations:**
+
+| Toleration | Reason |
+|---|---|
+| `dmz=true:NoSchedule` | Run on k8sworker05/06 |
+| `node-role.kubernetes.io/control-plane:NoSchedule` | Run on k8scp01/02/03 |
+
+**Log sources scraped:** `/var/log/pods`, `/var/log/containers`
+
+**Push target:** `http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push`
+
+**Pod labels:** `app: promtail`, `env: production`, `category: observability`
+
+---
+
+## Section 4 — MinIO Changes
+
+One addition to `clusters/vollminlab-cluster/minio/minio/app/configmap.yaml`:
+
+```yaml
+buckets:
+  - name: velero        # existing
+    ...
+  - name: loki          # new
+    policy: none
+    purge: false
+    versioning: false
+    objectlocking: false
+```
+
+No other MinIO changes.
+
+---
+
+## Section 5 — Flux Integration
+
+### New file structure
+
+```
+clusters/vollminlab-cluster/monitoring/
+  kube-prometheus-stack/app/
+    helmrelease.yaml
+    configmap.yaml
+    ingress.yaml
+    alertmanager-sealedsecret.yaml
+    kustomization.yaml
+  loki/app/
+    helmrelease.yaml
+    configmap.yaml
+    loki-sealedsecret.yaml
+    kustomization.yaml
+  promtail/app/
+    helmrelease.yaml
+    configmap.yaml
+    kustomization.yaml
+  kustomization.yaml              # updated to list all three apps
+```
+
+### Flux index updates (both required per flux.md)
+
+**`flux-system/flux-kustomizations/kustomization.yaml`**
+- Verify `- monitoring-kustomization.yaml` is present (namespace exists but check if kustomization CR exists)
+- Add if missing
+
+**`flux-system/repositories/kustomization.yaml`**
+- Add `- prometheus-community-helmrepository.yaml`
+- Add `- grafana-helmrepository.yaml`
+
+### New repository files
+
+- `flux-system/repositories/prometheus-community-helmrepository.yaml` — `kind: HelmRepository`, URL `https://prometheus-community.github.io/helm-charts`
+- `flux-system/repositories/grafana-helmrepository.yaml` — `kind: HelmRepository`, URL `https://grafana.github.io/helm-charts`
+
+---
+
+## Section 6 — ECK Removal (follow-up PR)
+
+After Loki is confirmed healthy (logs flowing in Grafana):
+
+1. Delete `clusters/vollminlab-cluster/elastic-system/` directory entirely
+2. Remove `- elastic-system-kustomization.yaml` from `flux-system/flux-kustomizations/kustomization.yaml`
+3. Remove ECK HelmRepository entry from `flux-system/repositories/kustomization.yaml`
+4. Flux will garbage-collect the eck-operator HelmRelease and namespace
+
+---
+
+## Decisions Made
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Alert delivery | PushOver | Reliable, $5 one-time, no infra to run |
+| Log backend | Loki (replace ECK) | Grafana-native, MinIO already present, lighter than ELK |
+| Loki mode | SingleBinary | Homelab scale, operational simplicity |
+| OTel Collector | Deferred | No apps emitting traces yet; revisit at Istio (Phase 5) |
+| Namespace | Single `monitoring` | Simpler than split monitoring/logging at this scale |
+
+---
+
+## Out of Scope
+
+- OpenTelemetry Collector (deferred to Phase 5 — Istio)
+- Authentik SSO on Grafana (Phase 3 — Security & Access)
+- SLOs / SLOTH (Phase 6 — SRE Practice)
+- Chaos Mesh (Phase 6)


### PR DESCRIPTION
## Summary
- Adds `pihole-watchdog` CronJob that runs every 5 minutes in the `homepage` namespace
- Detects Pi-hole 401 errors in homepage pod logs (5-minute window), validates Pi-hole is reachable, then patches the Deployment to trigger a rolling restart
- Post-restart: waits for rollout to complete and checks for residual 401 errors
- API key injected at runtime via `secretKeyRef` from existing `homepage-env-vars` sealed secret — nothing sensitive is committed

## Resources added
- `ServiceAccount` — `pihole-watchdog`
- `Role` + `RoleBinding` — namespaced; grants get/patch deployments, get/list pods, get pods/log
- `ConfigMap` — `pihole-watchdog-script` (shell script)
- `CronJob` — `pihole-watchdog`, `concurrencyPolicy: Forbid`, `schedule: */5 * * * *`
- All resources carry `app: homepage`, `env: production`, `category: apps` labels

## Test plan
- [ ] Verify Flux reconciles the new resources after merge
- [ ] Check that the CronJob pod starts successfully every 5 minutes
- [ ] Confirm the watchdog does NOT restart homepage when no 401 errors are present
- [ ] Manually inject a 401 scenario and verify restart + post-validation logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)