### PR TITLE
feat: enable Longhorn/Velero/cert-manager monitoring and custom alert rules

### DIFF
--- a/clusters/vollminlab-cluster/cert-manager/cert-manager/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/cert-manager/cert-manager/app/configmap.yaml
@@ -12,3 +12,7 @@ data:
     extraArgs:
       - --dns01-recursive-nameservers-only
       - --dns01-recursive-nameservers=10.96.0.10:53
+    prometheus:
+      enabled: true
+      servicemonitor:
+        enabled: true

--- a/clusters/vollminlab-cluster/longhorn-system/longhorn/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn/app/configmap.yaml
@@ -87,3 +87,6 @@ data:
         app: longhorn-support-bundle-kit
         env: production
         category: storage
+    metrics:
+      serviceMonitor:
+        enabled: true

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -110,6 +110,11 @@ data:
         app: node-exporter
         env: production
         category: observability
+      prometheus:
+        monitor:
+          relabelings:
+            - sourceLabels: [__meta_kubernetes_node_name]
+              targetLabel: instance
 
     kubeEtcd:
       enabled: true

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - ingress.yaml
   - alertmanager-sealedsecret.yaml
   - grafana-admin-sealedsecret.yaml
+  - prometheusrule-custom.yaml

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -1,0 +1,75 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: vollminlab-custom-rules
+  namespace: monitoring
+  labels:
+    app: kube-prometheus-stack
+    env: production
+    category: observability
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: cert-manager
+      rules:
+        - alert: CertManagerCertificateExpiringSoon
+          expr: |
+            certmanager_certificate_expiration_timestamp_seconds - time() < 14 * 24 * 3600
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Certificate {{ $labels.name }} in {{ $labels.namespace }} expires soon"
+            description: "Certificate {{ $labels.name }} (namespace {{ $labels.namespace }}) expires in {{ $value | humanizeDuration }}."
+
+        - alert: CertManagerCertificateExpiringCritical
+          expr: |
+            certmanager_certificate_expiration_timestamp_seconds - time() < 24 * 3600
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Certificate {{ $labels.name }} in {{ $labels.namespace }} expires in < 24 hours"
+            description: "Certificate {{ $labels.name }} (namespace {{ $labels.namespace }}) expires in {{ $value | humanizeDuration }}. Immediate action required."
+
+    - name: velero
+      rules:
+        - alert: VeleroScheduledBackupOverdue
+          expr: |
+            time() - velero_backup_last_successful_timestamp{schedule="daily-full"} > 90000
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Velero minio backup last succeeded > 25 hours ago"
+            description: "The daily-full (minio) backup last succeeded at {{ $value | humanizeTimestamp }}. Check Velero logs."
+
+        - alert: VeleroBackupFailed
+          expr: |
+            increase(velero_backup_failure_total{schedule="daily-full"}[26h]) > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Velero daily-full backup failed"
+            description: "A daily-full backup has Failed in the last 26 hours. Check velero backup get."
+
+        - alert: VeleroBackupPartiallyFailed
+          expr: |
+            increase(velero_backup_partial_failure_total{schedule="daily-full"}[26h]) > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Velero daily-full backup partially failed"
+            description: "A daily-full backup has PartiallyFailed in the last 26 hours. Check velero backup describe."
+
+        - alert: VeleroBackupMetricMissing
+          expr: |
+            absent(velero_backup_last_successful_timestamp{schedule="daily-full"}) == 1
+          for: 30m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Velero daily-full backup metric absent — Velero may not be running"
+            description: "velero_backup_last_successful_timestamp for schedule=daily-full is missing. Velero may be down or no backup has ever completed."

--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -3,6 +3,10 @@ kind: ConfigMap
 metadata:
   name: velero-values
   namespace: velero
+  labels:
+    app: velero
+    env: production
+    category: storage
 data:
   values.yaml: |
     podLabels:
@@ -89,6 +93,13 @@ data:
         limits:
           cpu: 1000m
           memory: 1Gi
+
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+      nodeAgentPodMonitor:
+        enabled: true
 
     schedules:
       daily-full:


### PR DESCRIPTION
## Summary

- Enable Longhorn `metrics.serviceMonitor` — activates Longhorn's built-in PrometheusRules (volume health, disk space, replica failures)
- Enable Velero `metrics.serviceMonitor` and `nodeAgentPodMonitor` — exposes backup counters and kopia transfer metrics; also fixes missing required labels on the ConfigMap
- Enable cert-manager `prometheus.servicemonitor` — exposes certificate expiry timestamps
- Add `prometheusrule-custom.yaml` with 5 alert rules:
  - `CertManagerCertificateExpiringSoon` — warning at < 14 days
  - `CertManagerCertificateExpiringCritical` — critical at < 24h
  - `VeleroScheduledBackupOverdue` — warning if daily-full (minio) last succeeded > 25h ago
  - `VeleroBackupFailed` / `VeleroBackupPartiallyFailed` — warning on any failure in last 26h
  - `VeleroBackupMetricMissing` — critical if metric is absent (Velero down or never ran)
- Fix node-exporter `instance` label: relabel from `<IP>:<port>` to node hostname so Grafana dashboards show `k8sworker01` instead of IPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)