### PR TITLE
fix: remove ingress restriction from runner NetworkPolicy

### DIFF
--- a/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/networkpolicy.yaml
@@ -10,9 +10,7 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
-    - Ingress
     - Egress
-  ingress: []
   egress:
     # DNS via kube-dns
     - to:


### PR DESCRIPTION
## Summary

Fixes CI being stuck in queued state after PR #451.

Denying all ingress was blocking DNS responses. CoreDNS pods send responses from their pod IPs (`172.18.x.x`) before SNAT, which hit the ingress deny and caused `EAI_AGAIN` failures in the runner — preventing it from resolving GitHub domains and picking up jobs.

The egress restriction is the meaningful security control (prevents runners from reaching internal cluster services). Ingress restriction wasn't adding anything useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)