### PR TITLE
fix: exclude velero from hostpath policy and enforce it

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-hostpath.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-hostpath.yaml
@@ -13,7 +13,7 @@ metadata:
     env: production
     category: security
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: disallow-hostpath-except-system
@@ -31,6 +31,7 @@ spec:
             - longhorn-system
             - monitoring
             - tigera-operator
+            - velero
       skipBackgroundRequests: false
       validate:
         message: "Using hostPath volumes is not allowed outside system namespaces."


### PR DESCRIPTION
## Summary

- Adds `velero` namespace to the `restrict-hostpath-usage` ClusterPolicy exclusion list so the node-agent DaemonSet (which mounts `/var/lib/kubelet/pods` and `/var/lib/kubelet/plugins` for Kopia pod volume backups) is no longer flagged
- Flips `validationFailureAction` from `Audit` to `Enforce` — all legitimate hostPath users are now in the exclusion list, so enforcement is safe

## Verification

Pre-merge: confirmed the only active `restrict-hostpath-usage` violation was `velero`, which is now excluded. No other namespaces have hostPath violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)