### PR TITLE
chore: rename bazarr-exportarr resources to exportarr

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/bazarr/app/exportarr-deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr/app/exportarr-deployment.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: bazarr-exportarr
+  name: exportarr
   namespace: mediastack
   labels:
-    app: bazarr-exportarr
+    app: exportarr
     env: production
     category: media
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: bazarr-exportarr
+      app: exportarr
   template:
     metadata:
       labels:
-        app: bazarr-exportarr
+        app: exportarr
         env: production
         category: media
     spec:

--- a/clusters/vollminlab-cluster/mediastack/bazarr/app/exportarr-service.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr/app/exportarr-service.yaml
@@ -1,16 +1,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: bazarr-exportarr
+  name: exportarr
   namespace: mediastack
   labels:
-    app: bazarr-exportarr
+    app: exportarr
     env: production
     category: media
 spec:
   type: ClusterIP
   selector:
-    app: bazarr-exportarr
+    app: exportarr
   ports:
     - name: metrics
       port: 9707

--- a/clusters/vollminlab-cluster/mediastack/bazarr/app/exportarr-servicemonitor.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr/app/exportarr-servicemonitor.yaml
@@ -1,10 +1,10 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: bazarr-exportarr
+  name: exportarr
   namespace: mediastack
   labels:
-    app: bazarr-exportarr
+    app: exportarr
     env: production
     category: media
 spec:
@@ -14,4 +14,4 @@ spec:
   jobLabel: app
   selector:
     matchLabels:
-      app: bazarr-exportarr
+      app: exportarr


### PR DESCRIPTION
## Summary

- Renames `bazarr-exportarr` → `exportarr` across Deployment, Service, and ServiceMonitor
- The exportarr instance now scrapes the full arr stack, so the bazarr-specific prefix was misleading
- SealedSecret (`bazarr-exportarr-apikey`) is intentionally unchanged — it is name-bound and would require a re-seal to rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)