### PR TITLE
fix: add control-plane toleration to Velero node-agent DaemonSet

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -86,6 +86,9 @@ data:
           operator: Equal
           value: "true"
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
## Summary

- Adds `node-role.kubernetes.io/control-plane:Exists:NoSchedule` toleration to the Velero `nodeAgent` DaemonSet
- node-agent will now schedule on all 9 nodes (6 workers + 3 control plane) instead of only the 6 workers
- Eliminates the 4 recurring `PartiallyFailed` errors on `velero-daily-full`

## Root cause

With `defaultVolumesToFsBackup: true`, Velero checks for a running node-agent on every node that has a pod to back up. `metallb-speaker` (×3) and `csi-smb-controller` run on the control plane nodes (`k8scp01/02/03`), which carry the `node-role.kubernetes.io/control-plane:NoSchedule` taint. Since the node-agent DaemonSet only tolerated the `dmz` taint, it never scheduled there — producing "daemonset pod not found in running state" for those 4 pods on every backup run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)