### PR TITLE
fix: switch pihole-watchdog image from bitnami/kubectl to alpine/kubectl

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/pihole-watchdog-cronjob.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/pihole-watchdog-cronjob.yaml
@@ -153,8 +153,8 @@ spec:
           restartPolicy: Never
           containers:
             - name: watchdog
-              image: docker.io/bitnami/kubectl:1.32
-              command: ["/bin/sh", "/scripts/watchdog.sh"]
+              image: docker.io/alpine/kubectl:1.33.4
+              command: ["/bin/sh", "-c", "apk add --no-cache curl -q && /bin/sh /scripts/watchdog.sh"]
               env:
                 - name: PIHOLE_API_KEY
                   valueFrom:


### PR DESCRIPTION
## Summary
- Replaces `docker.io/bitnami/kubectl:1.32` with `docker.io/alpine/kubectl:1.33.4`
- Adds `apk add --no-cache curl` before script execution (curl not included in alpine/kubectl base)
- alpine/kubectl is the cluster standard for kubectl CronJobs (see `disk-cleanup-cronjob`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)