### PR TITLE
fix: add ClusterCleanupPolicy to Kyverno resourceFilters

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
@@ -182,6 +182,7 @@ data:
         # Deprecated Kyverno / Flux CRDs — removed in newer API versions
         - '[Alert,*,*]'
         - '[CleanupPolicy,*,*]'
+        - '[ClusterCleanupPolicy,*,*]'
         - '[GlobalContextEntry,*,*]'
         - '[ImageValidatingPolicy,*,*]'
         - '[PolicyException,*,*]'


### PR DESCRIPTION
## Summary

- Add `[ClusterCleanupPolicy,*,*]` to `config.resourceFilters` in the Kyverno Helm values

The namespaced `CleanupPolicy` was already filtered but the cluster-scoped `ClusterCleanupPolicy` was missing, causing Kyverno's background/reports controllers to enumerate it using the deprecated `kyverno.io/v2beta1` API and log deprecation warnings.

**Not addressed here:** The remaining three warnings (`v1beta2 Alert`, `v1alpha1 ImageValidatingPolicy`, `v1alpha1 ValidatingPolicy`) are from those kinds already being in `resourceFilters`. They originate from Kyverno's internal component code using deprecated API versions — not from the reports controller scan — and require a Kyverno version upgrade to silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)