### PR TITLE
feat: add Longhorn and Velero Grafana dashboards

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -64,6 +64,30 @@ data:
       plugins:
         - grafana-lokiexplore-app
 
+      dashboardProviders:
+        dashboardproviders.yaml:
+          apiVersion: 1
+          providers:
+            - name: default
+              orgId: 1
+              folder: ''
+              type: file
+              disableDeletion: false
+              editable: true
+              options:
+                path: /var/lib/grafana/dashboards/default
+
+      dashboards:
+        default:
+          longhorn:
+            gnetId: 13032
+            revision: 6
+            datasource: prometheus
+          velero:
+            gnetId: 11055
+            revision: 2
+            datasource: prometheus
+
       additionalDataSources:
         - name: Loki
           type: loki


### PR DESCRIPTION
## Summary

- Adds `dashboardProviders` and `dashboards` to the kube-prometheus-stack Helm values ConfigMap
- Provisions **Longhorn** community dashboard (gnetId 13032, rev 6) from grafana.com
- Provisions **Velero** community dashboard (gnetId 11055, rev 2) from grafana.com
- Both dashboards use the `prometheus` datasource and are placed in the default Grafana folder

Both ServiceMonitors (Longhorn + Velero) are already active from Phase 2, so metrics will be available immediately after Flux reconciles the ConfigMap change and Grafana restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)