### PR TITLE
fix: scale harbor-db to 2 CNPG instances for node drain support

### DIFF
--- a/clusters/vollminlab-cluster/harbor/harbor-db/app/cluster.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor-db/app/cluster.yaml
@@ -8,7 +8,7 @@ metadata:
     env: production
     category: storage
 spec:
-  instances: 1
+  instances: 2
   inheritedMetadata:
     labels:
       app: harbor-db


### PR DESCRIPTION
## Summary

- Increases `harbor-db` CNPG cluster from 1 → 2 instances
- Single-replica CNPG sets `minAvailable: 1` on its PDB, permanently blocking node drains
- With 2 instances, CNPG allows `maxUnavailable: 1` — drains proceed normally

## Storage impact

Second replica adds a 10Gi PVC × 3 Longhorn replicas = ~30Gi additional storage. Verified all worker nodes have ≥31Gi available before merging.

## Test plan

- [ ] Merge and let Flux reconcile
- [ ] Verify `harbor-db-2` pod comes up healthy (`kubectl get pods -n harbor`)
- [ ] Verify Harbor remains functional
- [ ] Re-attempt node drain — should no longer block on harbor-db PDB

🤖 Generated with [Claude Code](https://claude.com/claude-code)