### PR TITLE
chore: disable prowlarr built-in Grafana dashboard

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/prowlarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/prowlarr/app/configmap.yaml
@@ -9,6 +9,9 @@ metadata:
     category: media
 data:
   values.yaml: |
+    grafana:
+      main:
+        enabled: false
     persistence:
       config:
         enabled: true


### PR DESCRIPTION
## Summary

- Sets `grafana.main.enabled: false` in the prowlarr Helm values
- The TrueCharts prowlarr chart ships a `prowlarr-dashboard` ConfigMap with `grafana_dashboard: "1"` that auto-provisions a standalone Prowlarr dashboard in Grafana
- Prowlarr metrics are already covered by the arr-media dashboard; the standalone one is redundant

🤖 Generated with [Claude Code](https://claude.com/claude-code)