### PR TITLE
fix: correct pod label exclude logic to use any instead of AND

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/require-labels.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/require-labels.yaml
@@ -52,14 +52,10 @@ spec:
           kinds:
             - Pod
       exclude:
-        any:
-          - resources:
-              namespaces:
-                - kube-system
-                - kyverno
-          - resources:
-              names:
-                - "kyverno-migrate-resources-*"
+        resources:
+          namespaces:
+            - kube-system
+            - kyverno
       validate:
         message: "Required labels: app, env, category"
         pattern:

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/require-labels.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/require-labels.yaml
@@ -52,12 +52,14 @@ spec:
           kinds:
             - Pod
       exclude:
-        resources:
-          namespaces:
-            - kube-system
-            - kyverno
-          names:
-            - "kyverno-migrate-resources-*"
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kyverno
+          - resources:
+              names:
+                - "kyverno-migrate-resources-*"
       validate:
         message: "Required labels: app, env, category"
         pattern:


### PR DESCRIPTION
## Summary

- When PR #368 added `names: ["kyverno-migrate-resources-*"]` to the `require-labels-on-pods` exclude block alongside the existing `namespaces` list, it accidentally broke the namespace exclusion
- In Kyverno, multiple fields within a single `resources` block are ANDed — so the rule was excluding pods that matched **both** the namespace list and the name pattern, meaning kube-system pods with any other name were not excluded
- Fixed by converting to `exclude.any` so each condition is evaluated independently (OR semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)