### PR TITLE
fix(prometheus): add retentionSize cap and correct PVC size

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -15,6 +15,7 @@ data:
       prometheusSpec:
         scrapeInterval: 30s
         retention: 15d
+        retentionSize: 9GB
         serviceMonitorSelectorNilUsesHelmValues: false
         serviceMonitorSelector: {}
         serviceMonitorNamespaceSelector: {}
@@ -38,7 +39,7 @@ data:
                 - ReadWriteOnce
               resources:
                 requests:
-                  storage: 5Gi
+                  storage: 10Gi
 
     grafana:
       enabled: true


### PR DESCRIPTION
## Summary

- Adds `retentionSize: 9GB` to Prometheus spec so it prunes old TSDB blocks before filling the disk (hard cap, prevents recurrence of the 2026-04-19 disk-full / CrashLoopBackOff incident)
- Corrects PVC storage request from 5Gi to 10Gi to match the manual Longhorn expansion performed during the incident
- `retention: 15d` is kept as a time-based soft limit; `retentionSize` enforces the hard cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)