### PR TITLE
fix: disable Grafana 13 kubernetesDashboards feature toggle, bump memory

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -54,13 +54,16 @@ data:
         app: grafana
         env: production
         category: observability
+      grafana.ini:
+        feature_toggles:
+          kubernetesDashboards: false
       resources:
         requests:
           cpu: 100m
-          memory: 128Mi
+          memory: 256Mi
         limits:
           cpu: 500m
-          memory: 256Mi
+          memory: 512Mi
       plugins:
         - grafana-lokiexplore-app
 


### PR DESCRIPTION
## Summary

- Grafana 13 (landed via Renovate) enables `kubernetesDashboards` by default, which starts an embedded Kubernetes-style API server for dashboard storage
- That apiserver deadlocks making internal HTTPS calls to itself (`context deadline exceeded` on `/apis/dashboard.grafana.app/*`), causing the grafana container to stay not-Ready (2/3)
- Fix: disable the feature toggle via `grafana.ini` — restores file-based dashboard provisioning through the existing sc-dashboard sidecar
- Memory bumped 128→256Mi request, 256→512Mi limit to cover Grafana 13's higher baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)