### PR TITLE
fix: correct Kyverno resourceFilter format for Calico GlobalNetworkPolicy

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
@@ -148,7 +148,7 @@ data:
 
     config:
       resourceFilters:
-        - '[GlobalNetworkPolicy,projectcalico.org/v3,*]'
+        - '[GlobalNetworkPolicy,*,*]'
 
     serviceMonitor:
       enabled: true


### PR DESCRIPTION
## Summary

- The `resourceFilters` entry `[GlobalNetworkPolicy,projectcalico.org/v3,*]` was malformed — Kyverno's format is `[Kind,namespace,name]`, so the API group was being matched against the namespace field and never hitting
- This caused the Kyverno TTL controller to continuously log preflight authorization errors against Calico's tiered policy webhook (`globalnetworkpolicies.projectcalico.org is forbidden: Operation on Calico tiered policy is forbidden`)
- Fixed to `[GlobalNetworkPolicy,*,*]` so the TTL controller correctly skips this CRD

🤖 Generated with [Claude Code](https://claude.com/claude-code)