### PR TITLE
fix: add DMZ toleration to velero node-agent

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -77,6 +77,11 @@ data:
         app: velero-node-agent
         env: production
         category: storage
+      tolerations:
+        - key: dmz
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
## Summary

- Adds `dmz=true:NoSchedule` toleration to the velero node-agent DaemonSet
- Allows node-agent to run on k8sworker05/06 (DMZ nodes) so Minecraft PVC data is included in kopia file-system backups
- Previously, DMZ node PVC backups failed with "daemonset pod not found in running state in node k8sworker05"

🤖 Generated with [Claude Code](https://claude.com/claude-code)