### PR TITLE
fix(monitoring): disable etcd scraping and noisy false-positive alerts

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -104,6 +104,15 @@ data:
         env: production
         category: observability
 
+    kubeEtcd:
+      enabled: false
+
+    defaultRules:
+      rules:
+        kubeApiserver: true
+      disabled:
+        KubeClientCertificateExpiration: true
+
     kube-state-metrics:
       podLabels:
         app: kube-state-metrics


### PR DESCRIPTION
## Summary

- Disables `kubeEtcd` scraping — etcd listens on localhost only on kubeadm clusters, Prometheus can never reach it, causing `etcdInsufficientMembers` critical false positives
- Disables `KubeClientCertificateExpiration` alert rule — fires from short-lived auto-rotating kubelet certs (0.01 quantile threshold), not expiring control plane certs

## Verification

`kubeadm certs check-expiration` on all control plane nodes confirms all certs valid for 360 days (expire Apr 2027).

## Test plan

- [ ] `etcdInsufficientMembers` alert stops firing after reconcile
- [ ] `KubeClientCertificateExpiration` alert stops firing after reconcile

🤖 Generated with [Claude Code](https://claude.com/claude-code)