### PR TITLE
fix: normalise arr media dashboard collapsed row y-offsets

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/arr-media-dashboard-configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/arr-media-dashboard-configmap.yaml
@@ -2705,7 +2705,7 @@ data:
                 "h": 4,
                 "w": 3,
                 "x": 0,
-                "y": 3
+                "y": 32
               },
               "options": {
                 "colorMode": "background",
@@ -2795,7 +2795,7 @@ data:
                 "h": 4,
                 "w": 3,
                 "x": 3,
-                "y": 3
+                "y": 32
               },
               "options": {
                 "colorMode": "background",
@@ -2873,7 +2873,7 @@ data:
                 "h": 4,
                 "w": 6,
                 "x": 6,
-                "y": 3
+                "y": 32
               },
               "options": {
                 "colorMode": "value",
@@ -2967,7 +2967,7 @@ data:
                 "h": 4,
                 "w": 6,
                 "x": 12,
-                "y": 3
+                "y": 32
               },
               "options": {
                 "colorMode": "value",
@@ -3108,7 +3108,7 @@ data:
                 "h": 4,
                 "w": 6,
                 "x": 18,
-                "y": 3
+                "y": 32
               },
               "options": {
                 "colorMode": "value",
@@ -3188,7 +3188,7 @@ data:
                 "h": 10,
                 "w": 24,
                 "x": 0,
-                "y": 7
+                "y": 36
               },
               "options": {
                 "displayMode": "lcd",
@@ -3287,7 +3287,7 @@ data:
                 "h": 9,
                 "w": 8,
                 "x": 0,
-                "y": 17
+                "y": 46
               },
               "options": {
                 "legend": {
@@ -3389,7 +3389,7 @@ data:
                 "h": 9,
                 "w": 8,
                 "x": 8,
-                "y": 17
+                "y": 46
               },
               "options": {
                 "legend": {
@@ -3480,7 +3480,7 @@ data:
                 "h": 9,
                 "w": 8,
                 "x": 16,
-                "y": 17
+                "y": 46
               },
               "options": {
                 "cellHeight": "sm",
@@ -3624,7 +3624,7 @@ data:
                 "h": 4,
                 "w": 4,
                 "x": 0,
-                "y": 5
+                "y": 33
               },
               "options": {
                 "colorMode": "background",
@@ -3714,7 +3714,7 @@ data:
                 "h": 4,
                 "w": 4,
                 "x": 4,
-                "y": 5
+                "y": 33
               },
               "options": {
                 "colorMode": "background",
@@ -3775,7 +3775,7 @@ data:
                 "h": 4,
                 "w": 4,
                 "x": 8,
-                "y": 5
+                "y": 33
               },
               "options": {
                 "colorMode": "value",
@@ -3867,7 +3867,7 @@ data:
                 "h": 4,
                 "w": 4,
                 "x": 12,
-                "y": 5
+                "y": 33
               },
               "options": {
                 "colorMode": "value",
@@ -3939,7 +3939,7 @@ data:
                 "h": 4,
                 "w": 4,
                 "x": 16,
-                "y": 5
+                "y": 33
               },
               "options": {
                 "colorMode": "value",
@@ -4015,7 +4015,7 @@ data:
                 "h": 4,
                 "w": 4,
                 "x": 20,
-                "y": 5
+                "y": 33
               },
               "options": {
                 "colorMode": "value",
@@ -4090,7 +4090,7 @@ data:
                 "h": 10,
                 "w": 24,
                 "x": 0,
-                "y": 9
+                "y": 37
               },
               "options": {
                 "displayMode": "lcd",
@@ -4202,7 +4202,7 @@ data:
                 "h": 9,
                 "w": 8,
                 "x": 0,
-                "y": 19
+                "y": 47
               },
               "options": {
                 "legend": {
@@ -4304,7 +4304,7 @@ data:
                 "h": 9,
                 "w": 8,
                 "x": 8,
-                "y": 19
+                "y": 47
               },
               "options": {
                 "legend": {
@@ -4397,7 +4397,7 @@ data:
                 "h": 9,
                 "w": 8,
                 "x": 16,
-                "y": 19
+                "y": 47
               },
               "options": {
                 "cellHeight": "sm",
@@ -4541,7 +4541,7 @@ data:
                 "h": 4,
                 "w": 3,
                 "x": 0,
-                "y": 7
+                "y": 34
               },
               "options": {
                 "colorMode": "background",
@@ -4631,7 +4631,7 @@ data:
                 "h": 4,
                 "w": 3,
                 "x": 3,
-                "y": 7
+                "y": 34
               },
               "options": {
                 "colorMode": "background",
@@ -4730,7 +4730,7 @@ data:
                 "h": 4,
                 "w": 8,
                 "x": 6,
-                "y": 7
+                "y": 34
               },
               "options": {
                 "colorMode": "value",
@@ -4839,7 +4839,7 @@ data:
                 "h": 4,
                 "w": 4,
                 "x": 14,
-                "y": 7
+                "y": 34
               },
               "options": {
                 "colorMode": "value",
@@ -4916,7 +4916,7 @@ data:
                 "h": 4,
                 "w": 6,
                 "x": 18,
-                "y": 7
+                "y": 34
               },
               "options": {
                 "colorMode": "value",
@@ -5004,7 +5004,7 @@ data:
                 "h": 10,
                 "w": 24,
                 "x": 0,
-                "y": 11
+                "y": 38
               },
               "options": {
                 "displayMode": "lcd",
@@ -5102,7 +5102,7 @@ data:
                 "h": 9,
                 "w": 8,
                 "x": 0,
-                "y": 21
+                "y": 48
               },
               "options": {
                 "legend": {
@@ -5205,7 +5205,7 @@ data:
                 "h": 9,
                 "w": 8,
                 "x": 8,
-                "y": 21
+                "y": 48
               },
               "options": {
                 "legend": {
@@ -5296,7 +5296,7 @@ data:
                 "h": 9,
                 "w": 8,
                 "x": 16,
-                "y": 21
+                "y": 48
               },
               "options": {
                 "cellHeight": "sm",
@@ -5441,7 +5441,7 @@ data:
                 "h": 4,
                 "w": 3,
                 "x": 0,
-                "y": 8
+                "y": 35
               },
               "options": {
                 "colorMode": "background",
@@ -5531,7 +5531,7 @@ data:
                 "h": 4,
                 "w": 3,
                 "x": 3,
-                "y": 8
+                "y": 35
               },
               "options": {
                 "colorMode": "background",
@@ -5609,7 +5609,7 @@ data:
                 "h": 4,
                 "w": 6,
                 "x": 6,
-                "y": 8
+                "y": 35
               },
               "options": {
                 "colorMode": "value",
@@ -5746,7 +5746,7 @@ data:
                 "h": 4,
                 "w": 12,
                 "x": 12,
-                "y": 8
+                "y": 35
               },
               "options": {
                 "colorMode": "value",
@@ -5891,7 +5891,7 @@ data:
                 "h": 9,
                 "w": 8,
                 "x": 0,
-                "y": 12
+                "y": 39
               },
               "options": {
                 "legend": {
@@ -5993,7 +5993,7 @@ data:
                 "h": 9,
                 "w": 8,
                 "x": 8,
-                "y": 12
+                "y": 39
               },
               "options": {
                 "legend": {
@@ -6084,7 +6084,7 @@ data:
                 "h": 9,
                 "w": 8,
                 "x": 16,
-                "y": 12
+                "y": 39
               },
               "options": {
                 "cellHeight": "sm",
@@ -6257,7 +6257,7 @@ data:
                 "h": 4,
                 "w": 6,
                 "x": 0,
-                "y": 2
+                "y": 36
               },
               "options": {
                 "colorMode": "background",
@@ -6332,7 +6332,7 @@ data:
                 "h": 4,
                 "w": 6,
                 "x": 6,
-                "y": 2
+                "y": 36
               },
               "options": {
                 "colorMode": "value",
@@ -6400,7 +6400,7 @@ data:
                 "h": 4,
                 "w": 6,
                 "x": 12,
-                "y": 2
+                "y": 36
               },
               "options": {
                 "colorMode": "background",
@@ -6465,7 +6465,7 @@ data:
                 "h": 4,
                 "w": 6,
                 "x": 18,
-                "y": 2
+                "y": 36
               },
               "options": {
                 "colorMode": "value",
@@ -6529,7 +6529,7 @@ data:
                 "h": 4,
                 "w": 6,
                 "x": 0,
-                "y": 6
+                "y": 40
               },
               "options": {
                 "colorMode": "value",
@@ -6593,7 +6593,7 @@ data:
                 "h": 4,
                 "w": 6,
                 "x": 6,
-                "y": 6
+                "y": 40
               },
               "options": {
                 "colorMode": "value",
@@ -6661,7 +6661,7 @@ data:
                 "h": 4,
                 "w": 6,
                 "x": 12,
-                "y": 6
+                "y": 40
               },
               "options": {
                 "colorMode": "background",
@@ -6726,7 +6726,7 @@ data:
                 "h": 4,
                 "w": 6,
                 "x": 18,
-                "y": 6
+                "y": 40
               },
               "options": {
                 "colorMode": "value",
@@ -6794,7 +6794,7 @@ data:
                 "h": 8,
                 "w": 24,
                 "x": 0,
-                "y": 10
+                "y": 44
               },
               "options": {
                 "displayMode": "lcd",


### PR DESCRIPTION
## Summary

- All collapsed rows (Radarr, Sonarr, Lidarr, Readarr, Bazarr) had stale inner-panel `y` coordinates from when the dashboard was first built, before SABnzbd was added above them
- Grafana treats stored `y` as absolute coordinates — panels were rendering in the Prowlarr area rather than inside their own section, causing the scattered/overlapping layout
- SABnzbd was already correct (inner `min_y == row_y + 1`); the other 5 rows needed offsets of +27 to +34

This is the root cause of the broken Radarr/Sonarr/Bazarr layouts reported after PR #447. The panel width/layout changes in #447 are still included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)