### PR TITLE
fix: exclude minio namespace from Velero FSB schedules

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -110,6 +110,8 @@ data:
           ttl: 720h
           storageLocation: minio
           defaultVolumesToFsBackup: true
+          excludedNamespaces:
+            - minio
           resourcePolicy:
             kind: ConfigMap
             name: velero-skip-smb-policy
@@ -121,6 +123,8 @@ data:
           ttl: 720h
           storageLocation: b2
           defaultVolumesToFsBackup: true
+          excludedNamespaces:
+            - minio
           resourcePolicy:
             kind: ConfigMap
             name: velero-skip-smb-policy


### PR DESCRIPTION
## Summary

- Adds `excludedNamespaces: [minio]` to both `daily-full` and `daily-b2` Velero schedule templates
- Velero was running FSB on the MinIO pod's own PVC and writing the snapshots back into MinIO, consuming 25 GiB of the 35 GiB PVC (filling it to 100% and triggering a critical disk alert)
- MinIO's PVC contains Velero's own backup artifacts — not application state that needs Velero protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)