### PR TITLE
fix(kyverno): exclude kyverno and longhorn-system from force-rescan policy

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/force-rescan.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/force-rescan.yaml
@@ -29,6 +29,8 @@ spec:
           - resources:
               namespaces:
                 - kube-system
+                - kyverno
+                - longhorn-system
                 - tigera-operator
                 - calico-system
                 - calico-apiserver


### PR DESCRIPTION
## Summary

- Adds `kyverno` and `longhorn-system` to the force-rescan policy namespace exclusions
- Both namespaces have controllers that continuously self-update their deployments, causing optimistic concurrency conflicts (`the object has been modified`) when the background mutation controller races to annotate them

🤖 Generated with [Claude Code](https://claude.com/claude-code)