### PR TITLE
fix: downgrade plex chart to 22.0.6 for Kubernetes 1.32.x compatibility

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/plex-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/plex-ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
   url: oci://oci.trueforge.org/truecharts/plex
   interval: 5m
   ref:
-    tag: 22.1.2
+    tag: 22.0.6


### PR DESCRIPTION
## Summary

- `22.1.2` requires `kubeVersion: >=1.33.0-0`; cluster is on `1.32.3`
- Downgrade OCIRepository tag to `22.0.6`, the last version with `>=1.27.0-0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)