### PR TITLE
fix: Velero FSB exclusions for ephemeral pods + fix Velero 12 alert rules

### DIFF
--- a/clusters/vollminlab-cluster/kube-system/smb-csi-driver/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kube-system/smb-csi-driver/app/configmap.yaml
@@ -9,4 +9,5 @@ metadata:
     category: storage
 data:
   values.yaml: |
-    {}
+    podAnnotations:
+      backup.velero.io/backup-volumes-excludes: "socket-dir"

--- a/clusters/vollminlab-cluster/metallb-system/metallb/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/metallb-system/metallb/app/configmap.yaml
@@ -22,6 +22,8 @@ data:
           memory: 128Mi
     speaker:
       enabled: true
+      podAnnotations:
+        backup.velero.io/backup-volumes-excludes: "frr-sockets,frr-conf,reloader,metrics,frr-tmp,frr-lib,frr-log"
       tolerations:
         - key: dmz
           operator: Exists

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -34,19 +34,21 @@ spec:
 
     - name: velero
       rules:
-        - alert: VeleroScheduledBackupOverdue
+        # velero_backup_last_successful_timestamp was removed in Velero 12.
+        # Schedule CRs are named velero-<schedule-name> by Helm, so the label is velero-daily-full.
+        - alert: VeleroBackupNotAttempted
           expr: |
-            time() - velero_backup_last_successful_timestamp{schedule="daily-full"} > 90000
-          for: 15m
+            increase(velero_backup_attempt_total{schedule="velero-daily-full"}[26h]) == 0
+          for: 30m
           labels:
             severity: warning
           annotations:
-            summary: "Velero minio backup last succeeded > 25 hours ago"
-            description: "The daily-full (minio) backup last succeeded at {{ $value | humanizeTimestamp }}. Check Velero logs."
+            summary: "Velero daily-full backup has not run in 26 hours"
+            description: "No daily-full backup attempt detected in the past 26 hours. Check the Velero schedule."
 
         - alert: VeleroBackupFailed
           expr: |
-            increase(velero_backup_failure_total{schedule="daily-full"}[26h]) > 0
+            increase(velero_backup_failure_total{schedule="velero-daily-full"}[26h]) > 0
           for: 15m
           labels:
             severity: warning
@@ -56,7 +58,7 @@ spec:
 
         - alert: VeleroBackupPartiallyFailed
           expr: |
-            increase(velero_backup_partial_failure_total{schedule="daily-full"}[26h]) > 0
+            increase(velero_backup_partial_failure_total{schedule="velero-daily-full"}[26h]) > 0
           for: 15m
           labels:
             severity: warning
@@ -66,10 +68,10 @@ spec:
 
         - alert: VeleroBackupMetricMissing
           expr: |
-            absent(velero_backup_last_successful_timestamp{schedule="daily-full"}) == 1
+            absent(velero_backup_last_status{schedule="velero-daily-full"}) == 1
           for: 30m
           labels:
             severity: critical
           annotations:
             summary: "Velero daily-full backup metric absent — Velero may not be running"
-            description: "velero_backup_last_successful_timestamp for schedule=daily-full is missing. Velero may be down or no backup has ever completed."
+            description: "velero_backup_last_status for schedule=velero-daily-full is missing. Velero may be down or metrics scraping has failed."


### PR DESCRIPTION
## Summary

- Add `backup.velero.io/backup-volumes-excludes` annotations to metallb-speaker and smb-csi-controller pods so Velero skips their ephemeral volumes (frr-*, socket-dir) — these pods run on control-plane nodes where no Velero node-agent is deployed, causing every backup to PartiallyFail with 4 errors
- Fix all Velero PrometheusRule alert expressions broken by the Velero 12 upgrade: `velero_backup_last_successful_timestamp` was removed; replace the overdue check with an attempt-count check using `velero_backup_attempt_total`
- Fix schedule label across all rules: Helm prefixes Schedule CR names with the release name, so the metric label is `velero-daily-full` not `daily-full` — this was silently preventing `VeleroBackupFailed` and `VeleroBackupPartiallyFailed` from ever firing
- Fix `VeleroBackupMetricMissing` to use `velero_backup_last_status` (the replacement metric in Velero 12) — this clears the critical alert that has been firing since the monitoring stack was deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)