### PR TITLE
fix(kyverno): use time_now_utc() in force-rescan policy

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/force-rescan.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/force-rescan.yaml
@@ -35,4 +35,4 @@ spec:
         patchStrategicMerge:
           metadata:
             annotations:
-              policy.kyverno.io/kyverno-force-rescan: "{{ time.now.epochTime(@) }}"
+              policy.kyverno.io/kyverno-force-rescan: "{{ time_now_utc() }}"


### PR DESCRIPTION
## Summary

- Fixes a JMESPath resolution error in the `force-rescan-on-rollout` ClusterPolicy that was spamming errors in Loki on every DaemonSet, Deployment, and StatefulSet in the cluster
- `time.now.epochTime(@)` is not a valid Kyverno JMESPath expression — the correct built-in is `time_now_utc()`
- The background mutation controller retries indefinitely, so this error was occurring continuously

## Test plan

- [ ] Verify Flux reconciles the updated ClusterPolicy without errors
- [ ] Confirm the background mutation errors stop appearing in Loki for `force-rescan-on-rollout`
- [ ] Verify the annotation is successfully applied to a sample workload after a rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)