### PR TITLE
fix: set externalUrl for Alertmanager and Prometheus

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -13,6 +13,7 @@ data:
 
     prometheus:
       prometheusSpec:
+        externalUrl: https://prometheus.vollminlab.com
         scrapeInterval: 30s
         retention: 15d
         retentionSize: 9GB
@@ -72,6 +73,7 @@ data:
     alertmanager:
       alertmanagerSpec:
         replicas: 3
+        externalUrl: https://alertmanager.vollminlab.com
         configSecret: alertmanager-pushover-config
         podMetadata:
           labels:


### PR DESCRIPTION
## Summary

- Set `externalUrl: https://alertmanager.vollminlab.com` on `alertmanagerSpec`
- Set `externalUrl: https://prometheus.vollminlab.com` on `prometheusSpec`

Both were defaulting to internal cluster DNS names (`*.monitoring:9090/9093`), making the links embedded in Pushover alert notifications unreachable from outside the cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)