### PR TITLE
revert(capacitor): back to v0.4.8 — only published image on GHCR

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/capacitor/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/flux-system/capacitor/app/configmap.yaml
@@ -11,7 +11,7 @@ data:
   values.yaml: |
     image:
       repository: ghcr.io/gimlet-io/capacitor
-      tag: "0.14.0"
+      tag: v0.4.8
     containerPort: 9000
     probe:
       enabled: true


### PR DESCRIPTION
## Summary

- Reverts the upgrade attempt from #357 and #358
- `ghcr.io/gimlet-io/capacitor` only has images up to `v0.4.8` — the project stopped publishing Docker images after that release
- The nil pod panic that triggered the original crash loop was transient (triggered by a specific pod deletion event), not a version bug we can fix by upgrading
- Returning to `v0.4.8` restores normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)