### PR TITLE
fix(kyverno): exclude system namespaces from force-rescan policy

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/force-rescan.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/force-rescan.yaml
@@ -24,6 +24,14 @@ spec:
                 - Deployment
                 - StatefulSet
                 - DaemonSet
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - tigera-operator
+                - calico-system
+                - calico-apiserver
       mutate:
         targets:
           - apiVersion: apps/v1


### PR DESCRIPTION
## Summary

- Adds an `exclude` block to `force-rescan-on-rollout` to skip `kube-system`, `tigera-operator`, `calico-system`, and `calico-apiserver`
- Calico/Tigera components self-update frequently, causing optimistic concurrency conflicts when the background controller tries to annotate them — surfacing as continuous error spam in Loki
- Our workloads all live in application namespaces so excluding these system namespaces has no impact on policy report coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)