### PR TITLE
fix(promtail): increase HelmRelease timeout to 10m

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/promtail/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/monitoring/promtail/app/helmrelease.yaml
@@ -9,6 +9,7 @@ metadata:
     category: observability
 spec:
   interval: 10m
+  timeout: 10m
   chart:
     spec:
       chart: promtail


### PR DESCRIPTION
## Summary

DaemonSet rollout across 9 nodes exceeded the default 5m Helm timeout, causing a spurious upgrade failure even though all pods came up healthy. Bumps timeout to 10m.

🤖 Generated with [Claude Code](https://claude.com/claude-code)