### PR TITLE
fix(minio): set Recreate update strategy to prevent RWO PVC deadlock

### DIFF
--- a/clusters/vollminlab-cluster/minio/minio/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/minio/minio/app/configmap.yaml
@@ -8,6 +8,9 @@ data:
     mode: standalone
     replicas: 1
 
+    deploymentUpdate:
+      type: Recreate
+
     existingSecret: "minio-credentials"
 
     podLabels:


### PR DESCRIPTION
## Summary
- Adds `deploymentUpdate.type: Recreate` to MinIO Helm values
- Fixes upgrade deadlock where RollingUpdate spins up a new pod that can't mount the RWO PVC while the old pod holds it, causing Helm to time out

## Background
PR #324 (loki bucket addition) triggered a Helm upgrade. The new MinIO pod got stuck in `ContainerCreating` for 3h+ because it couldn't mount the RWO Longhorn PVC held by the running pod. The upgrade timed out with `context deadline exceeded`. Helm was rolled back manually and Flux suspended.

With `Recreate` strategy, Helm upgrades will terminate the old pod first (releasing the PVC), then start the new pod — no deadlock.

## Test plan
- [ ] After merge, run `flux resume helmrelease minio -n minio`
- [ ] MinIO pod restarts cleanly (old pod terminates, new pod comes up)
- [ ] `flux get helmrelease minio -n minio` shows Ready=True
- [ ] MinIO console accessible at https://minio.vollminlab.com
- [ ] `loki` bucket visible (created manually or by makeBucketJob)