### PR TITLE
kyverno: exclude migrate hook pods from label audit

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-calico.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-calico.yaml
@@ -28,7 +28,7 @@ spec:
     - policyName: require-standard-labels
       ruleNames:
         - require-labels-on-controllers
-        - require-labels-on-pods-and-namespaces
+        - require-labels-on-pods
     - policyName: require-resources
       ruleNames:
         - require-limits

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-ci-test-namespaces.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-ci-test-namespaces.yaml
@@ -21,4 +21,4 @@ spec:
   exceptions:
     - policyName: require-standard-labels
       ruleNames:
-        - require-labels-on-pods-and-namespaces
+        - require-labels-on-namespaces

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-kyverno-hooks.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-kyverno-hooks.yaml
@@ -23,4 +23,4 @@ spec:
   exceptions:
     - policyName: require-standard-labels
       ruleNames:
-        - require-labels-on-pods-and-namespaces
+        - require-labels-on-pods

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-longhorn-dynamic.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-longhorn-dynamic.yaml
@@ -46,7 +46,7 @@ spec:
     - policyName: require-standard-labels
       ruleNames:
         - require-labels-on-controllers
-        - require-labels-on-pods-and-namespaces
+        - require-labels-on-pods
     - policyName: require-resources
       ruleNames:
         - require-limits

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/require-labels.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/require-labels.yaml
@@ -46,24 +46,35 @@ spec:
                   app: "?*"
                   env: "?*"
                   category: "?*"
-    - name: require-labels-on-pods-and-namespaces
+    - name: require-labels-on-pods
       match:
         resources:
           kinds:
             - Pod
+      exclude:
+        resources:
+          namespaces:
+            - kube-system
+            - kyverno
+          names:
+            - "kyverno-migrate-resources-*"
+      validate:
+        message: "Required labels: app, env, category"
+        pattern:
+          metadata:
+            labels:
+              app: "?*"
+              env: "?*"
+              category: "?*"
+    - name: require-labels-on-namespaces
+      match:
+        resources:
+          kinds:
             - Namespace
       exclude:
-        any:
-          - resources:
-              namespaces:
-                - kube-system
-          - resources:
-              kinds:
-                - Pod
-              namespaces:
-                - kyverno
-              names:
-                - "kyverno-migrate-resources-*"
+        resources:
+          names:
+            - kube-system
       validate:
         message: "Required labels: app, env, category"
         pattern:

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/require-labels.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/require-labels.yaml
@@ -53,9 +53,17 @@ spec:
             - Pod
             - Namespace
       exclude:
-        resources:
-          namespaces:
-            - kube-system
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+          - resources:
+              kinds:
+                - Pod
+              namespaces:
+                - kyverno
+              names:
+                - "kyverno-migrate-resources-*"
       validate:
         message: "Required labels: app, env, category"
         pattern:


### PR DESCRIPTION
## Summary
- exclude Kyverno migrate hook pods from the pod label audit rule
- stop repeated Headlamp policy violation noise for kyverno-migrate-resources-* pods
- keep the exclusion narrowly scoped to pods in the kyverno namespace

## Testing
- kubectl kustomize clusters/vollminlab-cluster/kyverno/kyverno/policies >/tmp/kyverno-policies-rendered.yaml
