### PR TITLE
fix: skip SMB-backed PVCs in Velero backups

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -99,6 +99,9 @@ data:
           ttl: 720h
           storageLocation: minio
           defaultVolumesToFsBackup: true
+          resourcePolicies:
+            kind: ConfigMap
+            name: velero-skip-smb-policy
       daily-b2:
         disabled: false
         schedule: "0 4 * * *"
@@ -107,3 +110,6 @@ data:
           ttl: 720h
           storageLocation: b2
           defaultVolumesToFsBackup: true
+          resourcePolicies:
+            kind: ConfigMap
+            name: velero-skip-smb-policy

--- a/clusters/vollminlab-cluster/velero/velero/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 resources:
   - helmrelease.yaml
   - configmap.yaml
+  - resource-policy-configmap.yaml
   - velero-minio-credentials-sealedsecret.yaml
   - velero-b2-credentials-sealedsecret.yaml

--- a/clusters/vollminlab-cluster/velero/velero/app/resource-policy-configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/resource-policy-configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: velero-skip-smb-policy
+  namespace: velero
+  labels:
+    app: velero
+    env: production
+    category: storage
+data:
+  policy.yaml: |
+    version: v1
+    volumePolicies:
+      - conditions:
+          storageClass:
+            - smb
+        action:
+          type: skip


### PR DESCRIPTION
## Summary

- Adds a `velero-skip-smb-policy` ResourcePolicy ConfigMap that instructs Velero to skip volumes backed by the `smb` StorageClass
- Prevents `pvc-movies`, `pvc-tv`, `pvc-completed-downloads`, and `pvc-incomplete-downloads` (each 100Gi NAS shares) from being written to MinIO/B2 via kopia — which would fill the 20Gi MinIO PVC on every backup run
- Longhorn-backed config PVCs (radarr, sonarr, bazarr, etc.) are unaffected and continue to be backed up
- Policy referenced from both `daily-full` (minio) and `daily-b2` schedule templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)