### PR TITLE
Bump external-dns image to v0.21.0

### DIFF
--- a/clusters/vollminlab-cluster/external-dns/external-dns/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/external-dns/external-dns/app/configmap.yaml
@@ -15,6 +15,9 @@ data:
     sources:
       - ingress
 
+    image:
+      tag: v0.21.0
+
     policy: upsert-only
 
     # Pi-hole cannot store TXT ownership records.


### PR DESCRIPTION
## Summary
- pin the external-dns image tag to v0.21.0 in Helm values
- keep the existing chart version, provider settings, and 1 minute sync interval unchanged

## Why
This is a proactive upgrade to pick up upstream external-dns fixes while we continue investigating the frequent crash loop seen with the Pi-hole provider.

## Testing
- repo hooks passed during commit
- verified the diff only changes the external-dns values ConfigMap
