### PR TITLE
fix: use deployNodeAgent flag for velero chart v12 node-agent DaemonSet

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -70,8 +70,9 @@ data:
             key: cloud
 
     # node-agent DaemonSet runs kopia on every node for file-system PVC backups
+    deployNodeAgent: true
+
     nodeAgent:
-      enabled: true
       podLabels:
         app: velero-node-agent
         env: production


### PR DESCRIPTION
## Summary
- Replace `nodeAgent.enabled: true` with `deployNodeAgent: true` — the chart v12.0.0 gates the DaemonSet on `.Values.deployNodeAgent`, not `.Values.nodeAgent.enabled`
- Previous PR #383 set the wrong key so the DaemonSet was never rendered into the Helm manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)