### PR TITLE
fix: filter deprecated CRDs from Kyverno report scans

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
@@ -129,6 +129,11 @@ data:
           memory: 256Mi
 
     reportsController:
+      featuresOverride:
+        backgroundScan:
+          # Let the reports controller honor config.resourceFilters so it does
+          # not list deprecated served CRD versions during background scans.
+          skipResourceFilters: false
       labels:
         app: kyverno-reports-controller
         env: production
@@ -162,6 +167,12 @@ data:
         - '[StagedNetworkPolicy,*,*]'
         - '[StagedKubernetesNetworkPolicy,*,*]'
         - '[GlobalNetworkSet,*,*]'
+        - '[Alert,*,*]'
+        - '[CleanupPolicy,*,*]'
+        - '[GlobalContextEntry,*,*]'
+        - '[ImageValidatingPolicy,*,*]'
+        - '[PolicyException,*,*]'
+        - '[ValidatingPolicy,*,*]'
 
     serviceMonitor:
       enabled: true


### PR DESCRIPTION
## Summary
- make the Kyverno reports controller honor resource filters during background scans
- filter noisy deprecated CRD kinds from report scans, including Kyverno policy CRDs and Flux Alert

## Validation
- kubectl kustomize clusters/vollminlab-cluster/kyverno/kyverno/app
- commit hook: Check flux helm values