### PR TITLE
chore: disable Prometheus admin API after TSDB cleanup

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -17,7 +17,6 @@ data:
         scrapeInterval: 30s
         retention: 15d
         retentionSize: 9GB
-        enableAdminAPI: true
         serviceMonitorSelectorNilUsesHelmValues: false
         serviceMonitorSelector: {}
         serviceMonitorNamespaceSelector: {}


### PR DESCRIPTION
## Summary

- Removes `enableAdminAPI: true` from kube-prometheus-stack Prometheus spec
- Admin API was temporarily enabled (PR #399) to delete stale IP-labeled node-exporter series from TSDB after the hostname relabeling fix landed
- All 9 stale series (`192.168.152.8:9100` through `192.168.152.16:9100`) deleted and tombstones cleaned; admin API no longer needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)