### PR TITLE
fix: bump Prometheus memory to resolve OOMKill restarts

### DIFF
--- a/.claude/rules/flux.md
+++ b/.claude/rules/flux.md
@@ -77,6 +77,7 @@ See `kyverno.md` for valid `category` values.
 - **Never manually apply** manifests under `clusters/` — Flux reconciles from `main` within 10 minutes.
 - **Never push directly to `main`** — branch protection enforced via GitHub repository settings, PR required.
 - **Never use `:latest`** chart version ranges or image tags.
+- **Never use inline `values:` in a HelmRelease.** All Helm values go in `configmap.yaml` and are referenced via `valuesFrom`. This keeps HelmRelease files minimal and diffs readable.
 - `bootstrap/` is for DR reference only; changes there have no effect on the cluster.
 
 ## Emergency: HelmRelease stuck in failure loop

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -27,10 +27,10 @@ data:
         resources:
           requests:
             cpu: 250m
-            memory: 512Mi
+            memory: 1Gi
           limits:
             cpu: 1000m
-            memory: 1Gi
+            memory: 2Gi
         storageSpec:
           volumeClaimTemplate:
             spec:


### PR DESCRIPTION
## Summary

- Bump Prometheus memory request `512Mi → 1Gi` and limit `1Gi → 2Gi` — pod was OOMKilling (exit 137) with 10+ restarts on a 15-day retention instance scraping the full cluster
- Add hard rule to `.claude/rules/flux.md`: never use inline `values:` in a HelmRelease — all values go in `configmap.yaml` via `valuesFrom`

🤖 Generated with [Claude Code](https://claude.com/claude-code)