### PR TITLE
fix: enable Velero node-agent DaemonSet for kopia PVC backups

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -71,6 +71,7 @@ data:
 
     # node-agent DaemonSet runs kopia on every node for file-system PVC backups
     nodeAgent:
+      enabled: true
       podLabels:
         app: velero-node-agent
         env: production


### PR DESCRIPTION
## Summary
- Add `nodeAgent.enabled: true` to Velero Helm values
- The node-agent DaemonSet was missing entirely, causing every PVC backup to fail with "daemonset pod not found in running state in node X"
- `defaultVolumesToFsBackup: true` was set but kopia had no agent to run on any node

Backups have been completing in `FinalizingPartiallyFailed` state since the node-agent was not deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)