### PR TITLE
chore: upgrade metallb and tautulli HelmRelease to helm.toolkit.fluxcd.io/v2

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/tautulli/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/mediastack/tautulli/app/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: tautulli

--- a/clusters/vollminlab-cluster/metallb-system/metallb/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/metallb-system/metallb/app/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: metallb


### PR DESCRIPTION
## Summary

- metallb: `v2beta1` → `v2`
- tautulli: `v2beta2` → `v2`

The remaining deprecation warnings (`HelmChart v1beta2`, `GitRepository v1beta2`, `Kustomization v1beta1`, `Provider v1beta2`, `CleanupPolicy v2beta1`) are not sourced from manifests in this repo — they originate from Flux's internal controllers using old client-go API paths. Fixing those requires a Flux version upgrade (`gotk-components.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)