### PR TITLE
fix: remove cleanup controller from Flux health check (disabled component)

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/kyverno-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/kyverno-kustomization.yaml
@@ -17,10 +17,8 @@ spec:
       kind: Deployment
       name: kyverno-background-controller
       namespace: kyverno
-    - apiVersion: apps/v1
-      kind: Deployment
-      name: kyverno-cleanup-controller
-      namespace: kyverno
+    # kyverno-cleanup-controller omitted: disabled in configmap.yaml (Calico tiered policy webhook conflict)
+    # Re-add when cleanupController.enabled is set back to true
     - apiVersion: apps/v1
       kind: Deployment
       name: kyverno-reports-controller


### PR DESCRIPTION
## Summary

- `kyverno-cleanup-controller` was disabled in PR #372 due to Calico tiered policy webhook conflict
- Flux Kustomization health check still had an explicit entry for the now-missing Deployment, causing `HealthCheckFailed` on every reconcile
- Removed the health check entry; added a comment pointing back to PR #372 and noting where to restore it when the controller is re-enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)