### PR TITLE
Reduce Kyverno noise for CI namespaces and reports

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-ci-test-namespaces.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-ci-test-namespaces.yaml
@@ -1,0 +1,24 @@
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: ignore-ci-test-namespaces
+  namespace: kyverno
+  labels:
+    app: kyverno
+    env: production
+    category: security
+spec:
+  # External CI workflows create short-lived test namespaces outside GitOps.
+  # These namespaces are ephemeral and disappear before they can be brought into
+  # compliance with the standard labelling policy.
+  match:
+    any:
+      - resources:
+          kinds:
+            - Namespace
+          names:
+            - "ci-test-*"
+  exceptions:
+    - policyName: require-standard-labels
+      ruleNames:
+        - require-labels-on-pods-and-namespaces

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/kustomization.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - dmz-enforce-node-placement.yaml
   - dmz-restrict-external-access.yaml
   - exceptions-calico.yaml
+  - exceptions-ci-test-namespaces.yaml
   - exceptions-kyverno-hooks.yaml
   - exceptions-longhorn-dynamic.yaml
   - flux-exception.yaml

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-default.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-default.yaml
@@ -44,6 +44,7 @@ spec:
                 - VolumeAttachment
                 - ClusterIssuer
                 - Event
+                - EphemeralReport
       validate:
         message: "Do not deploy resources into the 'default' namespace."
         deny: {}


### PR DESCRIPTION
## Summary
- add a PolicyException for ephemeral CI test namespaces named ci-test-*
- exclude EphemeralReport objects from the restrict-default-namespace policy
- include the new exception in the Kyverno policies kustomization

## Why
CI creates short-lived integration test namespaces that are not managed through this repo and disappear quickly. Kyverno also emits EphemeralReport objects in the default namespace for blocked admissions, which creates noisy warnings without representing real workloads in default.

## Testing
- repo hooks passed during commit
- rendered with kubectl kustomize clusters/vollminlab-cluster/kyverno/kyverno/policies
