### PR TITLE
fix: correct SABnzbd exportarr URL port 8080 → 10097

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/sabnzbd/app/exportarr-deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sabnzbd/app/exportarr-deployment.yaml
@@ -25,7 +25,7 @@ spec:
           args: ["sabnzbd"]
           env:
             - name: URL
-              value: "http://sabnzbd:8080"
+              value: "http://sabnzbd:10097"
             - name: PORT
               value: "9707"
             - name: INTERFACE


### PR DESCRIPTION
## Summary

- SABnzbd runs on port 10097 (TrueCharts non-standard port), not the default 8080
- Exportarr was timing out on every scrape, producing zero metrics
- This caused the SABnzbd metrics missing/alert to fire and all SABnzbd dashboard panels to show "No data"
- API key verified working against the correct port before committing

🤖 Generated with [Claude Code](https://claude.com/claude-code)