### PR TITLE
fix(kyverno): exclude flux-system from force-rescan policy

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/force-rescan.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/force-rescan.yaml
@@ -34,6 +34,7 @@ spec:
                 - tigera-operator
                 - calico-system
                 - calico-apiserver
+                - flux-system
       mutate:
         targets:
           - apiVersion: apps/v1


### PR DESCRIPTION
## Summary

- Adds `flux-system` to the namespace exclusions in the `force-rescan-on-rollout` ClusterPolicy
- Flux continuously reconciles its own controllers (kustomize-controller, helm-controller, etc.), causing constant `resourceVersion` conflict errors when the Kyverno background controller tries to stamp the force-rescan annotation on the same Deployments simultaneously
- Stops the log spam: `failed to update target resource ... the object has been modified; please apply your changes to the latest version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)