### PR TITLE
fix: clean up arr media dashboard panel layouts

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/arr-media-dashboard-configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/arr-media-dashboard-configmap.yaml
@@ -2961,58 +2961,11 @@ data:
                   },
                   "unit": "none"
                 },
-                "overrides": [
-                  {
-                    "matcher": {
-                      "id": "byName",
-                      "options": "Disk Free"
-                    },
-                    "properties": [
-                      {
-                        "id": "unit",
-                        "value": "bytes"
-                      },
-                      {
-                        "id": "thresholds",
-                        "value": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "red"
-                            },
-                            {
-                              "color": "#EAB839",
-                              "value": 500000000
-                            },
-                            {
-                              "color": "green",
-                              "value": 5000000000
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "id": "color"
-                      }
-                    ]
-                  },
-                  {
-                    "matcher": {
-                      "id": "byName",
-                      "options": "Disk Used"
-                    },
-                    "properties": [
-                      {
-                        "id": "unit",
-                        "value": "bytes"
-                      }
-                    ]
-                  }
-                ]
+                "overrides": []
               },
               "gridPos": {
                 "h": 4,
-                "w": 12,
+                "w": 6,
                 "x": 12,
                 "y": 3
               },
@@ -3074,7 +3027,106 @@ data:
                   "legendFormat": "History",
                   "range": false,
                   "refId": "C"
+                }
+              ],
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "continuous-BlPu"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
                 },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Disk Free"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red"
+                            },
+                            {
+                              "color": "#EAB839",
+                              "value": 500000000
+                            },
+                            {
+                              "color": "green",
+                              "value": 5000000000
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "color"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Disk Used"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 6,
+                "x": 18,
+                "y": 3
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+              },
+              "pluginVersion": "9.5.2",
+              "targets": [
                 {
                   "datasource": {
                     "type": "prometheus",
@@ -3104,7 +3156,8 @@ data:
                   "refId": "A"
                 }
               ],
-              "type": "stat"
+              "type": "stat",
+              "title": "Disk"
             },
             {
               "datasource": {
@@ -3569,7 +3622,7 @@ data:
               },
               "gridPos": {
                 "h": 4,
-                "w": 3,
+                "w": 4,
                 "x": 0,
                 "y": 5
               },
@@ -3659,8 +3712,8 @@ data:
               },
               "gridPos": {
                 "h": 4,
-                "w": 3,
-                "x": 3,
+                "w": 4,
+                "x": 4,
                 "y": 5
               },
               "options": {
@@ -3720,8 +3773,8 @@ data:
               },
               "gridPos": {
                 "h": 4,
-                "w": 6,
-                "x": 6,
+                "w": 4,
+                "x": 8,
                 "y": 5
               },
               "options": {
@@ -6170,11 +6223,39 @@ data:
                     ]
                   }
                 },
-                "overrides": []
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Health Issues"
+                    },
+                    "properties": [
+                      {
+                        "id": "mappings",
+                        "value": []
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green"
+                            },
+                            {
+                              "color": "red",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
               },
               "gridPos": {
                 "h": 4,
-                "w": 3,
+                "w": 6,
                 "x": 0,
                 "y": 2
               },
@@ -6207,62 +6288,7 @@ data:
                   "legendFormat": "Status",
                   "range": false,
                   "refId": "A"
-                }
-              ],
-              "title": "Status",
-              "type": "stat"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "thresholds"
-                  },
-                  "mappings": [],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      },
-                      {
-                        "color": "red",
-                        "value": 1
-                      }
-                    ]
-                  }
                 },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 4,
-                "w": 3,
-                "x": 3,
-                "y": 2
-              },
-              "options": {
-                "colorMode": "background",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "fields": "",
-                  "values": false
-                },
-                "text": {
-                  "valueSize": 60
-                },
-                "textMode": "auto"
-              },
-              "pluginVersion": "9.5.2",
-              "targets": [
                 {
                   "datasource": {
                     "type": "prometheus",
@@ -6277,7 +6303,7 @@ data:
                   "refId": "A"
                 }
               ],
-              "title": "Health Issues",
+              "title": "Status",
               "type": "stat"
             },
             {


### PR DESCRIPTION
## Summary

- **Radarr**: the summary stat row had a massive `w=12` panel cramming 5 unrelated metrics (queue, history, downloaded, disk used, disk free) into one cell — split into `w=6` activity panel + `w=6` disk panel, giving a clean `3+3+6+6+6` row
- **Sonarr**: stat widths were uneven (`3,3,6,4,4,4`) — normalised to uniform `w=4` across all 6 panels
- **Bazarr**: TV row (`3+3+6+6+6`) and movies row (`6+6+6+6`) were misaligned in the first column — merged Status + Health Issues into one `w=6` panel so both rows are `6+6+6+6` and align perfectly; Health Issues retains correct threshold colouring via a per-field override (`0`=green, `≥1`=red)

🤖 Generated with [Claude Code](https://claude.com/claude-code)