### PR TITLE
fix(kyverno): filter Calico GlobalNetworkPolicy from TTL controller

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
@@ -146,5 +146,9 @@ data:
         cpu: 200m
         memory: 256Mi
 
+    config:
+      resourceFilters:
+        - '[GlobalNetworkPolicy,projectcalico.org/v3,*]'
+
     serviceMonitor:
       enabled: true


### PR DESCRIPTION
## Summary

- Adds `config.resourceFilters` to the Kyverno Helm values to exclude `GlobalNetworkPolicy` (projectcalico.org/v3) from Kyverno's TTL controller
- Calico's tiered policy authorization model rejects Kyverno's preflight RBAC check on this resource with "Operation on Calico tiered policy is forbidden", causing continuous error log spam observed in Loki
- Kyverno has no policies targeting Calico GlobalNetworkPolicies, so filtering is safe and has no functional impact

## Test plan

- [ ] Flux reconciles the Kyverno HelmRelease without errors
- [ ] TTL controller errors for `globalnetworkpolicies.projectcalico.org` stop appearing in Loki

🤖 Generated with [Claude Code](https://claude.com/claude-code)