### PR TITLE
feat: deploy Jellyfin alongside Plex in mediastack

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/jellyfin-helmrepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/jellyfin-helmrepository.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: jellyfin-repo
+  namespace: flux-system
+  labels:
+    app: jellyfin
+    env: production
+    category: media
+spec:
+  url: https://jellyfin.github.io/jellyfin-helm/
+  interval: 5m

--- a/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - headlamp-helmrepository.yaml
   - homepage-helmrepository.yaml
   - ingress-nginx-helmrepository.yaml
+  - jellyfin-helmrepository.yaml
   - kyverno-helmrepository.yaml
   - kyverno-policyreporter-helmrepository.yaml
   - local-path-provisioner-gitrepository.yaml

--- a/clusters/vollminlab-cluster/mediastack/cloudflared-jellyfin/app/cloudflared-jellyfin-tunnel-sealedsecret.yaml
+++ b/clusters/vollminlab-cluster/mediastack/cloudflared-jellyfin/app/cloudflared-jellyfin-tunnel-sealedsecret.yaml
@@ -1,0 +1,39 @@
+# PLACEHOLDER — replace this file with the real sealed secret before merging.
+#
+# Steps:
+#   1. Create a Cloudflare tunnel named "jellyfin" in Zero Trust → Networks → Tunnels
+#   2. Copy the tunnel token
+#   3. Run:
+#        kubeseal --fetch-cert \
+#          --controller-namespace sealed-secrets \
+#          --controller-name sealed-secrets-controller > pub-cert.pem
+#        kubectl create secret generic cloudflared-jellyfin-tunnel-credentials \
+#          -n mediastack --from-literal=tunnel-token=<TOKEN> \
+#          --dry-run=client -o yaml | \
+#          kubeseal --cert pub-cert.pem --format yaml \
+#          > clusters/vollminlab-cluster/mediastack/cloudflared-jellyfin/app/cloudflared-jellyfin-tunnel-sealedsecret.yaml
+#        rm pub-cert.pem
+#   4. Commit and push — Flux will reconcile the Deployment once the Secret is available
+#
+# Until this file is replaced, the cloudflared-jellyfin Deployment will not start pods
+# (the Secret will not be created because decryption will fail).
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: cloudflared-jellyfin-tunnel-credentials
+  namespace: mediastack
+  labels:
+    app: cloudflared-jellyfin
+    env: production
+    category: networking
+spec:
+  encryptedData:
+    tunnel-token: PLACEHOLDER_REPLACE_WITH_REAL_SEALED_TOKEN
+  template:
+    metadata:
+      name: cloudflared-jellyfin-tunnel-credentials
+      namespace: mediastack
+      labels:
+        app: cloudflared-jellyfin
+        env: production
+        category: networking

--- a/clusters/vollminlab-cluster/mediastack/cloudflared-jellyfin/app/cloudflared-jellyfin-tunnel-sealedsecret.yaml
+++ b/clusters/vollminlab-cluster/mediastack/cloudflared-jellyfin/app/cloudflared-jellyfin-tunnel-sealedsecret.yaml
@@ -1,22 +1,4 @@
-# PLACEHOLDER — replace this file with the real sealed secret before merging.
-#
-# Steps:
-#   1. Create a Cloudflare tunnel named "jellyfin" in Zero Trust → Networks → Tunnels
-#   2. Copy the tunnel token
-#   3. Run:
-#        kubeseal --fetch-cert \
-#          --controller-namespace sealed-secrets \
-#          --controller-name sealed-secrets-controller > pub-cert.pem
-#        kubectl create secret generic cloudflared-jellyfin-tunnel-credentials \
-#          -n mediastack --from-literal=tunnel-token=<TOKEN> \
-#          --dry-run=client -o yaml | \
-#          kubeseal --cert pub-cert.pem --format yaml \
-#          > clusters/vollminlab-cluster/mediastack/cloudflared-jellyfin/app/cloudflared-jellyfin-tunnel-sealedsecret.yaml
-#        rm pub-cert.pem
-#   4. Commit and push — Flux will reconcile the Deployment once the Secret is available
-#
-# Until this file is replaced, the cloudflared-jellyfin Deployment will not start pods
-# (the Secret will not be created because decryption will fail).
+---
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
@@ -28,7 +10,7 @@ metadata:
     category: networking
 spec:
   encryptedData:
-    tunnel-token: PLACEHOLDER_REPLACE_WITH_REAL_SEALED_TOKEN
+    tunnel-token: AgCPbif4mYZuX1+Wd27ri9W6VwCVkW/55utGpM4YqKPrrr9O+17Gn5kZftJVUTG0CHEAkDcfjNWSiq+ZeivEW0AnhStc+j2WCOPX7YAGTEV/EFFlt/z0u5fOp+8s7qy8KvTV0mf4DEM2MMivmbL6sJI49WBiaog8nx2ZMDtwdY0hK9reE7BXlqvQ/3BqV+mEjp02PteVb3G49rP0FG8gErSrQ60v2/37jc7JpWMpvyaj4zIAAXmSR2AOgnt6Yqmbg6/ygxZcPYxudM2NVyvjToSYvSqZSa/OurCEGsnD94ZbV9ZYki7WZiZsaX76ZyV+Ckf6Yc23mMdd8F5LH3b9ln7kXp9C+FdguF9kKGFXOyXfe9UwcJN8SNbsIy/nvGC5QF8AiAuCwZFOT11ylMtIOun6o4iUaOBindgYFjf9BF3sB/A97pFfUZoYUS0GMGTK/TecgYqHpJ27mWpvlrVVRi622GLI10wX5DRlM/MZ7TX6EOaRxtAFz9pjJwL38vd78X9Dfg2CDFtc3iBRJYha1W7D/s8R67FR3RRAQCBpo7ij//NFSwbvtqWw4nhispaT18Aq7u6mhLSRpuvqkgyxe7PPAfA2CrYRzkaABe/U4Ov96eDx/Zo77B4wCW25ltKzqtp8oiI+tngA9MYjbjS0bZLmpFFcnM143VlPf18HM8A0GSvQomMk5tCDs4E/7I2TnLG3EPwVFL/vG1u5EA92j9vZIhkFoVA1fHCX0dZ7domuSkQlhtQ76ufu0eTLEXsGU7hWoy+KX6K/BcU4+4uVodd8bQAmYPjkBrbrB9K6HssqmjGPNfs2hDQe3ZJJ9bd7jxajEj4ynZYsLVpwoUBxmDbAVNI0IVwaFDk03HbSUhA8zJvH8Usxv11emJbtEDX+AhD3VkKmAD29IzSFXnV0sPS6WWsSNPzG6Lgrb5J2LcZidmgN773X0P7p
   template:
     metadata:
       name: cloudflared-jellyfin-tunnel-credentials

--- a/clusters/vollminlab-cluster/mediastack/cloudflared-jellyfin/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/cloudflared-jellyfin/app/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudflared-jellyfin
+  namespace: mediastack
+  labels:
+    app: cloudflared-jellyfin
+    env: production
+    category: networking
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cloudflared-jellyfin
+  template:
+    metadata:
+      labels:
+        app: cloudflared-jellyfin
+        env: production
+        category: networking
+    spec:
+      containers:
+        - name: cloudflared
+          image: cloudflare/cloudflared:2026.3.0
+          args:
+            - tunnel
+            - --no-autoupdate
+            - run
+          env:
+            - name: TUNNEL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflared-jellyfin-tunnel-credentials
+                  key: tunnel-token
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi

--- a/clusters/vollminlab-cluster/mediastack/cloudflared-jellyfin/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/cloudflared-jellyfin/app/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: cloudflared-jellyfin-app
+resources:
+  - cloudflared-jellyfin-tunnel-sealedsecret.yaml
+  - deployment.yaml

--- a/clusters/vollminlab-cluster/mediastack/jellyfin/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/jellyfin/app/configmap.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jellyfin-values
+  namespace: mediastack
+  labels:
+    app: jellyfin
+    env: production
+    category: media
+data:
+  values.yaml: |
+    persistence:
+      config:
+        existingClaim: pvc-jellyfin-config
+      media:
+        enabled: false
+    volumes:
+      - name: movies
+        persistentVolumeClaim:
+          claimName: pvc-movies
+      - name: tv
+        persistentVolumeClaim:
+          claimName: pvc-tv
+    volumeMounts:
+      - name: movies
+        mountPath: /movies
+      - name: tv
+        mountPath: /tv
+    securityContext:
+      runAsUser: 568
+      runAsGroup: 568
+    podSecurityContext:
+      fsGroup: 568
+      fsGroupChangePolicy: "OnRootMismatch"
+    podLabels:
+      app: jellyfin
+      env: production
+      category: media
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+      limits:
+        cpu: 2000m
+        memory: 2Gi

--- a/clusters/vollminlab-cluster/mediastack/jellyfin/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/mediastack/jellyfin/app/helmrelease.yaml
@@ -1,0 +1,23 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: jellyfin
+  namespace: mediastack
+  labels:
+    app: jellyfin
+    env: production
+    category: media
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: jellyfin
+      version: 3.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: jellyfin-repo
+        namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: jellyfin-values
+      valuesKey: values.yaml

--- a/clusters/vollminlab-cluster/mediastack/jellyfin/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/jellyfin/app/ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: jellyfin-ingress
+  namespace: mediastack
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    shlink.vollminlab.com/slug: jellyfin
+  labels:
+    app: jellyfin
+    env: production
+    category: media
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: jellyfin.vollminlab.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: jellyfin
+                port:
+                  number: 8096
+  tls:
+    - hosts:
+        - jellyfin.vollminlab.com
+      secretName: wildcard-tls

--- a/clusters/vollminlab-cluster/mediastack/jellyfin/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/jellyfin/app/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: jellyfin-app
+resources:
+  - configmap.yaml
+  - helmrelease.yaml
+  - ingress.yaml
+  - pvc-jellyfin-config.yaml

--- a/clusters/vollminlab-cluster/mediastack/jellyfin/app/pvc-jellyfin-config.yaml
+++ b/clusters/vollminlab-cluster/mediastack/jellyfin/app/pvc-jellyfin-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-jellyfin-config
+  namespace: mediastack
+  labels:
+    app: jellyfin
+    env: production
+    category: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/clusters/vollminlab-cluster/mediastack/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/kustomization.yaml
@@ -8,8 +8,10 @@ resources:
   - ./secrets
   - ./bazarr/app
   - ./cloudflared/app
+  - ./cloudflared-jellyfin/app
   - ./exportarr/app
   - ./overseerr/app
+  - ./jellyfin/app
   - ./plex/app
   - ./prowlarr/app
   - ./radarr/app

--- a/docs/cluster-reference.md
+++ b/docs/cluster-reference.md
@@ -390,6 +390,7 @@ All ingresses use `ingressClassName: nginx`, TLS termination via `wildcard-tls`,
 | `prowlarr.vollminlab.com` | prowlarr | 9696 | mediastack | wildcard-tls |
 | `bazarr.vollminlab.com` | bazarr | 6767 | mediastack | wildcard-tls |
 | `overseerr.vollminlab.com` | overseerr | 5055 | mediastack | wildcard-tls |
+| `jellyfin.vollminlab.com` | jellyfin | 8096 | mediastack | wildcard-tls |
 | `plex.vollminlab.com` | plex | 32400 | mediastack | wildcard-tls |
 | `tautulli.vollminlab.com` | tautulli | 8181 | mediastack | wildcard-tls |
 | `go.vollminlab.com` | shlink-shlink-backend | 8080 | shlink | wildcard-tls |
@@ -447,6 +448,7 @@ All ingresses use `ingressClassName: nginx`, TLS termination via `wildcard-tls`,
 | `pvc-prowlarr-config` | mediastack | 5Gi | longhorn | RWO |
 | `pvc-bazarr-config` | mediastack | 5Gi | longhorn | RWO |
 | `pvc-overseerr-config` | mediastack | 5Gi | longhorn | RWO |
+| `pvc-jellyfin-config` | mediastack | 20Gi | longhorn | RWO |
 | `pvc-plex-config` | mediastack | 20Gi | longhorn | RWO |
 | `pvc-tautulli-config` | mediastack | 1Gi | longhorn | RWO |
 | `pvc-minecraft-datadir` | dmz | 20Gi | longhorn-dmz | RWX |
@@ -584,11 +586,31 @@ velero restore create --from-backup <backup-name>
 | CPU | req: 50m, limits: 200m |
 | Memory | req: 64Mi, limits: 128Mi |
 
-**Public hostnames (configured in Cloudflare Zero Trust dashboard):**
+Two separate tunnels are deployed — one per externally-accessible media service, for independent blast-radius and revocability.
+
+#### cloudflared (Plex tunnel)
+
+| Parameter | Value |
+|---|---|
+| Deployment | `cloudflared` in `mediastack` |
+| Tunnel token | SealedSecret `cloudflared-tunnel-credentials` (1Password: "Cloudflare Tunnel Token - vollminlab") |
 
 | Hostname | Internal target |
 |---|---|
 | `plex.vollminlab.com` | `http://plex.mediastack.svc.cluster.local:32400` |
+
+#### cloudflared-jellyfin (Jellyfin tunnel)
+
+| Parameter | Value |
+|---|---|
+| Deployment | `cloudflared-jellyfin` in `mediastack` |
+| Tunnel token | SealedSecret `cloudflared-jellyfin-tunnel-credentials` (1Password: store after sealing) |
+| CPU | req: 50m, limits: 200m |
+| Memory | req: 64Mi, limits: 128Mi |
+
+| Hostname | Internal target |
+|---|---|
+| `jellyfin.vollminlab.com` | `http://jellyfin.mediastack.svc.cluster.local:8096` |
 
 **DNS split:** Internal requests resolve via Pi-hole to `192.168.152.244` (ingress VIP). External requests hit Cloudflare edge → tunnel → cluster service. No inbound ports on the router.
 
@@ -768,6 +790,22 @@ All apps in the `mediastack` namespace. Shared SMB storage mounted at the namesp
 | Ingress | `overseerr.vollminlab.com` |
 | Port | 5055 |
 | Config PVC | 5Gi Longhorn RWO |
+
+### Jellyfin (Media server)
+
+| Parameter | Value |
+|---|---|
+| Chart | jellyfin/jellyfin 3.2.0 (HelmRepository: <https://jellyfin.github.io/jellyfin-helm/>) |
+| App version | 10.11.8 |
+| Ingress | `jellyfin.vollminlab.com` |
+| Port | 8096 |
+| Config PVC | `pvc-jellyfin-config` 20Gi Longhorn RWO |
+| Volumes | `pvc-movies` at `/movies` (RWX), `pvc-tv` at `/tv` (RWX) |
+| UID/GID | 568 |
+| External access | Cloudflare Tunnel via `cloudflared-jellyfin` Deployment (separate from Plex tunnel) |
+| Security gate | Jellyfin built-in auth only — no Cloudflare Access (native apps require no browser challenge) |
+| Public signup | Disabled — accounts created manually by admin |
+| Hardware transcoding | Deferred — CPU only for initial deployment |
 
 ### Plex (Media server)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -170,7 +170,24 @@ Deploy Authentik as the central IdP:
 - Pi-hole DNS updated: `plex.vollminlab.com → 192.168.152.244`. TrueNAS Plex shut down.
 - Overseerr remains internal-only. Can be added to tunnel via Cloudflare dashboard with no code changes.
 
-### 3.4 Tautulli / Plex Metrics Dashboard
+### 3.4 Jellyfin — Free External Streaming for Friends
+
+**Status:** `done`
+
+- Jellyfin deployed in `mediastack` alongside Plex. Official `jellyfin/jellyfin` chart v3.2.0.
+- Shares `pvc-movies` and `pvc-tv` SMB RWX mounts with Plex (read-only access, UID/GID 568).
+- Dedicated `pvc-jellyfin-config` 20Gi Longhorn RWO.
+- Separate `cloudflared-jellyfin` Deployment with its own tunnel — independent blast-radius from Plex.
+- Route: `jellyfin.vollminlab.com → http://jellyfin.mediastack.svc.cluster.local:8096`.
+- Security gate: Jellyfin built-in auth only. No Cloudflare Access policy (native apps cannot complete browser auth challenge). Public signup disabled; accounts managed manually.
+- Hardware transcoding deferred — CPU only. See roadmap for follow-up.
+
+**Deferred follow-ups:**
+
+- Hardware transcoding (`/dev/dri` device mount) — requires evaluating Kyverno `hostPath` audit policy impact
+- Jellyfin metrics / Grafana dashboard (parallel to Tautulli work in 3.5)
+
+### 3.5 Tautulli / Plex Metrics Dashboard
 
 **Status:** `planned`
 

--- a/docs/superpowers/specs/jellyfin-design.md
+++ b/docs/superpowers/specs/jellyfin-design.md
@@ -1,0 +1,175 @@
+# Jellyfin Deployment Design
+
+**Created:** 2026-04-25
+**Status:** Approved — ready for implementation
+
+## Goal
+
+Deploy Jellyfin alongside Plex in the `mediastack` namespace, accessible externally through Cloudflare Tunnel, usable from native apps for the owner and friends, with no router port forwarding and no publicly open NodePort/LoadBalancer.
+
+Plex remains untouched. Both media servers share the existing `pvc-movies` and `pvc-tv` SMB RWX PVCs.
+
+## Helm chart
+
+- **Source:** Official Jellyfin chart, `https://jellyfin.github.io/jellyfin-helm/`
+- **Chart version:** 3.2.0
+- **App version:** 10.11.8 (Jellyfin)
+- **Source kind:** `HelmRepository` (HTTP, not OCI)
+- **Source name:** `jellyfin-repo`
+
+## Architecture
+
+```text
+External (friends) ──► Cloudflare Edge ──► cloudflared-jellyfin (Deployment)
+                                                     │
+                                                     ▼
+LAN ─────────────────► nginx ingress ──► jellyfin Service (ClusterIP :8096)
+                                                     │
+                                                     ▼
+                                            Jellyfin Pod (UID/GID 568)
+                                              /config  → pvc-jellyfin-config (Longhorn 20Gi RWO)
+                                              /movies  → pvc-movies (SMB RWX)
+                                              /tv      → pvc-tv (SMB RWX)
+```
+
+## Security model
+
+- No Cloudflare Access policy on `jellyfin.vollminlab.com`. Cloudflare Access email-gate does not work with native Jellyfin apps (Android, iOS, Apple TV, Roku, etc.) — those apps make HTTP requests that cannot complete a browser-based auth challenge.
+- Cloudflare Tunnel provides connectivity only; Jellyfin's built-in authentication is the gate.
+- Public signup disabled in Jellyfin settings on first launch.
+- Admin account created on first launch with a strong password; user accounts added manually.
+- No NodePort, no LoadBalancer, no router port forwarding.
+
+## Tunnel architecture
+
+**Separate tunnel** (Option B). Jellyfin gets its own Cloudflare Tunnel, its own `cloudflared` Deployment, and its own SealedSecret. This gives independent blast-radius isolation: the Plex tunnel and Jellyfin tunnel can be individually revoked or rotated without affecting the other. This matters because Jellyfin is shared with external users.
+
+- Existing `cloudflared` Deployment (for Plex) is unchanged.
+- New `cloudflared-jellyfin` Deployment reads from `cloudflared-jellyfin-tunnel-credentials` SealedSecret.
+
+## Storage
+
+| PVC | Type | Size | StorageClass | Access | Mount |
+| --- | --- | --- | --- | --- | --- |
+| `pvc-jellyfin-config` | Longhorn (default) | 20Gi | (default) | RWO | `/config` |
+| `pvc-movies` | SMB (existing) | — | smb | RWX | `/movies` |
+| `pvc-tv` | SMB (existing) | — | smb | RWX | `/tv` |
+
+The Jellyfin chart's built-in `persistence.media` PVC is disabled. `pvc-movies` and `pvc-tv` are mounted via the chart's `volumes[]` / `volumeMounts[]` extra-volume mechanism.
+
+## Helm values (configmap.yaml)
+
+```yaml
+persistence:
+  config:
+    existingClaim: pvc-jellyfin-config
+  media:
+    enabled: false
+
+volumes:
+  - name: movies
+    persistentVolumeClaim:
+      claimName: pvc-movies
+  - name: tv
+    persistentVolumeClaim:
+      claimName: pvc-tv
+
+volumeMounts:
+  - name: movies
+    mountPath: /movies
+  - name: tv
+    mountPath: /tv
+
+securityContext:
+  runAsUser: 568
+  runAsGroup: 568
+
+podSecurityContext:
+  fsGroup: 568
+  fsGroupChangePolicy: OnRootMismatch
+
+podLabels:
+  app: jellyfin
+  env: production
+  category: media
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 512Mi
+  limits:
+    cpu: 2000m
+    memory: 2Gi
+```
+
+CPU transcoding only for initial deployment. Hardware transcoding deferred (requires hostPath or device mount — Kyverno audit-mode violation; must be evaluated separately).
+
+## Ingress
+
+- `ingressClassName: nginx`
+- Host: `jellyfin.vollminlab.com`
+- TLS: `wildcard-tls`
+- `nginx.ingress.kubernetes.io/ssl-redirect: "true"`
+- `shlink.vollminlab.com/slug: jellyfin` (auto-creates `vollm.in/jellyfin`)
+
+Cloudflare Tunnel targets the Service directly at `http://jellyfin.mediastack.svc.cluster.local:8096`. The ingress serves LAN/split-DNS access.
+
+## Files to create (9)
+
+```text
+flux-system/repositories/jellyfin-helmrepository.yaml
+mediastack/jellyfin/app/helmrelease.yaml
+mediastack/jellyfin/app/configmap.yaml
+mediastack/jellyfin/app/ingress.yaml
+mediastack/jellyfin/app/pvc-jellyfin-config.yaml
+mediastack/jellyfin/app/kustomization.yaml
+mediastack/cloudflared-jellyfin/app/deployment.yaml
+mediastack/cloudflared-jellyfin/app/cloudflared-jellyfin-tunnel-sealedsecret.yaml
+mediastack/cloudflared-jellyfin/app/kustomization.yaml
+```
+
+## Files to modify (4)
+
+```text
+flux-system/repositories/kustomization.yaml      — add jellyfin-helmrepository.yaml (alphabetical)
+mediastack/kustomization.yaml                    — add ./jellyfin/app and ./cloudflared-jellyfin/app
+docs/cluster-reference.md                        — add Jellyfin section
+docs/roadmap.md                                  — add Jellyfin entry
+```
+
+## Manual Cloudflare dashboard steps (post-merge)
+
+1. Zero Trust → Networks → Tunnels → Create a tunnel → name `jellyfin`
+2. Copy the tunnel token
+3. Seal the token:
+
+   ```bash
+   kubeseal --fetch-cert --controller-namespace sealed-secrets \
+     --controller-name sealed-secrets-controller > pub-cert.pem
+   kubectl create secret generic cloudflared-jellyfin-tunnel-credentials \
+     -n mediastack --from-literal=tunnel-token=<TOKEN> \
+     --dry-run=client -o yaml | \
+     kubeseal --cert pub-cert.pem --format yaml \
+     > clusters/vollminlab-cluster/mediastack/cloudflared-jellyfin/app/cloudflared-jellyfin-tunnel-sealedsecret.yaml
+   rm pub-cert.pem
+   ```
+
+4. Push the sealed secret to the branch; Flux will reconcile
+5. In the tunnel's Public Hostnames tab: add `jellyfin.vollminlab.com` → `http://jellyfin.mediastack.svc.cluster.local:8096`
+
+## Post-deployment first-launch checklist
+
+1. Navigate to `jellyfin.vollminlab.com` (or LAN URL) to complete setup wizard
+2. Create admin account with strong password
+3. Add media libraries: Movies → `/movies`, TV Shows → `/tv`
+4. Settings → Dashboard → Disable "Allow remote connections without authentication" if present
+5. Settings → Users → Disable "Allow users to join this server" (no public signup)
+6. Create user accounts for friends manually
+
+## Deferred: hardware transcoding
+
+Requires a device mount (e.g. `/dev/dri`) via hostPath or device plugin. `hostPath` is a Kyverno audit-mode violation in this cluster. Evaluate separately; document the policy impact before enabling.
+
+## Deferred: Cloudflare Access for browser access
+
+If a browser-only admin UI behind email-gate is desired in future, a separate subdomain (e.g. `jellyfin-admin.vollminlab.com`) with Cloudflare Access could be added without breaking native app support on the main hostname.


### PR DESCRIPTION
## Summary

- Deploys Jellyfin (chart v3.2.0, app 10.11.8) in `mediastack` alongside Plex using the official Jellyfin HelmRepository
- Shares existing `pvc-movies` and `pvc-tv` SMB RWX mounts (UID/GID 568); dedicated `pvc-jellyfin-config` 20Gi Longhorn RWO
- Separate `cloudflared-jellyfin` Deployment with its own sealed tunnel token for independent blast-radius isolation from the Plex tunnel
- Ingress at `jellyfin.vollminlab.com` with `wildcard-tls` and `vollm.in/jellyfin` shlink slug
- Security model: Jellyfin built-in auth only, no Cloudflare Access (native apps cannot complete browser auth challenge), public signup disabled

## Manual steps after merge

1. **Cloudflare Zero Trust dashboard** — in the `vollminlab-Jellyfin` tunnel's Public Hostnames tab, add:
   `jellyfin.vollminlab.com → http://jellyfin.mediastack.svc.cluster.local:8096`
2. **Pi-hole DNS** — `jellyfin.vollminlab.com → 192.168.152.244`
3. **First launch** — complete Jellyfin setup wizard, disable public signup, add media libraries at `/movies` and `/tv`, create user accounts manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)