### PR TITLE
chore: temporarily enable Prometheus admin API to purge stale node-exporter IP series

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -17,6 +17,7 @@ data:
         scrapeInterval: 30s
         retention: 15d
         retentionSize: 9GB
+        enableAdminAPI: true
         serviceMonitorSelectorNilUsesHelmValues: false
         serviceMonitorSelector: {}
         serviceMonitorNamespaceSelector: {}


### PR DESCRIPTION
## Summary

- Node-exporter relabeling was fixed (PR #397) but stale IP-labeled series remain in the TSDB for 15 days
- Enabling `enableAdminAPI: true` temporarily to delete them via `delete_series`
- Will be immediately followed by a revert PR once the delete is executed

🤖 Generated with [Claude Code](https://claude.com/claude-code)