### PR TITLE
security: restrict ARC runner pod egress via NetworkPolicy (v2)

### DIFF
--- a/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - configmap.yaml
   - rbac.yaml
   - arc-githubapp-secret-sealedsecret.yaml
+  - networkpolicy.yaml

--- a/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/networkpolicy.yaml
@@ -1,0 +1,56 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: arc-runners-egress
+  namespace: actions-runner-system
+  labels:
+    app: arc-runners
+    env: production
+    category: ci
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    # DNS — target CoreDNS pods directly so the rule matches post-DNAT destinations.
+    # ipBlock on the kube-dns service VIP (10.96.0.10) does not work: Calico evaluates
+    # egress rules after kube-proxy rewrites the destination to the actual CoreDNS pod IP.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Kubernetes API server — use actual control plane node IPs on 6443.
+    # In-cluster kubectl targets the kubernetes service VIP (10.96.0.1:443) which
+    # kube-proxy DNATs to these node IPs. ipBlock on the real endpoints works.
+    - to:
+        - ipBlock:
+            cidr: 192.168.152.8/32
+        - ipBlock:
+            cidr: 192.168.152.9/32
+        - ipBlock:
+            cidr: 192.168.152.10/32
+      ports:
+        - port: 6443
+          protocol: TCP
+    # Public internet — GitHub, OCI registries, apt mirrors, etc.
+    # All RFC 1918 ranges blocked to prevent accessing internal cluster services.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - port: 443
+          protocol: TCP
+        - port: 80
+          protocol: TCP


### PR DESCRIPTION
## Summary

- Restricts egress from runner pods to DNS, the Kubernetes API, and public internet only
- All RFC 1918 ranges blocked — runners cannot reach internal cluster services, Longhorn, MinIO, node ports, or the home network

## What changed from the first attempt (PR #451)

The original PR used `ipBlock` for the kube-dns service VIP (`10.96.0.10`) and the Kubernetes API service VIP (`10.96.0.1`). Both broke because **Calico evaluates NetworkPolicy egress rules after kube-proxy performs DNAT** — by the time the rule is checked, the destination has already been rewritten to the actual pod/node IP, so the `ipBlock` rules never matched and DNS timed out.

Fixes:
- **DNS**: uses `namespaceSelector + podSelector` targeting CoreDNS pods (`k8s-app: kube-dns` in `kube-system`) — Calico resolves this to actual pod IPs, which match the post-DNAT destination
- **K8s API**: uses `ipBlock` on the actual control plane node IPs (`192.168.152.8-10:6443`) — no service VIP DNAT involved at that layer

## Verified before opening PR

Applied directly to the cluster and confirmed:
- DNS resolves through the policy ✓
- `github.com` reachable on 443 ✓
- Internal pod IPs (`172.18.x.x`) blocked ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)