### PR TITLE
fix: reduce velero node-agent CPU request to 100m

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -79,7 +79,7 @@ data:
         category: storage
       resources:
         requests:
-          cpu: 500m
+          cpu: 100m
           memory: 512Mi
         limits:
           cpu: 1000m


### PR DESCRIPTION
## Summary
- Drop node-agent CPU request from 500m to 100m
- node-agent is idle between backups and does not need 500m reserved
- k8sworker01 was unable to schedule the pod due to CPU pressure from Harbor, ARC runners, Prometheus, and mediastack

🤖 Generated with [Claude Code](https://claude.com/claude-code)