### PR TITLE
chore: add weekly etcd defrag CronJob

### DIFF
--- a/clusters/vollminlab-cluster/kube-system/etcd-defrag/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/kube-system/etcd-defrag/app/cronjob.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: etcd-defrag
+  namespace: kube-system
+  labels:
+    app: etcd-defrag
+    env: production
+    category: core
+spec:
+  schedule: "0 3 * * 0"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 3600
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: etcd-defrag
+            env: production
+            category: core
+        spec:
+          serviceAccountName: etcd-defrag
+          restartPolicy: Never
+          containers:
+            - name: etcd-defrag
+              image: docker.io/alpine/kubectl:1.33.4
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  CERTS="--cacert=/etc/kubernetes/pki/etcd/ca.crt --cert=/etc/kubernetes/pki/etcd/server.crt --key=/etc/kubernetes/pki/etcd/server.key"
+                  echo "etcd defrag started at $(date)"
+
+                  echo "Defragging k8scp01 (follower)..."
+                  kubectl exec -n kube-system etcd-k8scp01 -- etcdctl --endpoints=https://192.168.152.8:2379 $CERTS defrag
+                  sleep 10
+
+                  echo "Defragging k8scp03 (follower)..."
+                  kubectl exec -n kube-system etcd-k8scp03 -- etcdctl --endpoints=https://192.168.152.10:2379 $CERTS defrag
+                  sleep 10
+
+                  echo "Defragging k8scp02 (leader)..."
+                  kubectl exec -n kube-system etcd-k8scp02 -- etcdctl --endpoints=https://192.168.152.9:2379 $CERTS defrag
+
+                  echo "etcd defrag complete at $(date)"
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 50m
+                  memory: 64Mi

--- a/clusters/vollminlab-cluster/kube-system/etcd-defrag/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/kube-system/etcd-defrag/app/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: etcd-defrag
+resources:
+  - rbac.yaml
+  - cronjob.yaml

--- a/clusters/vollminlab-cluster/kube-system/etcd-defrag/app/rbac.yaml
+++ b/clusters/vollminlab-cluster/kube-system/etcd-defrag/app/rbac.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-defrag
+  namespace: kube-system
+  labels:
+    app: etcd-defrag
+    env: production
+    category: core
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: etcd-defrag
+  namespace: kube-system
+  labels:
+    app: etcd-defrag
+    env: production
+    category: core
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-defrag
+  namespace: kube-system
+  labels:
+    app: etcd-defrag
+    env: production
+    category: core
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: etcd-defrag
+subjects:
+  - kind: ServiceAccount
+    name: etcd-defrag
+    namespace: kube-system

--- a/clusters/vollminlab-cluster/kube-system/kustomization.yaml
+++ b/clusters/vollminlab-cluster/kube-system/kustomization.yaml
@@ -4,5 +4,6 @@ metadata:
   name: kube-system
 resources:
   - namespace.yaml
+  - ./etcd-defrag/app
   - ./metrics-server/app
   - ./smb-csi-driver/app


### PR DESCRIPTION
## Summary

- Adds a CronJob in `kube-system` that defrags all 3 etcd members every Sunday at 3am UTC
- Runs sequentially: k8scp01 → k8scp03 → k8scp02 (leader last), with 10s sleep between each
- Root cause: ~58% DB fragmentation across all members (56MB in use, 130MB allocated) causing intermittent `etcdHighCommitDurations` alerts

## RBAC

Scoped `Role`/`RoleBinding` in `kube-system` only — grants `get`/`list` pods and `create` pods/exec, nothing cluster-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)