### PR TITLE
fix: set Kyverno webhook timeout via admissionController.extraArgs

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
@@ -22,8 +22,6 @@ data:
       env: production
       category: security
 
-    webhookTimeout: 30
-
     admissionController:
       labels:
         app: kyverno-admission-controller
@@ -36,6 +34,8 @@ data:
       replicas: 3
       priorityClassName: system-cluster-critical
       failurePolicy: Ignore
+      extraArgs:
+        webhookTimeout: "30"
       namespaceSelector:
         matchExpressions:
           - key: kubernetes.io/metadata.name


### PR DESCRIPTION
## Summary

Corrects the previous webhook timeout fix (PR #378) which used a non-existent top-level `webhookTimeout` chart key that was silently ignored — the admission controller was still running with the default 10s timeout after that merge.

The correct Kyverno 3.7.x chart path is `admissionController.extraArgs.webhookTimeout: "30"`, which renders as `--webhookTimeout=30` in the container args and causes Kyverno to update both `ValidatingWebhookConfiguration` entries to 30s via its `autoUpdateWebhooks` mechanism.

Also removes the now-confirmed-ineffective `webhookTimeout: 30` top-level key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)