### PR TITLE
fix: enable Grafana persistence so users survive pod restarts

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -67,6 +67,13 @@ data:
       plugins:
         - grafana-lokiexplore-app
 
+      persistence:
+        enabled: true
+        storageClassName: longhorn
+        size: 1Gi
+        accessModes:
+          - ReadWriteOnce
+
       additionalDataSources:
         - name: Loki
           type: loki


### PR DESCRIPTION
## Summary

- Adds a `persistence` block to the Grafana section of the kube-prometheus-stack ConfigMap
- Provisions a 1Gi Longhorn PVC for Grafana's SQLite database
- Users, sessions, and manually-created dashboards will now survive pod restarts and Flux reconciliations

🤖 Generated with [Claude Code](https://claude.com/claude-code)