### PR TITLE
chore: add flux-check-hook pre-commit validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ on:
       - 'docs/**'
       - '*.md'
       - 'renovate.json'
+      - '.pre-commit-config.yaml'
   pull_request:
     branches: [ main, develop ]
     types: [opened, synchronize, reopened, ready_for_review]
@@ -27,6 +28,7 @@ on:
       - 'docs/**'
       - '*.md'
       - 'renovate.json'
+      - '.pre-commit-config.yaml'
   workflow_dispatch:
 
 concurrency:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/tarioch/flux-check-hook
+    rev: v0.8.0
+    hooks:
+      - id: check-flux-helm-values


### PR DESCRIPTION
## Summary

- Adds `.pre-commit-config.yaml` with `tarioch/flux-check-hook` v0.8.0
- Validates HelmRelease `valuesFrom` references on every commit — catches values mismatches before they reach the cluster
- Requires `helm` in PATH (already present)
- Installs into `.git/hooks/pre-commit` via `pre-commit install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)