### PR TITLE
feat(grafana): install Logs Drilldown plugin for Kibana-like log exploration

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -59,6 +59,9 @@ data:
         limits:
           cpu: 500m
           memory: 256Mi
+      plugins:
+        - grafana-lokiexplore-app
+
       additionalDataSources:
         - name: Loki
           type: loki


### PR DESCRIPTION
## Summary

Installs the `grafana-lokiexplore-app` plugin (Logs Drilldown) in Grafana.

Provides a dedicated log exploration interface on top of Loki with:
- Faceted label filtering (no LogQL required)
- Log volume histograms
- Service/namespace/pod drilldown
- Similar UX to Kibana Discover

After merge, accessible in Grafana left sidebar under **Logs Drilldown**.

## Test plan

- [ ] Grafana pod restarts with plugin installed
- [ ] "Logs Drilldown" appears in Grafana left sidebar
- [ ] Can browse logs by namespace/pod without writing LogQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)