### PR TITLE
fix: exclude SubjectAccessReview from Kyverno webhook via matchConditions

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
@@ -227,6 +227,10 @@ data:
         - '[PriorityClass,*,*]'
         - '[RuntimeClass,*,*]'
         - '[Lease,*,*]'
+      # namespaceSelector can't exclude cluster-scoped resources; CEL evaluated by apiserver before any Kyverno connection
+      matchConditions:
+        - name: exclude-auth-review-resources
+          expression: "!(request.resource.resource in ['subjectaccessreviews', 'selfsubjectaccessreviews', 'selfsubjectrulesreviews', 'tokenreviews'])"
 
     serviceMonitor:
       enabled: true


### PR DESCRIPTION
## Summary

Adds `config.matchConditions` to Kyverno's Helm values so the API server never calls the Kyverno webhook for authorization/authentication review resources (`SubjectAccessReview`, `SelfSubjectAccessReview`, `SelfSubjectRulesReview`, `TokenReview`).

## Root cause analysis

Periodic `finisher.go` errors were appearing on k8scp03 only, correlating exactly with the `patch-kyverno-webhooks` CronJob (every 5 minutes):

```
Internal error occurred: failed calling webhook "validate.kyverno.svc-fail":
failed to call webhook: Post "https://kyverno-svc.kyverno.svc:443/validate/fail?timeout=10s": context canceled
```

**Why k8scp03 only:** k8scp03 is the etcd leader, and every API server is configured with `--etcd-servers=https://127.0.0.1:2379` (local etcd only). Because k8scp03's etcd commits all writes, k8scp03's API server receives watch notifications for resource changes with **zero replication lag** — before k8scp01 and k8scp02. When the CronJob patches `ValidatingWebhookConfiguration`, k8scp03's API server is the first to reload its webhook connection pool to `kyverno-svc`.

**Why the CronJob causes it:** Kyverno uses self-signed TLS (no cert-manager `Certificate` CRs). The CronJob runs every 5 minutes to keep the `caBundle` in the webhook config fresh after pod restarts. Each patch causes k8scp03's API server to tear down and rebuild its HTTPS connection to `kyverno-svc`. Any request in flight at that instant that was about to call the Kyverno webhook loses its connection.

**Why SubjectAccessReviews:** vCenter (192.168.152.5) maintains watch connections to k8scp03:6443. An etcd compaction event at 19:10 disrupted those watches; vCenter reconnected and issued SubjectAccessReviews to re-establish authorization context. These went through Kyverno's `validate.kyverno.svc-fail` webhook because Kyverno's webhook matches `*/*/*` (all groups, all versions, all resources). `namespaceSelector` cannot exclude cluster-scoped resources like SubjectAccessReview, so they were always intercepted. The webhook connection rebuild at 19:15 (CronJob run) landed on top of the in-flight SubjectAccessReviews → `context canceled` → `failurePolicy: Fail` → requests rejected.

## The fix

Kyverno 3.7.2 supports `config.matchConditions`, which Kyverno reads from its runtime ConfigMap and injects into the `ValidatingWebhookConfiguration` objects it manages as Kubernetes webhook `matchConditions` fields. These are CEL expressions evaluated **by the API server itself** before it opens any connection to Kyverno. If the expression returns `false`, the webhook call is skipped entirely — no HTTPS connection is attempted.

Adding a condition that returns `false` for auth-review resources means:
- The API server never calls Kyverno for SubjectAccessReviews, regardless of connection state
- The CronJob's connection-pool churn on k8scp03 no longer has anything to disrupt for these requests
- `namespaceSelector` gaps for cluster-scoped resources are permanently closed for this class of objects

The `resourceFilters` mechanism (Kyverno's own internal filter) was not sufficient — it requires the HTTPS connection to already be established before Kyverno can return "allow". The `matchConditions` approach eliminates the connection attempt itself.

## What changes

`clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml` — adds `matchConditions` under `config:` (alongside `resourceFilters`). Flux reconciles the HelmRelease → Helm updates the `kyverno` runtime ConfigMap → Kyverno's admission controller picks up the watch event and patches the `ValidatingWebhookConfiguration`.