### PR TITLE
security: restrict ARC runner pod egress via NetworkPolicy

### DIFF
--- a/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - configmap.yaml
   - rbac.yaml
   - arc-githubapp-secret-sealedsecret.yaml
+  - networkpolicy.yaml

--- a/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/networkpolicy.yaml
@@ -1,0 +1,46 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: arc-runners-egress
+  namespace: actions-runner-system
+  labels:
+    app: arc-runners
+    env: production
+    category: ci
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress:
+    # DNS via kube-dns
+    - to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Kubernetes API server (in-cluster service endpoint)
+    - to:
+        - ipBlock:
+            cidr: 10.96.0.1/32
+      ports:
+        - port: 443
+          protocol: TCP
+    # Public internet — GitHub, OCI registries, apt mirrors, etc.
+    # All RFC 1918 ranges blocked to prevent accessing internal cluster services.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - port: 443
+          protocol: TCP
+        - port: 80
+          protocol: TCP


### PR DESCRIPTION
## Summary

- Adds a `NetworkPolicy` to the `actions-runner-system` namespace restricting all runner pod traffic
- Denies all ingress (runners only make outbound connections)
- Allows egress only to:
  - kube-dns (`10.96.0.10:53`) for DNS
  - Kubernetes API (`10.96.0.1:443`) for in-cluster `kubectl` used by CI jobs
  - Public internet on 80/443 — GitHub Actions service, OCI registries, apt mirrors
- Blocks all RFC 1918 ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`), preventing a fork PR from pivoting to internal cluster services, Longhorn, MinIO, or node ports

## Context

The runner scale set is used by public repos in the vollminlab org. While the org-level fork PR approval setting (configured separately in GitHub) gates *who can trigger* a run, this NetworkPolicy limits *what damage* a run that slips through could do at the network level.

The `dind` container's Docker socket (`tcp://localhost:2375`) is pod-internal loopback traffic — NetworkPolicy doesn't apply to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)