### PR TITLE
fix(loki): add delete_request_store for retention compactor

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/loki/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/loki/app/configmap.yaml
@@ -43,6 +43,7 @@ data:
 
       compactor:
         retention_enabled: true
+        delete_request_store: s3
 
     singleBinary:
       replicas: 1


### PR DESCRIPTION
## Summary

- Adds `compactor.delete_request_store: s3` to Loki config
- Loki requires this field when `retention_enabled: true` — without it the process exits immediately with a config validation error

## Test plan

- [ ] `loki-0` pod starts successfully
- [ ] Loki HelmRelease shows `Ready: True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)