### PR TITLE
chore: disable Kyverno cleanup controller + upgrade HelmRepository to v1

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/bazarr-helmrepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/bazarr-helmrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: bazarr-repo

--- a/clusters/vollminlab-cluster/flux-system/repositories/metallb-helmrepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/metallb-helmrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: metallb-repo

--- a/clusters/vollminlab-cluster/flux-system/repositories/minecraft-helmrepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/minecraft-helmrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: minecraft-repo

--- a/clusters/vollminlab-cluster/flux-system/repositories/tautulli-helmrepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/tautulli-helmrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: tautulli-repo

--- a/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
@@ -105,6 +105,13 @@ data:
           memory: 256Mi
 
     cleanupController:
+      # Disabled: cleanup controller scans all CRDs including Calico tiered
+      # policy CRDs (globalnetworkpolicies.projectcalico.org) which Calico's
+      # webhook rejects for non-Enterprise users. Kyverno's resourceFilters
+      # do not apply to the cleanup controller, and it has no exclude mechanism.
+      # Re-enable when TTL policies are needed; check if a newer Kyverno version
+      # resolves the Calico webhook conflict first.
+      enabled: false
       labels:
         app: kyverno-cleanup-controller
         env: production


### PR DESCRIPTION
## Summary

- **Cleanup controller disabled**: the controller scans all CRDs including Calico's `globalnetworkpolicies.projectcalico.org`, which Calico's tiered policy webhook rejects for non-Enterprise users. Kyverno's `resourceFilters` don't apply to this component and it has no built-in exclude mechanism. A comment in the values explains the context and conditions for re-enabling.
- **HelmRepository v1beta2 → v1**: upgrades bazarr, metallb, minecraft, and tautulli from the deprecated `source.toolkit.fluxcd.io/v1beta2` apiVersion to `v1`, eliminating the deprecation warning logged by Flux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)