### PR TITLE
feat: expose control plane metrics (etcd, controller-manager, scheduler, kube-proxy)

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -110,20 +110,36 @@ data:
         category: observability
 
     kubeEtcd:
-      enabled: false
-
-    kubeProxy:
-      enabled: false
+      enabled: true
+      endpoints:
+        - 192.168.152.8
+        - 192.168.152.9
+        - 192.168.152.10
+      service:
+        port: 2381
+        targetPort: 2381
 
     kubeControllerManager:
-      enabled: false
+      enabled: true
+      endpoints:
+        - 192.168.152.8
+        - 192.168.152.9
+        - 192.168.152.10
 
     kubeScheduler:
-      enabled: false
+      enabled: true
+      endpoints:
+        - 192.168.152.8
+        - 192.168.152.9
+        - 192.168.152.10
+
+    kubeProxy:
+      enabled: true
 
     defaultRules:
       rules:
         kubeApiserver: true
+        etcd: true
       disabled:
         KubeClientCertificateExpiration: true
 


### PR DESCRIPTION
## Summary
- Re-enable etcd scraping on port 2381 with explicit CP node endpoints (192.168.152.8/9/10)
- Re-enable kube-controller-manager and kube-scheduler scraping with explicit CP node endpoints
- Re-enable kube-proxy scraping (metricsBindAddress patched to 0.0.0.0:10249 via ConfigMap)
- Enable etcd default alert rules

All four components were manually patched on k8scp01/02/03 before this PR — endpoints verified reachable prior to enabling scrapers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)