### PR TITLE
feat: add Plex Media Server to mediastack

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
   - minecraft-helmrepository.yaml
   - minio-helmrepository.yaml
   - overseerr-ocirepository.yaml
+  - plex-ocirepository.yaml
   - portainer-helmrepository.yaml
   - prometheus-community-helmrepository.yaml
   - prowlarr-ocirepository.yaml

--- a/clusters/vollminlab-cluster/flux-system/repositories/plex-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/plex-ocirepository.yaml
@@ -1,0 +1,14 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: plex-repo
+  namespace: flux-system
+  labels:
+    app: plex
+    env: production
+    category: media
+spec:
+  url: oci://oci.trueforge.org/truecharts/plex
+  interval: 5m
+  ref:
+    tag: 22.1.2

--- a/clusters/vollminlab-cluster/mediastack/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ./bazarr/app
   - ./exportarr/app
   - ./overseerr/app
+  - ./plex/app
   - ./prowlarr/app
   - ./radarr/app
   - ./sabnzbd/app

--- a/clusters/vollminlab-cluster/mediastack/plex/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/plex/app/configmap.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: plex-values
+  namespace: mediastack
+  labels:
+    app: plex
+    env: production
+    category: media
+data:
+  values.yaml: |
+    env:
+      ALLOWED_NETWORKS: "172.16.0.0/12,10.0.0.0/8,192.168.0.0/16"
+    persistence:
+      config:
+        enabled: true
+        existingClaim: pvc-plex-config
+        mountPath: /config
+      movies:
+        enabled: true
+        existingClaim: pvc-movies
+        mountPath: /movies
+      tv:
+        enabled: true
+        existingClaim: pvc-tv
+        mountPath: /tv
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+      limits:
+        cpu: 2000m
+        memory: 2Gi
+    podLabels:
+      app: plex
+      env: production
+      category: media
+    securityContext:
+      runAsUser: 568
+      runAsGroup: 568
+    podSecurityContext:
+      fsGroup: 568
+      fsGroupChangePolicy: "OnRootMismatch"

--- a/clusters/vollminlab-cluster/mediastack/plex/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/mediastack/plex/app/helmrelease.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: plex
+  namespace: mediastack
+  labels:
+    app: plex
+    env: production
+    category: media
+spec:
+  interval: 5m
+  chartRef:
+    kind: OCIRepository
+    name: plex-repo
+    namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: plex-values
+      valuesKey: values.yaml

--- a/clusters/vollminlab-cluster/mediastack/plex/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/plex/app/ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: plex-ingress
+  namespace: mediastack
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    shlink.vollminlab.com/slug: plex
+  labels:
+    app: plex
+    env: production
+    category: media
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: plex.vollminlab.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: plex
+                port:
+                  number: 32400
+  tls:
+    - hosts:
+        - plex.vollminlab.com
+      secretName: wildcard-tls

--- a/clusters/vollminlab-cluster/mediastack/plex/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/plex/app/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: plex-app
+resources:
+  - configmap.yaml
+  - helmrelease.yaml
+  - ingress.yaml
+  - pvc-plex-config.yaml

--- a/clusters/vollminlab-cluster/mediastack/plex/app/pvc-plex-config.yaml
+++ b/clusters/vollminlab-cluster/mediastack/plex/app/pvc-plex-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-plex-config
+  namespace: mediastack
+  labels:
+    app: plex
+    env: production
+    category: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/docs/cluster-reference.md
+++ b/docs/cluster-reference.md
@@ -390,6 +390,7 @@ All ingresses use `ingressClassName: nginx`, TLS termination via `wildcard-tls`,
 | `prowlarr.vollminlab.com` | prowlarr | 9696 | mediastack | wildcard-tls |
 | `bazarr.vollminlab.com` | bazarr | 6767 | mediastack | wildcard-tls |
 | `overseerr.vollminlab.com` | overseerr | 5055 | mediastack | wildcard-tls |
+| `plex.vollminlab.com` | plex | 32400 | mediastack | wildcard-tls |
 | `tautulli.vollminlab.com` | tautulli | 8181 | mediastack | wildcard-tls |
 | `go.vollminlab.com` | shlink-shlink-backend | 8080 | shlink | wildcard-tls |
 | `vl.vollminlab.com` | shlink-shlink-backend | 8080 | shlink | wildcard-tls |
@@ -446,6 +447,7 @@ All ingresses use `ingressClassName: nginx`, TLS termination via `wildcard-tls`,
 | `pvc-prowlarr-config` | mediastack | 5Gi | longhorn | RWO |
 | `pvc-bazarr-config` | mediastack | 5Gi | longhorn | RWO |
 | `pvc-overseerr-config` | mediastack | 5Gi | longhorn | RWO |
+| `pvc-plex-config` | mediastack | 20Gi | longhorn | RWO |
 | `pvc-tautulli-config` | mediastack | 1Gi | longhorn | RWO |
 | `pvc-minecraft-datadir` | dmz | 20Gi | longhorn-dmz | RWX |
 | `portainer` | portainer | 10Gi | local-path | RWO |
@@ -746,6 +748,19 @@ All apps in the `mediastack` namespace. Shared SMB storage mounted at the namesp
 | Ingress | `overseerr.vollminlab.com` |
 | Port | 5055 |
 | Config PVC | 5Gi Longhorn RWO |
+
+### Plex (Media server)
+
+| Parameter | Value |
+|---|---|
+| Chart | TrueCharts plex 22.1.2 (OCIRepository) |
+| Ingress | `plex.vollminlab.com` |
+| Port | 32400 |
+| Config PVC | 20Gi Longhorn RWO |
+| Volumes | pvc-movies (RWX), pvc-tv (RWX) |
+| Allowed networks | `172.16.0.0/12, 10.0.0.0/8, 192.168.0.0/16` |
+| External access | Cloudflare Tunnel via cloudflared (see Infrastructure Services) |
+| Notes | Claim server via web UI on first launch from same-LAN browser |
 
 ### Tautulli (Plex monitoring)
 


### PR DESCRIPTION
## Summary

- Deploys Plex Media Server in the `mediastack` namespace via TrueCharts OCIRepository (`plex` chart v22.1.2)
- Mounts existing `pvc-movies` and `pvc-tv` SMB shares — no new NAS config needed
- 20Gi Longhorn PVC for Plex config/metadata (`pvc-plex-config`)
- ClusterIP service + ingress-nginx on `plex.vollminlab.com`, same pattern as all other mediastack apps
- `ALLOWED_NETWORKS` set to cover all internal RFC1918 ranges for local direct play

## Post-merge steps

1. **Claim the server**: navigate to `https://plex.vollminlab.com` from a browser on the local network. Plex will show the setup wizard — sign in with your plex.tv account to claim it.
2. **Add libraries**: add Movies (`/movies`) and TV (`/tv`) library paths. Initial scan runs in the background while TrueNAS Plex continues serving.
3. **Set custom access URL**: in Plex Settings → Remote Access → Advanced, set the custom server access URL to `https://plex.vollminlab.com` (Cloudflare Tunnel URL, added in follow-up PR).
4. **Pi-hole DNS**: `plex.vollminlab.com` should already resolve to `192.168.152.244` (ingress VIP) — verify both Pi-hole instances.
5. Once the cluster Plex is verified, stop Plex on TrueNAS.

> The Cloudflare Tunnel for external access is a separate follow-up PR (`feat/cloudflared-tunnel`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)