### PR TITLE
fix: add provider: github to flux-system GitRepository

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/gotk-sync.yaml
+++ b/clusters/vollminlab-cluster/flux-system/gotk-sync.yaml
@@ -13,6 +13,7 @@ spec:
   interval: 1m0s
   ref:
     branch: main
+  provider: github
   secretRef:
     name: flux-system
   url: https://github.com/vollminlab/k8s-vollminlab-cluster.git


### PR DESCRIPTION
## Summary

- Adds `spec.provider: github` to the `flux-system` GitRepository in `gotk-sync.yaml`

## Root cause

`source-controller` v1.7.4 (Flux v2.7.5) added strict validation: if `secretRef` contains GitHub App credentials, the GitRepository must explicitly declare `spec.provider: github`. The previous v1.4.x (Flux v2.4.0) auto-detected the provider from secret contents.

Without this field, the source-controller refuses to authenticate and every kustomization cluster-wide fails with `Source artifact not found`.

## Recovery

Fix was applied manually to the cluster (`kubectl apply`) to immediately restore the GitRepository. This PR persists the change in git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)