### PR TITLE
feat(minio): add loki bucket

### DIFF
--- a/clusters/vollminlab-cluster/minio/minio/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/minio/minio/app/configmap.yaml
@@ -43,6 +43,11 @@ data:
         purge: false
         versioning: false
         objectlocking: false
+      - name: loki
+        policy: none
+        purge: false
+        versioning: false
+        objectlocking: false
 
     makeBucketJob:
       resources:


### PR DESCRIPTION
## Summary
- Adds `loki` bucket to MinIO for the Loki log storage backend
- Pre-requisite for the observability stack PR (kube-prometheus-stack + Loki + Promtail)

## Test plan
- [ ] Flux reconciles the minio HelmRelease after merge
- [ ] MinIO console shows `loki` bucket created at https://minio.vollminlab.com