### PR TITLE
fix: set Kyverno webhook timeout to 30s via correct Helm key

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
@@ -22,6 +22,8 @@ data:
       env: production
       category: security
 
+    webhookTimeout: 30
+
     admissionController:
       labels:
         app: kyverno-admission-controller
@@ -34,7 +36,6 @@ data:
       replicas: 3
       priorityClassName: system-cluster-critical
       failurePolicy: Ignore
-      timeoutSeconds: 30
       namespaceSelector:
         matchExpressions:
           - key: kubernetes.io/metadata.name
@@ -58,7 +59,6 @@ data:
 
     validatingWebhookConfiguration:
       failurePolicy: Ignore
-      timeoutSeconds: 30
       namespaceSelector:
         matchExpressions:
           - key: kubernetes.io/metadata.name
@@ -70,7 +70,6 @@ data:
 
     mutatingWebhookConfiguration:
       failurePolicy: Ignore
-      timeoutSeconds: 30
       namespaceSelector:
         matchExpressions:
           - key: kubernetes.io/metadata.name


### PR DESCRIPTION
## Summary

- Adds `webhookTimeout: 30` at the top level of the Kyverno configmap — this is the correct Helm chart key that sets `--webhookTimeout` on the admission controller binary
- Removes three ineffective `timeoutSeconds` fields from `admissionController`, `validatingWebhookConfiguration`, and `mutatingWebhookConfiguration` — these were silently ignored because `--autoUpdateWebhooks=true` causes Kyverno to reconcile the live `ValidatingWebhookConfiguration` from its own flag, not from Helm's initial values

**Root cause:** `validate.kyverno.svc-fail` was running with the default 10s timeout (`?timeout=10s` visible in kube-apiserver error logs), causing frequent "context canceled" errors under load. The webhook timeout was never actually set to 30s despite our config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)