### PR TITLE
fix: sort nodes dashboard instance variable alphabetically

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/nodes-dashboard-configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/nodes-dashboard-configmap.yaml
@@ -702,7 +702,8 @@ data:
             "refresh": 2,
             "type": "query",
             "definition": "query_result(node_uname_info{job=\"node-exporter\", sysname!=\"Darwin\"})",
-            "regex": "/instance=\"([^\"]+)\"/"
+            "regex": "/instance=\"([^\"]+)\"/",
+            "sort": 1
           }
         ]
       },


### PR DESCRIPTION
## Summary

- Adds `"sort": 1` to the `instance` template variable in the patched nodes dashboard
- `query_result()` returns results in Prometheus response order; `label_values()` sorted automatically but `query_result()` does not
- `sort: 1` = alphabetical ascending, so instances appear as `k8scp01, k8scp02, k8scp03, k8sworker01...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)