### PR TITLE
chore: bump overseerr CPU limit to 500m

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/overseerr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/overseerr/app/configmap.yaml
@@ -27,7 +27,7 @@ data:
         cpu: 100m
         memory: 256Mi
       limits:
-        cpu: 200m
+        cpu: 500m
         memory: 512Mi
     podLabels:
       app: overseerr


### PR DESCRIPTION
## Summary

- Raises overseerr CPU limit from `200m` → `500m`
- CPU request unchanged at `100m`
- Resolves `CPUThrottlingHigh` alerts firing at ~40% throttling during Radarr/Sonarr background syncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)