### PR TITLE
chore: disable AIX and macOS node-exporter dashboards

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -97,6 +97,13 @@ data:
                 requests:
                   storage: 1Gi
 
+    nodeExporter:
+      operatingSystems:
+        aix:
+          enabled: false
+        darwin:
+          enabled: false
+
     prometheus-node-exporter:
       tolerations:
         - key: dmz


### PR DESCRIPTION
## Summary

- Adds `nodeExporter.operatingSystems.aix.enabled: false` and `darwin.enabled: false` to the kube-prometheus-stack Helm values
- Removes the `kube-prometheus-stack-nodes-aix` and `kube-prometheus-stack-nodes-darwin` Grafana dashboard ConfigMaps on next reconciliation
- All cluster nodes are Linux; these OS-specific dashboards reference macOS/AIX-only node-exporter metrics that will never have data here

🤖 Generated with [Claude Code](https://claude.com/claude-code)