### PR TITLE
fix(capacitor): correct image tag to 0.14.0 (no v prefix)

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/capacitor/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/flux-system/capacitor/app/configmap.yaml
@@ -11,7 +11,7 @@ data:
   values.yaml: |
     image:
       repository: ghcr.io/gimlet-io/capacitor
-      tag: v0.14.0
+      tag: "0.14.0"
     containerPort: 9000
     probe:
       enabled: true


### PR DESCRIPTION
## Summary

- Follow-up to #357 — the tag `v0.14.0` does not exist on `ghcr.io/gimlet-io/capacitor`
- Capacitor uses unprefixed semver tags; correct tag is `0.14.0`
- The `ErrImagePull` pod will resolve once Flux reconciles this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)