### PR TITLE
docs: major roadmap update — Phase 2 done, new phases added

### DIFF
--- a/.claude/rules/velero.md
+++ b/.claude/rules/velero.md
@@ -65,6 +65,6 @@ kubectl logs -n velero $(kubectl get pods -n velero --sort-by=.metadata.creation
   | grep "<namespace>-minio-kopia-maintain" | tail -1 | awk '{print $1}')
 ```
 
-## Gate for Observability PR 2
+## Gate for Cilium migration (Phase 8)
 
-Do not start Observability PR 2 (Longhorn/Velero/cert-manager ServiceMonitors + PrometheusRules) until a `daily-full` backup shows `Completed` status. First expected clean run: **2026-04-23 at 2am UTC**.
+Do not start the Cilium CNI migration until a `daily-full` backup shows `Completed` status and a test restore has been validated. First expected clean backup: **2026-04-23 at 2am UTC** (after circular backup fix in PR #410).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,17 +9,21 @@ Living document tracking planned infrastructure work. Update status as projects 
 ## Phase 1 — Foundations (Prerequisite for everything else)
 
 ### 1.1 Backup Stack — MinIO + Velero + Backblaze B2
+
 **Status:** `done`
 
 - MinIO deployed in-cluster as the primary (fast) backup target
 - Velero with two BackupStorageLocations: `minio` (default, daily at 02:00 UTC) and `b2` (off-site, daily at 04:00 UTC)
 - Backblaze B2 bucket: `vollminlab-k8s-backups`, region `us-west-000`
 - Credentials in SealedSecrets; validation frequency tuned to 1h to limit B2 Class C API calls
+- Circular backup fixed (PR #410): `minio` namespace excluded from FSB on both schedules; first clean `Completed` backup expected 2026-04-23 02:00 UTC
 - **Still needed:** run a test restore and document the procedure in `docs/`
+- **Still needed:** scoped MinIO access key for Velero (currently uses root credentials) — tracked in `chore/velero-minio-access-key`
 
 ---
 
 ### 1.2 GitHub Actions Runner Migration
+
 **Status:** `done`
 
 Migrated to ARC v2 (`gha-runner-scale-set-controller` + `AutoscalingRunnerSet`). Legacy summerwind resources removed. Both ARC HelmReleases use `OCIRepository` + `spec.chartRef` per current Flux best practice. Single `vollminlab` runner pool.
@@ -27,9 +31,11 @@ Migrated to ARC v2 (`gha-runner-scale-set-controller` + `AutoscalingRunnerSet`).
 ---
 
 ### 1.3 Renovate Bot — Automated Helm Chart Updates
+
 **Status:** `done`
 
 Self-hosted Renovate deployed as a Kubernetes CronJob in the `renovate` namespace. Runs nightly at 02:00 ET. Covers:
+
 - All `HelmRelease` chart versions (`spec.chart.spec.version`) across all namespaces
 - All `OCIRepository` tag versions (`spec.ref.tag`) — TrueCharts mediastack apps, ARC, Renovate itself
 - GitHub Actions `uses:` version pins in all workflow files
@@ -39,6 +45,7 @@ All updates require manual review (no automerge). Dependency Dashboard issue mai
 ---
 
 ### 1.4 Kyverno Policy Violations Cleanup
+
 **Status:** `done`
 
 Fixed all outstanding Kyverno policy violations to establish a clean baseline (PRs #221, #229, 2026-04-04). Label injection via mutate policies, autogen disabled to prevent webhook breakage.
@@ -46,9 +53,10 @@ Fixed all outstanding Kyverno policy violations to establish a clean baseline (P
 ---
 
 ### 1.5 Flux Image Update Automation
+
 **Status:** `deferred`
 
-Renovate now covers OCI image tag updates via the `flux` manager on `OCIRepository` resources. Flux Image Update Automation adds complexity (additional controllers, ImagePolicy CRDs) for marginal gain. Revisit only if a use case arises that Renovate can't handle.
+Flux IUA's value is specifically for clusters that build and push custom container images — it scans a registry, detects new tags, and commits the update back to Git automatically (zero-touch CD for custom images). This cluster runs exclusively upstream Helm charts; Renovate already handles version bumps with human review, which is preferable. Revisit only if a CI pipeline starts building and pushing custom images.
 
 ---
 
@@ -58,34 +66,53 @@ Renovate now covers OCI image tag updates via the `flux` manager on `OCIReposito
 
 ### 2.1 Prometheus + Grafana (kube-prometheus-stack)
 
-**Status:** `planned`
+**Status:** `done`
 
-Deploy `kube-prometheus-stack` to a new `monitoring` namespace:
+`kube-prometheus-stack` deployed in `monitoring` namespace:
 
-- Prometheus for metrics scraping
-- Grafana for dashboards (behind Authentik SSO once available)
-- Alertmanager → delivery target TBD (Ntfy, PushOver, or email)
-- ServiceMonitors for existing apps (ingress-nginx, Longhorn, Flux, etc.)
+- Prometheus scraping cluster metrics, Grafana as the unified UI, Alertmanager → Pushover notifications via SealedSecret
+- ServiceMonitors: ingress-nginx (built-in), Longhorn, Velero, cert-manager
+- Control plane metrics: etcd, controller-manager, scheduler, kube-proxy all bound to `0.0.0.0` and scraped
+- Node-exporter hostname relabeling: `instance` label is node hostname, not `ip:port`
+- Custom `PrometheusRule`: cert-manager certificate expiry (14d warning / 24h critical), Velero backup overdue/failed/metric-missing
+- Dashboards: arr-media (Radarr/Sonarr/Bazarr consolidated), exportarr (Radarr/Sonarr/Bazarr/SABnzbd), Longhorn (custom sidecar), Velero (custom sidecar)
 
 ### 2.2 Loki + Promtail
 
-**Status:** `planned`
+**Status:** `done`
 
-Log aggregation stack:
-
-- Loki for log storage (S3-backed via MinIO once backup stack is deployed)
-- Promtail DaemonSet for log shipping from all nodes
-- Grafana Loki data source (integrated with 2.1)
+- Loki (SingleBinary mode) deployed, MinIO-backed object storage
+- Promtail DaemonSet shipping logs from all nodes
+- Grafana Loki data source configured and integrated with Grafana from 2.1
 
 ### 2.3 OpenTelemetry Collector
 
-**Status:** `planned`
+**Status:** `planned` (deploy after Phase 5 Istio)
 
 Deploy the OpenTelemetry Operator + a collector pipeline:
 
-- Receive OTLP traces from instrumented apps
-- Export to Jaeger or Tempo (Grafana Tempo preferred for Grafana integration)
-- Foundation for Istio distributed tracing
+- Receive OTLP traces from instrumented apps and Istio
+- Export to Grafana Tempo (preferred for Grafana integration)
+- Foundation for distributed tracing across the service mesh
+
+---
+
+## Phase 2.5 — Flux Upgrade (v2.4 → v2.8)
+
+**Status:** `planned`
+**Depends on:** Phase 2 observability complete (done)
+**Risk:** Low — two-hop upgrade with manifest migration; cluster stays up throughout
+
+Cluster currently runs Flux v2.4.0. Latest stable is v2.8.x. Deprecated APIs generate continuous Kyverno log warnings about invalid `apiVersion` values, and will be hard-removed in future releases.
+
+**Two hops required** (cannot skip):
+
+1. v2.4 → v2.7: removes `Kustomization v1beta1`, `Provider v1beta2/v2beta1` — run `flux migrate` first
+2. v2.7 → v2.8: removes `OCIRepository v1beta2`, `HelmChart v1beta2`, `GitRepository v1beta2` — 11 `OCIRepository` files in this repo need migration (handled by `flux migrate` automatically)
+
+**Kubernetes compatibility:** v1.32.3 meets v2.8 minimum.
+
+**Procedure per hop:** migrate manifests PR → merge → upgrade `gotk-components.yaml` PR → merge → verify reconciliation before next hop. Do not bundle with other work.
 
 ---
 
@@ -93,11 +120,11 @@ Deploy the OpenTelemetry Operator + a collector pipeline:
 
 ### 3.0 PKI — Automated Certificate Lifecycle
 
-**Status:** `deferred`
+**Status:** `planned`
 
 Control plane certs issued by kubeadm expire annually and require manual renewal on each control plane node. This became an incident on 2026-04-14 when all certs expired simultaneously.
 
-**Interim:** Next expiry is **2027-04-14**. Until a proper solution is in place, renew manually on each control plane node when prompted:
+**Hard deadline:** Next expiry is **2027-04-14**. Emergency renewal procedure until automated:
 
 ```bash
 sudo kubeadm certs renew all
@@ -128,6 +155,79 @@ Deploy Authentik as the central IdP:
 
 ---
 
+### 3.2 MetalLB: L2 → BGP Peering
+
+**Status:** `planned` (low priority — discuss before Phase 8 Cilium migration)
+
+**Problem:** k8sworker04 shows the MetalLB VIP (ingress-nginx LoadBalancer IP) in the UDM console instead of its actual node IP. In L2 mode, MetalLB answers ARP for VIPs from whichever node is the current leader; the UDM sees this ARP and maps that node's MAC to the VIP address, shadowing the real node IP.
+
+**Fix:** Switch MetalLB from L2 advertisement to BGP peering with the UDM Pro. MetalLB advertises VIP routes over BGP; the router learns them as routes (not ARP entries) and routes VIP traffic at L3. Node IPs are unaffected. Also enables ECMP across multiple nodes for better load distribution.
+
+**Note on Cilium overlap:** Cilium (Phase 8) has native BGP support (`CiliumBGPPeeringPolicy`) and a built-in L4LB that can replace MetalLB entirely. If Phase 8 is imminent, it may be cleaner to skip this and migrate BGP as part of the Cilium rollout. Decide at the start of Phase 8 planning.
+
+---
+
+### 3.3 Personal Media Services — External Access (Plex + Overseerr)
+
+**Status:** `planned` (architectural decision required — DMZ isolation constraint applies)
+
+**Goal:** Make Plex and Overseerr accessible to friends and family externally, without disrupting local use.
+
+**Hard constraint:** The DMZ is fully isolated from the internal network by design. No DMZ pod may initiate connections to internal LAN hosts or internal-cluster namespaces. This rules out any approach that puts Plex or Overseerr in the DMZ and has them reach back to TrueNAS (media) or the arr stack (Radarr/Sonarr/Prowlarr). Any solution must work with that isolation preserved.
+
+#### The core problem
+
+Both services have hard dependencies on internal resources:
+
+- **Plex** needs direct filesystem access to the media library on TrueNAS
+- **Overseerr** needs to call Radarr, Sonarr, Prowlarr, and Plex — all in `mediastack`
+
+Neither can run in an isolated DMZ without solving this. The viable approaches are:
+
+---
+
+##### Option A — Cloudflare Tunnel (recommended)
+
+Run `cloudflared` as a Deployment inside the internal cluster (in `mediastack` or a new `cloudflared` namespace). It creates an outbound-only connection to Cloudflare's edge — no inbound ports, no DMZ involvement, no internal network exposure. Visitors hit `plex.vollminlab.com` → Cloudflare edge → tunnel → internal Plex on TrueNAS (or Overseerr in mediastack).
+
+- Cloudflare Access gates both services with SSO (email-based invites for friends/family)
+- Zero impact on DMZ isolation — cloudflared runs inside the trusted internal network
+- No dependency on Authentik being ready
+- Plex stays on TrueNAS; Overseerr stays in mediastack — no migration needed
+- Tradeoff: Cloudflare sits in the traffic path; free tier has bandwidth limits on some features
+
+---
+
+##### Option B — Dedicated storage VLAN
+
+Add TrueNAS to a separate storage VLAN that DMZ workers (k8sworker05/06) also have access to. Plex and Overseerr run in the `dmz` namespace; media mounts come over the storage VLAN, not the main internal LAN. Arr stack connections from Overseerr → mediastack would still require a separate solution (either a storage VLAN for data + a message queue for requests, or accepting Overseerr can't be fully in DMZ).
+
+- Requires UDM VLAN configuration and TrueNAS network interface changes
+- True isolation preserved: DMZ workers connect to a dedicated storage network, not the internal LAN
+- High complexity for what is essentially a personal use case
+- Better long-term fit if storage VLAN is needed for other reasons anyway
+
+---
+
+##### Option C — UDM port forward (simple, no K8s changes)
+
+Port forward 32400 on the UDM directly to TrueNAS. Friends connect to your external IP or a dynamic DNS hostname. No DMZ, no cluster involvement.
+
+- No security model changes, no migration
+- Exposes TrueNAS directly to the internet — depends entirely on Plex's own auth
+- Overseerr would need a separate port forward; no SSO gating
+- Fine as a stopgap but not the right long-term answer given the security posture of this cluster
+
+---
+
+#### Decision needed before implementation
+
+1. **Preferred approach:** Cloudflare Tunnel (Option A) is the most consistent with the existing security model and requires the least new infrastructure. Decide whether to run `cloudflared` in-cluster (Flux-managed) or on TrueNAS directly.
+2. **Overseerr capacity gate:** Before enabling external requests, audit TrueNAS free space and set per-user request quotas in Overseerr to prevent runaway downloads.
+3. **Plex migration question:** Regardless of which option is chosen for external access, decide independently whether Plex should eventually migrate from TrueNAS into the cluster (better metrics, GitOps management) or stay on TrueNAS permanently.
+
+---
+
 ## Phase 4 — Infrastructure Diagrams
 
 **Goal:** Create living architecture diagrams for every repo in the org once observability and security are settled — so diagrams reflect a stable system and don't need immediate revision.
@@ -136,25 +236,27 @@ Deploy Authentik as the central IdP:
 
 **Status:** `planned`
 
-Create an Excalidraw-based `diagrams/` folder in each repo with architecture diagrams covering the full system as it exists at that point. Scope:
+Create a `diagrams/` folder in each repo with declarative Mermaid diagrams covering the full system as it exists at that point. Scope:
 
 - `k8s-vollminlab-cluster` — cluster topology (nodes, namespaces, networking), Flux reconciliation flow, storage layout (Longhorn, MinIO), backup data path (Velero → B2), DMZ isolation
 - `homelab-infrastructure` — Terraform resource graph, network topology, VM/node inventory
 - `github-admin` — repo/branch protection structure
 - Any other repos as they exist
 
-**Format:** `.excalidraw` files (JSON, committable to Git and viewable in VS Code via Excalidraw extension or on excalidraw.com). Optionally export `.svg` alongside for quick previewing in GitHub.
+**Format:** `.mmd` files (Mermaid — declarative, committable to Git, rendered natively in GitHub PRs/issues, previewable in VS Code with the Mermaid extension). Matches the declarative/GitOps ethos of the cluster. Diagram types: `graph TD` for topology, `flowchart` for data flows, `sequenceDiagram` for reconciliation flows.
 
-**Maintenance:** diagrams live in `<repo>/diagrams/` and are updated as the system changes — not generated, hand-authored.
+**Maintenance:** diagrams live in `<repo>/diagrams/` and are updated as the system changes.
 
 ---
 
 ## Phase 5 — Service Mesh
 
 ### 5.1 Istio
+
 **Status:** `planned` (depends on Phase 2 observability being in place)
 
 Deploy Istio via the Helm-based install (not `istioctl`):
+
 - Mutual TLS (mTLS) between all services by default
 - Traffic management (weighted routing, retries, circuit breaking)
 - Integration with Kiali for topology visualization
@@ -167,20 +269,20 @@ Note: Istio's sidecar injection will interact with Kyverno policies — review `
 ## Phase 6 — SRE Practice
 
 ### 6.1 SLOTH — SLO-based Alerting
+
 **Status:** `planned` (depends on Phase 2.1 Prometheus)
 
 Use SLOTH to generate SLO alert rules from a declarative YAML spec:
+
 - Define SLIs/SLOs for key services (ingress latency, Shlink availability, etc.)
 - SLOTH generates Prometheus recording rules + multi-burn-rate alerts
 - Dashboards in Grafana
 
 ### 6.2 Chaos Mesh
-**Status:** `planned` (depends on Phase 2 observability)
 
-Controlled fault injection for resilience testing:
-- Pod kill, network partition, CPU/memory stress experiments
-- Scheduled chaos experiments via CronWorkflow
-- Dashboards to verify SLOs hold under fault conditions
+**Status:** `deferred`
+
+Controlled fault injection for resilience testing (pod kill, network partition, CPU/memory stress). No immediate plans — incidents are being handled well without it. Revisit after SLOs (6.1) are established so there are clear baselines to validate against.
 
 ---
 
@@ -189,10 +291,10 @@ Controlled fault injection for resilience testing:
 **Status:** `planned` (depends on Phase 2 observability being in place for monitoring during maintenance)
 **Risk:** Medium — rolling node reboots; cluster should stay available if done one node at a time
 
-Normalize all nodes to current versions before the CNI migration. Current state (as of 2026-04-01):
+Normalize all nodes to current versions before the CNI migration. Current state (as of 2026-04-01 — **update table before starting this phase**):
 
 | Node | k8s | Kernel | Ubuntu |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | k8scp01 | v1.32.3 | 6.8.0-106 | 24.04.2 |
 | k8scp02 | v1.32.3 | 6.8.0-85 | 24.04.1 |
 | k8scp03 | v1.32.3 | 6.8.0-87 | 24.04.1 |
@@ -204,6 +306,7 @@ Normalize all nodes to current versions before the CNI migration. Current state 
 | k8sworker06 | v1.32.3 | 6.8.0-106 | 24.04.1 |
 
 Scope:
+
 - Upgrade all nodes to the latest Kubernetes 1.32.x patch (or latest stable minor if 1.33+ is current)
 - `apt upgrade` on all nodes to normalize Ubuntu patch levels and kernel versions
 - Upgrade containerd if a newer stable version is available (currently 1.7.27 across all nodes)
@@ -221,12 +324,14 @@ Do not bundle this with the Cilium migration — they should be separate mainten
 **Risk:** High — CNI replacement requires a full cluster maintenance window
 
 Cilium offers significant advantages over Calico for this use case:
+
 - **Hubble** — built-in L4/L7 network observability (flows, DNS, HTTP)
 - eBPF-native (better performance, richer policy)
 - Native Gateway API support
 - Industry direction for SRE/platform engineering roles
 
 Migration approach:
+
 1. Confirm Velero backups are healthy and a test restore has been validated
 2. Confirm Phase 2 observability is in place (Prometheus + Loki at minimum)
 3. Confirm all nodes are on current, normalized versions (Phase 7)
@@ -242,10 +347,9 @@ This is a cluster rebuild risk event — do not attempt without working backups.
 ## Deferred / Under Evaluation
 
 | Item | Notes |
-|---|---|
-| Dynatrace / Dash0 | Evaluate after homegrown observability stack is established |
+| --- | --- |
+| Dynatrace / Dash0 | Homegrown stack (Prometheus + Loki + Grafana) is now established — evaluate if a managed platform adds value |
 | Tekton | Not needed for dependency updates (Renovate covers that); revisit if building/pushing custom images |
-| ELK (Elasticsearch/Kibana) | ECK is already deployed; evaluate whether Loki replaces it or both coexist |
 | Crossplane | Potential future IaC-as-Kubernetes for cloud resources |
 
 ---
@@ -253,7 +357,7 @@ This is a cluster rebuild risk event — do not attempt without working backups.
 ## Completed
 
 | Item | PR / Notes |
-|---|---|
+| --- | --- |
 | Kyverno policy violations cleanup | PRs #221, #229 — label injection via mutate policies, autogen disabled |
 | Shlink Ingress Controller | Custom Go controller: Ingress annotation → auto-create `vollm.in/<slug>` via Shlink API |
 | Shlink short link service | Deployed with `vollm.in`, `go.vollminlab.com`, `vl.vollminlab.com` |
@@ -265,3 +369,12 @@ This is a cluster rebuild risk event — do not attempt without working backups.
 | Kyverno category expansion | Added `media` and `ci` as valid category values |
 | Sealed Secrets | Bootstrap procedure + 1Password key backup |
 | DMZ namespace + Minecraft | Node-isolated on k8sworker05, Kyverno-enforced |
+| kube-prometheus-stack | Prometheus + Grafana + Alertmanager (→ Pushover) in `monitoring` namespace |
+| Loki + Promtail | SingleBinary Loki, MinIO-backed; Promtail DaemonSet on all nodes |
+| Control plane metrics | etcd/controller-manager/scheduler/kube-proxy bound to `0.0.0.0` and scraped by Prometheus |
+| Observability ServiceMonitors + alert rules | Longhorn, Velero, cert-manager scraped; custom `PrometheusRule` for cert expiry + Velero health (PR #395) |
+| Node-exporter hostname relabeling | `instance` label is node hostname instead of IP:port (PR #397) |
+| Exportarr | Radarr, Sonarr, Bazarr, SABnzbd exportarr exporters + Grafana dashboards (PRs #393–#394) |
+| Grafana dashboards | Arr-media consolidated, Longhorn custom sidecar (PR #419), Velero custom sidecar (PR #420) |
+| Etcd defrag CronJob | Weekly defrag job in `kube-system` (PR #413) |
+| Velero circular backup fix | `minio` namespace excluded from FSB on both schedules; node-agents healthy on all 6 nodes (PR #410) |


### PR DESCRIPTION
## Summary

- Phase 2.1 (Prometheus/Grafana) and 2.2 (Loki/Promtail) marked `done` with full deployment summaries
- Phase 2.3 OTel: `deferred` → `planned`, dependency on Phase 5 Istio
- Phase 2.5 added: Flux v2.4 → v2.8 two-hop upgrade (next project)
- Phase 3.0 PKI: `deferred` → `planned` with hard deadline 2027-04-14
- Phase 3.2 added: MetalLB L2 → BGP peering discussion (k8sworker04 UDM IP issue)
- Phase 3.3 added: Plex/Overseerr external access — documents DMZ isolation constraint and Cloudflare Tunnel as recommended path
- Phase 4.0 diagrams: Excalidraw → Mermaid (declarative, GitOps-consistent)
- Phase 6.2 Chaos Mesh: `planned` → `deferred`
- Completed section: added full observability stack, exportarr, custom dashboards, etcd defrag, Velero fix
- Removed ECK row (no longer deployed); updated Dynatrace/Dash0 note
- Fixed pre-existing markdown lint warnings throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)