### PR TITLE
fix: filter third-party and built-in CRDs from Kyverno reports controller scans

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
@@ -160,6 +160,7 @@ data:
 
     config:
       resourceFilters:
+        # Calico / Tigera CRDs — reports controller SA has no RBAC for these
         - '[GlobalNetworkPolicy,*,*]'
         - '[NetworkPolicy,*,*]'
         - '[Tier,*,*]'
@@ -167,12 +168,64 @@ data:
         - '[StagedNetworkPolicy,*,*]'
         - '[StagedKubernetesNetworkPolicy,*,*]'
         - '[GlobalNetworkSet,*,*]'
+        - '[BGPPeer,*,*]'
+        - '[BlockAffinity,*,*]'
+        - '[ClusterInformation,*,*]'
+        - '[FelixConfiguration,*,*]'
+        - '[HostEndpoint,*,*]'
+        - '[IPAMHandle,*,*]'
+        - '[IPPool,*,*]'
+        - '[IPReservation,*,*]'
+        - '[KubeControllersConfiguration,*,*]'
+        - '[Installation,*,*]'
+        - '[TigeraStatus,*,*]'
+        # Deprecated Kyverno / Flux CRDs — removed in newer API versions
         - '[Alert,*,*]'
         - '[CleanupPolicy,*,*]'
         - '[GlobalContextEntry,*,*]'
         - '[ImageValidatingPolicy,*,*]'
         - '[PolicyException,*,*]'
         - '[ValidatingPolicy,*,*]'
+        - '[DeletingPolicy,*,*]'
+        # Longhorn internal CRDs — no policies target these
+        - '[BackupBackingImage,*,*]'
+        - '[Backup,*,*]'
+        - '[EngineImage,*,*]'
+        - '[Orphan,*,*]'
+        - '[Setting,*,*]'
+        - '[ShareManager,*,*]'
+        - '[Snapshot,*,*]'
+        - '[SupportBundle,*,*]'
+        # MetalLB CRDs — no policies target these
+        - '[BFDProfile,*,*]'
+        - '[L2Advertisement,*,*]'
+        # Prometheus Operator / Grafana Agent CRDs — no policies target these
+        - '[Alertmanager,*,*]'
+        - '[AlertmanagerConfig,*,*]'
+        - '[ServiceMonitor,*,*]'
+        - '[ThanosRuler,*,*]'
+        - '[GrafanaAgent,*,*]'
+        - '[MetricsInstance,*,*]'
+        # CNPG CRDs — no policies target these
+        - '[Database,*,*]'
+        - '[ImageCatalog,*,*]'
+        - '[Subscription,*,*]'
+        # Velero CRDs — no policies target these
+        - '[PodVolumeBackup,*,*]'
+        # Elastic / ECK CRDs — no policies target these
+        - '[AutoOpsAgentPolicy,*,*]'
+        - '[ElasticsearchAutoscaler,*,*]'
+        - '[EnterpriseSearch,*,*]'
+        # Kubernetes built-ins with no applicable policies
+        - '[Secret,*,*]'
+        - '[PodTemplate,*,*]'
+        - '[ClusterRoleBinding,*,*]'
+        - '[StorageClass,*,*]'
+        - '[CSIStorageCapacity,*,*]'
+        - '[CustomResourceDefinition,*,*]'
+        - '[PriorityClass,*,*]'
+        - '[RuntimeClass,*,*]'
+        - '[Lease,*,*]'
 
     serviceMonitor:
       enabled: true


### PR DESCRIPTION
## Summary

- Extends `config.resourceFilters` with all CRD kinds the reports controller SA lacks RBAC for (Longhorn, MetalLB, Calico/Tigera, Prometheus Operator, Grafana Agent, CNPG, Velero, ECK, and Kubernetes built-ins like `Secret`, `Lease`, `CustomResourceDefinition`)
- Eliminates the `forbidden: cannot list resource` errors logged on every background scan cycle
- Follows the same pattern established in PR #444 — filter out resources with no applicable policies rather than granting unnecessary RBAC

🤖 Generated with [Claude Code](https://claude.com/claude-code)