### PR TITLE
fix: use __meta_kubernetes_pod_node_name for node-exporter hostname relabeling

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -113,7 +113,7 @@ data:
       prometheus:
         monitor:
           relabelings:
-            - sourceLabels: [__meta_kubernetes_node_name]
+            - sourceLabels: [__meta_kubernetes_pod_node_name]
               targetLabel: instance
 
     kubeEtcd:


### PR DESCRIPTION
## Summary

- Previous relabeling used `__meta_kubernetes_node_name` which is only populated under `role: node` service discovery
- The node-exporter ServiceMonitor uses `role: endpoints` with pod-backed targets; the correct label in that context is `__meta_kubernetes_pod_node_name`
- The empty source label caused Prometheus to fall back to setting `instance` from `__address__` (IP:port), leaving node dashboards showing IPs instead of hostnames

🤖 Generated with [Claude Code](https://claude.com/claude-code)