### PR TITLE
fix(kyverno): exclude Event from restrict-default-namespace policy

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-default.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-default.yaml
@@ -43,6 +43,7 @@ spec:
                 - CSINode
                 - VolumeAttachment
                 - ClusterIssuer
+                - Event
       validate:
         message: "Do not deploy resources into the 'default' namespace."
         deny: {}


### PR DESCRIPTION
## Summary

- Adds `Event` to the excluded kinds in `restrict-default-namespace`
- Kyverno's event controller writes `PolicyViolation` events to the `default` namespace; the policy was blocking them and logging a continuous error loop
- Events are transient observability objects — blocking them from `default` doesn't strengthen the policy's intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)