### PR TITLE
fix(capacitor): upgrade v0.4.8 → v0.14.0 to resolve pod controller nil panic

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/capacitor/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/flux-system/capacitor/app/configmap.yaml
@@ -11,7 +11,7 @@ data:
   values.yaml: |
     image:
       repository: ghcr.io/gimlet-io/capacitor
-      tag: v0.4.8
+      tag: v0.14.0
     containerPort: 9000
     probe:
       enabled: true


### PR DESCRIPTION
## Summary

- Capacitor v0.4.8 panics on startup with `interface conversion: interface {} is nil, not *v1.Pod` in `podController.go:40` — triggered by tombstoned/deleted pod objects coming through the informer cache as nil
- Pod has been in CrashLoopBackOff for ~11 minutes (6+ restarts) in flux-system
- Upgrading image tag from `v0.4.8` to `v0.14.0` (latest stable, released 2026-01-05)

🤖 Generated with [Claude Code](https://claude.com/claude-code)