### PR TITLE
Add Kyverno exception for migration hook pods

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-kyverno-hooks.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-kyverno-hooks.yaml
@@ -1,0 +1,26 @@
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: ignore-kyverno-hook-pods
+  namespace: kyverno
+  labels:
+    app: kyverno
+    env: production
+    category: security
+spec:
+  # Kyverno's Helm upgrade hook creates short-lived migration pods that do not
+  # carry the standard app/env/category labels. They complete successfully and
+  # are not GitOps-managed workload specs we can label directly.
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+          namespaces:
+            - kyverno
+          names:
+            - "kyverno-migrate-resources-*"
+  exceptions:
+    - policyName: require-standard-labels
+      ruleNames:
+        - require-labels-on-pods-and-namespaces

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/kustomization.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - dmz-enforce-node-placement.yaml
   - dmz-restrict-external-access.yaml
   - exceptions-calico.yaml
+  - exceptions-kyverno-hooks.yaml
   - exceptions-longhorn-dynamic.yaml
   - flux-exception.yaml
   - inject-namespace-labels.yaml


### PR DESCRIPTION
## Summary
- add a PolicyException for the short-lived Kyverno migration hook pods
- exempt only the require-standard-labels pod rule for that hook pattern
- include the new exception in the Kyverno policies kustomization

## Why
These hook pods complete successfully but do not carry the standard app, env, and category labels, which creates benign audit noise in Headlamp.

## Testing
- repo hooks passed during commit
- rendered with kubectl kustomize clusters/vollminlab-cluster/kyverno/kyverno/policies
