### PR TITLE
fix: strip grafana_dashboard label from prowlarr chart dashboard via post-renderer

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/prowlarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/prowlarr/app/configmap.yaml
@@ -9,9 +9,6 @@ metadata:
     category: media
 data:
   values.yaml: |
-    grafana:
-      main:
-        enabled: false
     persistence:
       config:
         enabled: true

--- a/clusters/vollminlab-cluster/mediastack/prowlarr/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/mediastack/prowlarr/app/helmrelease.yaml
@@ -17,3 +17,12 @@ spec:
     - kind: ConfigMap
       name: prowlarr-values
       valuesKey: values.yaml
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: ConfigMap
+              name: prowlarr-dashboard
+            patch: |
+              - op: remove
+                path: /metadata/labels/grafana_dashboard


### PR DESCRIPTION
## Summary

- The TrueCharts prowlarr chart always renders `prowlarr-dashboard` ConfigMap with `grafana_dashboard: "1"` — there is no values flag to disable it
- Adds a Flux `postRenderers` kustomize JSON patch to the prowlarr HelmRelease that removes the `grafana_dashboard` label after Helm renders the manifest
- Without the label, the Grafana sidecar ignores the ConfigMap and the dashboard is not provisioned
- Also removes the ineffective `grafana.main.enabled: false` Helm value added in the previous attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)