### PR TITLE
fix: exclude ci-test-* namespaces directly in ClusterPolicy rule

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/require-labels.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/require-labels.yaml
@@ -75,6 +75,7 @@ spec:
         resources:
           names:
             - kube-system
+            - "ci-test-*"
       validate:
         message: "Required labels: app, env, category"
         pattern:


### PR DESCRIPTION
## Summary

- PR #365 added a `PolicyException` for `ci-test-*` namespaces but violations continued appearing — `PolicyException` isn't reliably applied by Kyverno's background scanner in audit mode
- This PR adds `"ci-test-*"` directly to the `exclude.resources.names` block of the `require-labels-on-namespaces` rule, which is evaluated consistently in both admission control and background scanning

🤖 Generated with [Claude Code](https://claude.com/claude-code)