### PR TITLE
chore: bump bazarr CPU limit to 500m

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/bazarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr/app/configmap.yaml
@@ -47,5 +47,5 @@ data:
         cpu: 100m
         memory: 256Mi
       limits:
-        cpu: 200m
+        cpu: 500m
         memory: 512Mi


### PR DESCRIPTION
## Summary

- Raises bazarr CPU limit from `200m` → `500m`
- CPU request unchanged at `100m` (average usage is fine, only burst behaviour causes throttling)
- Resolves `CPUThrottlingHigh` alerts firing at ~28% throttling during subtitle processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)