### PR TITLE
fix(renovate): correct CronJob schedule values path and timezone

### DIFF
--- a/clusters/vollminlab-cluster/renovate/renovate/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/renovate/renovate/app/configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     category: apps
 data:
   values.yaml: |
-    cronjobs:
-      renovate:
-        schedule: "0 2 * * *"
-        suspend: false
+    cronjob:
+      schedule: "0 23 * * *"
+      timeZone: "America/New_York"
+      suspend: false
 
     pod:
       labels:


### PR DESCRIPTION
## Summary
- Fixes wrong Helm values path: `cronjobs.renovate.schedule` → `cronjob.schedule` (chart uses singular flat key; old path was silently ignored, CronJob always ran at the chart default `0 1 * * * UTC`)
- Fixes schedule mismatch: `0 1 * * * UTC` = 9 PM EST in winter, outside the `renovate.json5` "after 10pm America/New_York" window — Renovate would start a run and immediately skip it
- Uses `timeZone: America/New_York` with `0 23 * * *` (11 PM ET) so the CronJob stays inside the window year-round regardless of DST

## Test plan
- [ ] After merge + Flux reconcile: `kubectl get cronjob renovate -n renovate` shows schedule `0 23 * * *` with `TIMEZONE=America/New_York`
- [ ] `helm get values renovate -n renovate` shows `cronjob.schedule: 0 23 * * *`

🤖 Generated with [Claude Code](https://claude.com/claude-code)