### PR TITLE
fix: exclude Kyverno report kinds from restrict-default-namespace policy

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-default.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-default.yaml
@@ -45,6 +45,12 @@ spec:
                 - ClusterIssuer
                 - Event
                 - EphemeralReport
+                - PolicyReport
+                - ClusterPolicyReport
+                - AdmissionReport
+                - ClusterAdmissionReport
+                - BackgroundScanReport
+                - ClusterBackgroundScanReport
       validate:
         message: "Do not deploy resources into the 'default' namespace."
         deny: {}


### PR DESCRIPTION
## Summary

- Adds all Kyverno report resource kinds to the exclusion list in `restrict-default.yaml`
- `PolicyReport` (and siblings) are created by Kyverno itself in the `default` namespace when it detects violations — without this exclusion, the policy evaluates its own reports and logs spurious `skipping the rule evaluation as pre-existing violations are allowed` warnings in the admission controller

Kinds added alongside existing `EphemeralReport` exclusion: `PolicyReport`, `ClusterPolicyReport`, `AdmissionReport`, `ClusterAdmissionReport`, `BackgroundScanReport`, `ClusterBackgroundScanReport`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)