### PR TITLE
fix: exclude monitoring from Velero FSB, bump Grafana memory limit

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -60,10 +60,10 @@ data:
       resources:
         requests:
           cpu: 100m
-          memory: 256Mi
+          memory: 384Mi
         limits:
           cpu: 500m
-          memory: 512Mi
+          memory: 768Mi
       plugins:
         - grafana-lokiexplore-app
 

--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -115,6 +115,7 @@ data:
           defaultVolumesToFsBackup: true
           excludedNamespaces:
             - minio
+            - monitoring
           resourcePolicy:
             kind: ConfigMap
             name: velero-skip-smb-policy
@@ -128,6 +129,7 @@ data:
           defaultVolumesToFsBackup: true
           excludedNamespaces:
             - minio
+            - monitoring
           resourcePolicy:
             kind: ConfigMap
             name: velero-skip-smb-policy


### PR DESCRIPTION
## Summary

- Adds `monitoring` to `excludedNamespaces` on both Velero schedules (`daily-full` and `daily-b2`) — Prometheus TSDB data was consuming **17GiB** of the 35GiB MinIO PVC via FSB, growing with every backup. Prometheus metrics are ephemeral and provide no restore value.
- Bumps Grafana memory **request 256Mi → 384Mi, limit 512Mi → 768Mi** — OOMKilled after ~39h uptime on 2026-04-26; Grafana 13's unified storage index combined with Longhorn/Velero/Arr/Nodes dashboards now regularly exceeds 512Mi.

## Context

MinIO PVC hit **100% capacity** (critical alert 2026-04-26 23:18). Root-cause breakdown:

| Namespace | Kopia size |
|---|---|
| monitoring | 17GiB (Prometheus TSDB — excluded by this PR) |
| mediastack | 9.3GiB |
| dmz | 5.6GiB |
| everything else | ~1GiB |

MinIO PVC was also expanded 35Gi → 60Gi via Longhorn online resize (direct kubectl, not GitOps) as an immediate remediation alongside this PR.

After this PR merges and Flux reconciles, the monitoring kopia snapshots will stop accumulating. The 17GiB of existing kopia data for monitoring will be reclaimed by kopia GC within ~24h of the next backup cycle.