### PR TITLE
fix: correct resourcePolicy field name in velero schedule templates

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -99,7 +99,7 @@ data:
           ttl: 720h
           storageLocation: minio
           defaultVolumesToFsBackup: true
-          resourcePolicies:
+          resourcePolicy:
             kind: ConfigMap
             name: velero-skip-smb-policy
       daily-b2:
@@ -110,6 +110,6 @@ data:
           ttl: 720h
           storageLocation: b2
           defaultVolumesToFsBackup: true
-          resourcePolicies:
+          resourcePolicy:
             kind: ConfigMap
             name: velero-skip-smb-policy


### PR DESCRIPTION
## Summary

- Corrects `resourcePolicies` → `resourcePolicy` (singular) in both schedule templates
- The Velero Schedule CRD validates against `spec.template.resourcePolicy` — the plural form was silently dropped by Helm, leaving the SMB skip policy unattached to the schedules
- Schedules were already patched in-cluster manually (kubectl apply) to protect tonight's 2am backup; this PR corrects the GitOps source of truth for future Helm upgrades

🤖 Generated with [Claude Code](https://claude.com/claude-code)