### PR TITLE
fix(loki): correct PVC size to 5Gi after disk-full incident

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/loki/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/loki/app/configmap.yaml
@@ -63,7 +63,7 @@ data:
       persistence:
         enabled: true
         storageClass: longhorn
-        size: 2Gi
+        size: 5Gi
 
       resources:
         requests:


### PR DESCRIPTION
## Summary

- Corrects Loki PVC size from 2Gi to 5Gi to match the manual Longhorn expansion performed during the 2026-04-19 disk-full incident
- Without this change Flux would reconcile back to 2Gi and block future expansion attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)