### PR TITLE
feat(monitoring): add Prometheus and Alertmanager ingresses

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/ingress.yaml
@@ -27,3 +27,63 @@ spec:
     - hosts:
         - grafana.vollminlab.com
       secretName: wildcard-tls
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prometheus-ingress
+  namespace: monitoring
+  labels:
+    app: prometheus
+    env: production
+    category: observability
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    shlink.vollminlab.com/slug: prometheus
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: prometheus.vollminlab.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kube-prometheus-stack-prometheus
+                port:
+                  number: 9090
+  tls:
+    - hosts:
+        - prometheus.vollminlab.com
+      secretName: wildcard-tls
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: alertmanager-ingress
+  namespace: monitoring
+  labels:
+    app: alertmanager
+    env: production
+    category: observability
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    shlink.vollminlab.com/slug: alertmanager
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: alertmanager.vollminlab.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kube-prometheus-stack-alertmanager
+                port:
+                  number: 9093
+  tls:
+    - hosts:
+        - alertmanager.vollminlab.com
+      secretName: wildcard-tls


### PR DESCRIPTION
## Summary

Adds ingresses for all monitoring UIs so port-forwarding is never needed:
- `grafana.vollminlab.com` — existing, unchanged
- `prometheus.vollminlab.com` — new
- `alertmanager.vollminlab.com` — new (use Silences tab to suppress noisy alerts)

All use `wildcard-tls`, `ingressClassName: nginx`, and `shlink.vollminlab.com/slug` annotations.

## Test plan

- [ ] `prometheus.vollminlab.com` loads Prometheus UI
- [ ] `alertmanager.vollminlab.com` loads Alertmanager UI with Silences tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)