### PR TITLE
feat: add sabnzbd exportarr for Grafana metrics

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/sabnzbd/app/exportarr-apikey-sealedsecret.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sabnzbd/app/exportarr-apikey-sealedsecret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: sabnzbd-exportarr-apikey
+  namespace: mediastack
+spec:
+  encryptedData:
+    api-key: AgBEaZ/dICpagXqcnhYhCR4qWl4XKDh1xqVT0vEdxcsPdeQxn/i7ikKZR43mgi9a5sYZ0A5f6jL3NCziKxvEH97yPyULrv6H6paYNR3EGsKLnnZ2odSGxCN7SEVTaj7/7STcZN7N3sRyCChvqrsVrorpXhUUD6Z0OnZ/N9avXKL2hnADvDqiFbbIqaEDzfErFnAjBSglOjLM+9FYN17dqcpSnjYq8ptYk4P0NhRonATPnkiz3BBhXzbrXllq9rLsVofZaa7CKwvqSqBT1CL9uFSLQ8zNvVEeCZsCyHETrp+qCBVjwBvRpbWUbVmfXPA7+ndKkOzfERYf+ohKJUFWjMNRaiv5xIpnZrjtXzU9J9TlcgpZBFmZcemZ9khH8IkyXVBC+WsT1siaSSuW0l/JEiAqUEdL48M3yM/5d3ofqzNY0lgs1XOFUX/QFZyitIEA1yWyHrAz15CSbtCGX6QPV1AeGzCWfKnX5Igi/htGOLUZ68HhOzZ0fQHLqD4EwTVdxpc6zrpLBOVnvxDwIGNyFwGpSEPdfU0sIq6xSQrxzeqyNCvx20+qfAMuzbc/OkJdP1GKSBHQtSItjUFbGYDfLuX6WuKTCbnMZgjIN/bTzzWxBXAlYC1mP1yuXRCkUply4HnUjRmiH7vrgQ4+YRdae+55uKUd99iY6Re6iGAgV6qH0Xh0nzyibWmMYuR6PmUEgRJlyVIm0cclFg9azus3JWtxR5yzDvodLms+4lN1D4l9Lw==
+  template:
+    metadata:
+      name: sabnzbd-exportarr-apikey
+      namespace: mediastack

--- a/clusters/vollminlab-cluster/mediastack/sabnzbd/app/exportarr-deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sabnzbd/app/exportarr-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sabnzbd-exportarr
+  namespace: mediastack
+  labels:
+    app: sabnzbd-exportarr
+    env: production
+    category: media
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sabnzbd-exportarr
+  template:
+    metadata:
+      labels:
+        app: sabnzbd-exportarr
+        env: production
+        category: media
+    spec:
+      containers:
+        - name: exportarr
+          image: ghcr.io/onedr0p/exportarr:v2.2.0@sha256:320b0ea7399f4b9af4741dcdddd7d40c05c36b0359679305d8a54df4e97065df
+          args: ["sabnzbd"]
+          env:
+            - name: URL
+              value: "http://sabnzbd:8080"
+            - name: PORT
+              value: "9707"
+            - name: INTERFACE
+              value: "0.0.0.0"
+            - name: APIKEY
+              valueFrom:
+                secretKeyRef:
+                  name: sabnzbd-exportarr-apikey
+                  key: api-key
+          ports:
+            - name: metrics
+              containerPort: 9707
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 50m
+              memory: 64Mi

--- a/clusters/vollminlab-cluster/mediastack/sabnzbd/app/exportarr-service.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sabnzbd/app/exportarr-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sabnzbd-exportarr
+  namespace: mediastack
+  labels:
+    app: sabnzbd-exportarr
+    env: production
+    category: media
+spec:
+  type: ClusterIP
+  selector:
+    app: sabnzbd-exportarr
+  ports:
+    - name: metrics
+      port: 9707
+      targetPort: metrics
+      protocol: TCP

--- a/clusters/vollminlab-cluster/mediastack/sabnzbd/app/exportarr-servicemonitor.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sabnzbd/app/exportarr-servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: sabnzbd-exportarr
+  namespace: mediastack
+  labels:
+    app: sabnzbd-exportarr
+    env: production
+    category: media
+spec:
+  endpoints:
+    - path: /metrics
+      port: metrics
+  jobLabel: app
+  selector:
+    matchLabels:
+      app: sabnzbd-exportarr

--- a/clusters/vollminlab-cluster/mediastack/sabnzbd/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sabnzbd/app/kustomization.yaml
@@ -4,6 +4,10 @@ metadata:
   name: sabnzbd-app
 resources:
   - configmap.yaml
+  - exportarr-apikey-sealedsecret.yaml
+  - exportarr-deployment.yaml
+  - exportarr-service.yaml
+  - exportarr-servicemonitor.yaml
   - helmrelease.yaml
   - ingress.yaml
   - pvc-sabnzbd-config.yaml


### PR DESCRIPTION
## Summary

- Adds standalone exportarr Deployment, Service, and ServiceMonitor for SABnzbd
- Seals SABnzbd API key as a SealedSecret (`sabnzbd-exportarr-apikey`)
- Follows identical pattern to bazarr exportarr added in #393
- Enables SABnzbd panels in the arr-media Grafana dashboard to show data

🤖 Generated with [Claude Code](https://claude.com/claude-code)