### PR TITLE
chore: bump CPU limits to 500m across mediastack apps

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/prowlarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/prowlarr/app/configmap.yaml
@@ -28,5 +28,5 @@ data:
         cpu: 100m
         memory: 128Mi
       limits:
-        cpu: 200m
+        cpu: 500m
         memory: 256Mi

--- a/clusters/vollminlab-cluster/mediastack/radarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/radarr/app/configmap.yaml
@@ -32,7 +32,7 @@ data:
         cpu: 100m
         memory: 256Mi
       limits:
-        cpu: 200m
+        cpu: 500m
         memory: 512Mi
     podLabels:
       app: radarr

--- a/clusters/vollminlab-cluster/mediastack/sonarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sonarr/app/configmap.yaml
@@ -27,7 +27,7 @@ data:
         cpu: 100m
         memory: 256Mi
       limits:
-        cpu: 200m
+        cpu: 500m
         memory: 512Mi
     podLabels:
       app: sonarr

--- a/clusters/vollminlab-cluster/mediastack/tautulli/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/tautulli/app/configmap.yaml
@@ -35,5 +35,5 @@ data:
         cpu: 100m
         memory: 256Mi
       limits:
-        cpu: 200m
+        cpu: 500m
         memory: 512Mi


### PR DESCRIPTION
## Summary

Sweep of all mediastack apps with the same tight `200m` CPU limit that was causing throttling on bazarr (#416) and overseerr (#417).

| App | Before | After |
|---|---|---|
| Radarr | 200m | 500m |
| Sonarr | 200m | 500m |
| Prowlarr | 200m | 500m |
| Tautulli | 200m | 500m |
| SABnzbd | 500m | ✅ unchanged |

CPU requests are unchanged at `100m` throughout — only limits are raised to give burst headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)