### PR TITLE
chore: bump exportarr CPU limits to address throttling

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/exportarr/app/exportarr-deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/exportarr/app/exportarr-deployment.yaml
@@ -44,5 +44,5 @@ spec:
               cpu: 10m
               memory: 32Mi
             limits:
-              cpu: 50m
+              cpu: 150m
               memory: 64Mi

--- a/clusters/vollminlab-cluster/mediastack/sabnzbd/app/exportarr-deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sabnzbd/app/exportarr-deployment.yaml
@@ -44,5 +44,5 @@ spec:
               cpu: 10m
               memory: 32Mi
             limits:
-              cpu: 50m
+              cpu: 150m
               memory: 64Mi


### PR DESCRIPTION
## Summary

- Increase `cpu` limit from `50m` to `150m` on both `exportarr` (bazarr) and `sabnzbd-exportarr` deployments
- Requests unchanged at `10m` — pods are healthy but consistently CPU-throttled at the cap
- Memory limits unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)