### PR TITLE
chore: reduce pihole-watchdog history limit to 1

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/pihole-watchdog-cronjob.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/pihole-watchdog-cronjob.yaml
@@ -138,8 +138,8 @@ metadata:
 spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
Matches `disk-cleanup-cronjob` convention. No reason to keep more than the last run for a watchdog job.