### PR TITLE
chore(alertmanager): enable HA with 3 replicas

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -70,6 +70,7 @@ data:
 
     alertmanager:
       alertmanagerSpec:
+        replicas: 3
         configSecret: alertmanager-pushover-config
         podMetadata:
           labels:


### PR DESCRIPTION
## Summary

- Sets `alertmanager.alertmanagerSpec.replicas: 3` in the kube-prometheus-stack values
- Single-replica AlertManager shows "Cluster Status: disabled" in the UI; 3 replicas enables gossip-based clustering for deduplication and silencing coordination across instances

## Test plan

- [ ] Flux reconciles kube-prometheus-stack HelmRelease successfully
- [ ] 3 AlertManager pods running in `monitoring` namespace
- [ ] AlertManager UI shows "Cluster Status: ready" with 2 peers listed
- [ ] 3 × 1Gi PVCs provisioned on Longhorn (9Gi total with replicas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)