### PR TITLE
chore: upgrade inject ClusterPolicies from kyverno.io/v2beta1 to v1

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/inject-namespace-labels.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/inject-namespace-labels.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: inject-namespace-labels

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/inject-pod-labels.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/inject-pod-labels.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: inject-pod-labels

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/inject-resource-requirements.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/inject-resource-requirements.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: inject-resource-requirements


### PR DESCRIPTION
## Summary

- Upgrades the three inject ClusterPolicy files (`inject-namespace-labels`, `inject-pod-labels`, `inject-resource-requirements`) from the deprecated `kyverno.io/v2beta1` apiVersion to `kyverno.io/v1`

The remaining deprecation warnings (`v1beta2 Alert`, `v1beta2 Kustomization`, `MutatingPolicy v1alpha1`, `PolicyException v2beta1`, `v1beta2 GitRepository`) are not sourced from manifests in this repo — they originate from Flux and Kyverno internal clients using older API versions, and are a Flux/Kyverno version concern rather than a manifest fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)