### PR TITLE
feat(headlamp): deploy Headlamp + Flux plugin alongside Capacitor

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/headlamp-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/headlamp-kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: headlamp
+  namespace: flux-system
+  labels:
+    app: headlamp
+    env: production
+    category: core
+spec:
+  interval: 10m
+  path: ./clusters/vollminlab-cluster/flux-system/headlamp/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: flux-system
+  timeout: 2m

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - dmz-kustomization.yaml
   - metallb-system-kustomization.yaml
   - capacitor-kustomization.yaml
+  - headlamp-kustomization.yaml
   - kyverno-kustomization.yaml
   - kyverno-webhooks-patch-kustomization.yaml
   - kyverno-policies-kustomization.yaml

--- a/clusters/vollminlab-cluster/flux-system/headlamp/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/flux-system/headlamp/app/configmap.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: headlamp-values
+  namespace: flux-system
+  labels:
+    app: headlamp
+    env: production
+    category: core
+data:
+  values.yaml: |
+    config:
+      inCluster: true
+      inClusterContextName: "main"
+      pluginsDir: "/headlamp/plugins"
+      # OIDC disabled — issuerURL empty means no OIDC auth.
+      # Uncomment and populate when Authentik is deployed:
+      # oidc:
+      #   clientID: ""
+      #   clientSecret: ""
+      #   issuerURL: "https://authentik.vollminlab.com/application/o/<slug>/"
+      #   scopes: "openid profile email"
+      oidc:
+        secret:
+          create: false
+        clientID: ""
+        clientSecret: ""
+        issuerURL: ""
+        scopes: ""
+
+    initContainers:
+      - name: headlamp-plugin-flux
+        image: ghcr.io/headlamp-k8s/headlamp-plugin-flux:v0.6.0
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c", "cp -r /plugins/* /headlamp/plugins/ 2>/dev/null || true"]
+        volumeMounts:
+          - name: headlamp-plugins
+            mountPath: /headlamp/plugins
+
+    volumeMounts:
+      - name: headlamp-plugins
+        mountPath: /headlamp/plugins
+
+    volumes:
+      - name: headlamp-plugins
+        emptyDir: {}
+
+    podLabels:
+      app: headlamp
+      env: production
+      category: core
+
+    serviceAccount:
+      create: true
+
+    clusterRoleBinding:
+      create: true
+      clusterRoleName: cluster-admin
+
+    resources:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi

--- a/clusters/vollminlab-cluster/flux-system/headlamp/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/flux-system/headlamp/app/helmrelease.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: headlamp
+  namespace: flux-system
+  labels:
+    app: headlamp
+    env: production
+    category: core
+spec:
+  interval: 5m
+  releaseName: headlamp
+  chart:
+    spec:
+      chart: headlamp
+      version: 0.41.0
+      sourceRef:
+        kind: HelmRepository
+        name: headlamp-repo
+        namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: headlamp-values
+      valuesKey: values.yaml

--- a/clusters/vollminlab-cluster/flux-system/headlamp/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/flux-system/headlamp/app/ingress.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: headlamp-ingress
+  namespace: flux-system
+  labels:
+    app: headlamp
+    env: production
+    category: core
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Headlamp"
+    gethomepage.dev/description: "Kubernetes + Flux dashboard"
+    gethomepage.dev/group: "Infrastructure"
+    gethomepage.dev/icon: "kubernetes.png"
+    gethomepage.dev/pod-selector: "app=headlamp"
+    shlink.vollminlab.com/slug: headlamp
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: headlamp.vollminlab.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: headlamp
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - headlamp.vollminlab.com
+      secretName: wildcard-tls

--- a/clusters/vollminlab-cluster/flux-system/headlamp/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/headlamp/app/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: headlamp-app
+  namespace: flux-system
+resources:
+  - configmap.yaml
+  - helmrelease.yaml
+  - ingress.yaml
+  - networkpolicy.yaml

--- a/clusters/vollminlab-cluster/flux-system/headlamp/app/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/flux-system/headlamp/app/networkpolicy.yaml
@@ -12,7 +12,7 @@ spec:
     - Ingress
   ingress:
     - from:
-      - namespaceSelector: {}
+        - namespaceSelector: {}
   podSelector:
     matchLabels:
       app.kubernetes.io/instance: headlamp

--- a/clusters/vollminlab-cluster/flux-system/headlamp/app/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/flux-system/headlamp/app/networkpolicy.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: headlamp-ingress
+  namespace: flux-system
+  labels:
+    app: headlamp
+    env: production
+    category: core
+spec:
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: headlamp

--- a/clusters/vollminlab-cluster/flux-system/repositories/headlamp-helmrepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/headlamp-helmrepository.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: headlamp-repo
+  namespace: flux-system
+  labels:
+    app: headlamp
+    env: production
+    category: core
+spec:
+  url: https://kubernetes-sigs.github.io/headlamp/
+  interval: 5m

--- a/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - external-dns-helmrepository.yaml
   - grafana-helmrepository.yaml
   - harbor-helmrepository.yaml
+  - headlamp-helmrepository.yaml
   - homepage-helmrepository.yaml
   - ingress-nginx-helmrepository.yaml
   - kyverno-helmrepository.yaml

--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -163,6 +163,12 @@ data:
                 icon: homepage.png
                 namespace: homepage
                 app: homepage
+            - Headlamp:
+                description: Kubernetes + Flux dashboard
+                href: https://headlamp.vollminlab.com
+                icon: kubernetes.png
+                namespace: flux-system
+                app: headlamp
             - Shlink:
                 description: URL shortener dashboard
                 href: https://shlink.vollminlab.com


### PR DESCRIPTION
## Summary

- Adds Headlamp v0.41.0 to `flux-system` with the Flux plugin (v0.6.0 via init container)
- Auth disabled; OIDC config commented and ready for Authentik when it lands
- Accessible at https://headlamp.vollminlab.com
- Capacitor left running — retire in a follow-up PR after validation
- Headlamp tile added to the homepage dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)