### PR TITLE
fix: replace phantom Sonarr Qualities panel with Episode Status

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/arr-media-dashboard-configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/arr-media-dashboard-configmap.yaml
@@ -4464,15 +4464,29 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sonarr_episode_quality_total{instance=~\"${sonarr_instance}\"}",
+                  "expr": "sonarr_episode_downloaded_total{instance=~\"${sonarr_instance}\"}",
                   "format": "time_series",
                   "instant": true,
-                  "legendFormat": "{{quality}}",
+                  "legendFormat": "Downloaded",
                   "range": false,
                   "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "editorMode": "code",
+                  "exemplar": false,
+                  "expr": "sonarr_episode_missing_total{instance=~\"${sonarr_instance}\"}",
+                  "format": "time_series",
+                  "instant": true,
+                  "legendFormat": "Missing",
+                  "range": false,
+                  "refId": "B"
                 }
               ],
-              "title": "Qualities",
+              "title": "Episode Status",
               "type": "bargauge"
             },
             {


### PR DESCRIPTION
## Summary

- `sonarr_episode_quality_total` does not exist in exportarr (never implemented in any version)
- Replaced the Qualities bargauge panel with an **Episode Status** panel using two confirmed-live metrics:
  - `sonarr_episode_downloaded_total` → "Downloaded"
  - `sonarr_episode_missing_total` → "Missing"
- Radarr's `radarr_movie_quality_total` was verified to exist and is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)