### PR TITLE
fix: exclude all Calico tiered policy CRDs from Kyverno TTL preflight checks

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
@@ -149,6 +149,12 @@ data:
     config:
       resourceFilters:
         - '[GlobalNetworkPolicy,*,*]'
+        - '[NetworkPolicy,*,*]'
+        - '[Tier,*,*]'
+        - '[StagedGlobalNetworkPolicy,*,*]'
+        - '[StagedNetworkPolicy,*,*]'
+        - '[StagedKubernetesNetworkPolicy,*,*]'
+        - '[GlobalNetworkSet,*,*]'
 
     serviceMonitor:
       enabled: true


### PR DESCRIPTION
## Summary

- `GlobalNetworkPolicy` was already excluded (PR #369) but `networkpolicies.projectcalico.org` immediately triggered the same error
- Rather than one-at-a-time fixes, this excludes all Calico tiered policy CRDs that Calico's webhook blocks for non-Enterprise users: `NetworkPolicy`, `Tier`, `StagedGlobalNetworkPolicy`, `StagedNetworkPolicy`, `StagedKubernetesNetworkPolicy`, `GlobalNetworkSet`
- Note: `[NetworkPolicy,*,*]` also covers standard k8s NetworkPolicies — acceptable tradeoff since TTL labels on NetworkPolicies are not used

🤖 Generated with [Claude Code](https://claude.com/claude-code)