### PR TITLE
fix(monitoring): disable localhost-only scrapers and reduce promtail memory

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -107,6 +107,15 @@ data:
     kubeEtcd:
       enabled: false
 
+    kubeProxy:
+      enabled: false
+
+    kubeControllerManager:
+      enabled: false
+
+    kubeScheduler:
+      enabled: false
+
     defaultRules:
       rules:
         kubeApiserver: true

--- a/clusters/vollminlab-cluster/monitoring/promtail/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/promtail/app/configmap.yaml
@@ -24,8 +24,8 @@ data:
 
     resources:
       requests:
-        cpu: 100m
-        memory: 128Mi
+        cpu: 50m
+        memory: 64Mi
       limits:
         cpu: 200m
         memory: 256Mi


### PR DESCRIPTION
## Summary

- Disables `kubeProxy`, `kubeControllerManager`, `kubeScheduler` ServiceMonitors — these components listen on localhost only on kubeadm clusters, causing false-positive `TargetDown` alerts (same issue as `kubeEtcd` fixed in #335)
- Reduces promtail memory request from `128Mi` → `64Mi` so it can schedule on k8sworker02, which is near capacity due to SABnzbd's 4Gi request

## Test plan

- [ ] `TargetDown` alerts for kube-proxy, controller-manager, scheduler stop firing
- [ ] `promtail-hxmjr` pod schedules on k8sworker02 and becomes Ready
- [ ] `KubeDaemonSetRolloutStuck` and `KubePodNotReady` alerts clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)