### PR TITLE
chore: correct kyverno enforce/audit docs and normalize ARC category labels

### DIFF
--- a/.claude/rules/kyverno.md
+++ b/.claude/rules/kyverno.md
@@ -8,16 +8,16 @@ description: Kyverno policy rules, required labels, DMZ constraints, and enforce
 
 | Policy               | Rule                                                                      |
 | -------------------- | ------------------------------------------------------------------------- |
-| Required labels      | Every pod must have `app`, `env`, and `category` labels                   |
+| Resource limits      | Every pod must have CPU + memory requests and limits                      |
+| No `:latest` tags    | Image tags must be pinned — `:latest` is blocked                          |
+| No privileged        | Privileged containers are blocked                                         |
+| No `hostPath`        | `hostPath` volumes are blocked                                            |
 | No default namespace | Pods may not run in the `default` namespace                               |
 | DMZ placement        | DMZ pods must run on `k8sworker05`/`k8sworker06` (injected automatically) |
 
 ## Audit-mode policies (violations logged, not blocked)
 
-- Resource limits required (CPU + memory requests/limits)
-- No `:latest` image tags
-- No privileged containers
-- No `hostPath` volumes
+- Required labels (`app`, `env`, `category`) — pods missing these labels are logged but not blocked
 
 ## Valid `category` label values
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,5 @@
 name: CI Pipeline
 
-# Force workflow update for PR trigger
 on:
   push:
     branches: [ main, develop ]

--- a/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: arc-runners
     env: production
-    category: apps
+    category: ci
 data:
   values.yaml: |
     githubConfigUrl: "https://github.com/vollminlab"
@@ -26,7 +26,7 @@ data:
         labels:
           app: arc-runners
           env: production
-          category: apps
+          category: ci
       spec:
         serviceAccountName: github-actions-runner
         containers:
@@ -64,7 +64,7 @@ data:
         labels:
           app: arc-runners
           env: production
-          category: apps
+          category: ci
       spec:
         containers:
           - name: listener

--- a/clusters/vollminlab-cluster/arc-controller/arc-controller/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/arc-controller/arc-controller/app/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: arc-controller
     env: production
-    category: apps
+    category: ci
 data:
   values.yaml: |
     replicaCount: 2
@@ -16,7 +16,7 @@ data:
     podLabels:
       app: arc-controller
       env: production
-      category: apps
+      category: ci
 
     resources:
       requests:

--- a/clusters/vollminlab-cluster/homepage/homepage/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/helmrelease.yaml
@@ -11,7 +11,7 @@ spec:
   chart:
     spec:
       chart: homepage
-      version: 2.1.0  # Updated to latest version with Pi-hole v6 API support
+      version: 2.1.0
       sourceRef:
         kind: HelmRepository
         name: homepage-repo

--- a/clusters/vollminlab-cluster/portainer/portainer/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/portainer/portainer/app/helmrelease.yaml
@@ -11,7 +11,7 @@ spec:
   chart:
     spec:
       chart: portainer
-      version: "239.1.0"  # Current version based on existing deployment
+      version: "239.1.0"
       sourceRef:
         kind: HelmRepository
         name: portainer-repo


### PR DESCRIPTION
## Summary

- **Fix `.claude/rules/kyverno.md`** — enforce/audit policy tables were exactly backwards vs actual manifests: `require-labels` is `Audit`; `require-resources`, `restrict-latest-tag`, `restrict-privileged`, and `restrict-hostpath` are all `Enforce`
- **Normalize ARC category labels** — `arc-controller` and `arc-runners` ConfigMaps (both metadata and Helm values pod labels) were set to `category: apps`; corrected to `category: ci` to match HelmRelease metadata and the kyverno.md category table
- **Remove temporal comments** — stripped "Updated to latest", "Current version based on existing deployment", and "Force workflow update for PR trigger" from homepage/portainer HelmReleases and ci.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)