### PR TITLE
docs: sync README and cluster-reference to actual deployed state

### DIFF
--- a/.claude/rules/kyverno.md
+++ b/.claude/rules/kyverno.md
@@ -25,11 +25,11 @@ Every HelmRelease and pod must use one of:
 
 | Category        | Apps                                                           |
 | --------------- | -------------------------------------------------------------- |
-| `core`          | Flux, Capacitor, Kyverno                                       |
+| `core`          | Flux, Headlamp, Kyverno                                        |
 | `security`      | cert-manager, sealed-secrets, Kyverno policy-reporter          |
 | `storage`       | Longhorn, local-path-provisioner, smb-csi-driver               |
-| `networking`    | ingress-nginx, MetalLB                                         |
-| `observability` | metrics-server, ECK (Elasticsearch/Kibana)                     |
+| `networking`    | ingress-nginx, MetalLB, external-dns                           |
+| `observability` | metrics-server, kube-prometheus-stack, Grafana, Loki           |
 | `apps`          | homepage, portainer, shlink, renovate                          |
 | `media`         | Radarr, Sonarr, Bazarr, Overseerr, Prowlarr, SABnzbd, Tautulli |
 | `gaming`        | Minecraft (dmz namespace only)                                 |

--- a/README.md
+++ b/README.md
@@ -35,25 +35,32 @@ bootstrap/                              # Manual bootstrap only — NOT Flux-man
 
 clusters/vollminlab-cluster/            # Everything Flux reconciles
   flux-system/
-    repositories/                       # 24 HelmRepositories + 1 GitRepository
+    repositories/                       # 24 HelmRepositories + 10 OCIRepositories + 1 GitRepository
     flux-kustomizations/                # Flux Kustomization CRs (one per app/namespace)
-  actions-runner-system/                # GitHub Actions self-hosted runners
+  actions-runner-system/                # GitHub Actions ARC runners (scale set workloads)
+  arc-controller/                       # GitHub ARC scale set controller
   cert-manager/                         # TLS certificate automation
   clusterwide/                          # PersistentVolumes, StorageClasses, RBAC
+  cnpg-system/                          # CloudNative PG operator
   dmz/                                  # Internet-exposed workloads (Minecraft)
-  elastic-system/                       # ECK Operator
-  flux-system/                          # Flux controllers + sync config
+  external-dns/                         # Automated DNS record management
+  flux-system/                          # Flux controllers + Headlamp (Flux UI)
+  harbor/                               # Container registry
   homepage/                             # Homepage dashboard
   ingress-nginx/                        # Ingress controller
   kube-system/                          # metrics-server, smb-csi-driver
-  kyverno/                              # Policy engine + 12 ClusterPolicies + policy-reporter
+  kyverno/                              # Policy engine + ClusterPolicies + policy-reporter
   local-path-storage/                   # Node-local storage provisioner
   longhorn-system/                      # Distributed block storage
   mediastack/                           # Sonarr, Radarr, Bazarr, Prowlarr, SABnzbd, Overseerr, Tautulli
   metallb-system/                       # Bare-metal load balancer
-  monitoring/                           # Monitoring stack (in progress)
+  minio/                                # S3-compatible object storage (Velero backend)
+  monitoring/                           # Prometheus, Grafana, Loki, Promtail
   portainer/                            # Container management UI
+  renovate/                             # Automated dependency updates
   sealed-secrets/                       # Sealed secrets controller
+  shlink/                               # Short URL service + ingress annotation controller
+  velero/                               # Cluster backup
 
 scripts/                                # Utility scripts
 ```
@@ -67,30 +74,35 @@ scripts/                                # Utility scripts
 | App | Namespace | Chart Version | Purpose |
 |---|---|---|---|
 | Flux CD | flux-system | — | GitOps reconciliation |
-| Capacitor | flux-system | latest | Flux UI dashboard |
-| Kyverno | kyverno | v3.4.1 | Policy enforcement |
-| Policy Reporter | kyverno | ~v16 | Policy violation reporting |
-| ingress-nginx | ingress-nginx | v4.12.0 | Ingress controller |
-| cert-manager | cert-manager | v1.16.3 | TLS certificates |
+| Headlamp | flux-system | 0.41.0 | Kubernetes UI with Flux plugin |
+| Kyverno | kyverno | 3.7.2 | Policy enforcement |
+| Policy Reporter | kyverno | — | Policy violation reporting |
+| ingress-nginx | ingress-nginx | 4.15.1 | Ingress controller |
+| cert-manager | cert-manager | v1.20.2 | TLS certificates |
 | MetalLB | metallb-system | — | LoadBalancer IPs |
 | Sealed Secrets | sealed-secrets | — | Git-safe secrets |
-| metrics-server | kube-system | v3.12.2 | Resource metrics API |
-| ECK Operator | elastic-system | v2.16.1 | Elasticsearch on K8s |
+| metrics-server | kube-system | 3.13.0 | Resource metrics API |
+| External DNS | external-dns | — | Automated DNS records (Pi-hole) |
+| CNPG Operator | cnpg-system | — | CloudNative PostgreSQL |
 
 ### Storage
 
 | App | Namespace | Purpose |
 |---|---|---|
 | Longhorn | longhorn-system | Distributed block storage (RWO + RWX) |
-| SMB CSI Driver | kube-system | v1.17.0 — SMB/CIFS network shares |
+| SMB CSI Driver | kube-system | 1.20.1 — SMB/CIFS network shares |
 | Local Path Provisioner | local-path-storage | Node-local ephemeral storage |
+| MinIO | minio | S3-compatible object storage (Velero backend) |
 
 ### Applications
 
 | App | Namespace | Purpose |
 |---|---|---|
-| Homepage | homepage | v2.1.0 — Cluster dashboard |
+| Homepage | homepage | Cluster dashboard |
 | Portainer | portainer | Container management UI |
+| Harbor | harbor | Container registry |
+| Shlink | shlink | Short URL service (vollm.in) |
+| Renovate | renovate | Automated dependency updates |
 | Overseerr | mediastack | Media request management |
 | Sonarr | mediastack | TV series automation |
 | Radarr | mediastack | Movie automation |
@@ -104,7 +116,8 @@ scripts/                                # Utility scripts
 
 | App | Namespace | Purpose |
 |---|---|---|
-| Actions Runner Controller | actions-runner-system | v0.23.7 — Self-hosted GitHub Actions runners |
+| ARC Scale Set Controller | arc-controller | 0.14.0 — Self-hosted GitHub Actions runners (ARC v2) |
+| Velero | velero | Cluster backup to MinIO + Backblaze B2 |
 
 ---
 
@@ -143,7 +156,7 @@ For a full cluster rebuild, follow this order exactly:
 | Policy | Action | Rule |
 |---|---|---|
 | restrict-default | Block | No workloads in `default` namespace |
-| require-labels | Block | All pods need `app`, `env`, `category` labels |
+| require-labels | Audit | All pods need `app`, `env`, `category` labels (logged, not blocked) |
 | require-resources | Block | CPU/memory requests and limits required |
 | inject-resource-requirements | Mutate | Auto-inject default limits |
 | restrict-privileged | Block | No privileged containers |

--- a/clusters/vollminlab-cluster/portainer/portainer/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/portainer/portainer/app/configmap.yaml
@@ -13,7 +13,7 @@ data:
       type: ClusterIP
       annotations: {}
     ingress:
-      enabled: false  # Set to true if you want to expose via ingress
+      enabled: false
     persistence:
       enabled: true
       existingClaim: portainer
@@ -24,18 +24,15 @@ data:
       requests:
         cpu: 100m
         memory: 128Mi
-    # Preserve existing configuration
     serviceAccount:
       create: true
       name: portainer-sa-clusteradmin
       annotations: {}
     rbac:
       enabled: true
-    # Edge agent configuration
     edge:
       enabled: true
       tunnelPort: 30776
-    # Security settings
     securityContext:
       runAsNonRoot: false
       runAsUser: 0

--- a/docs/cluster-reference.md
+++ b/docs/cluster-reference.md
@@ -170,8 +170,6 @@ All volumes are `ReadWriteMany`, `100Gi`, backed by SMB shares at `192.168.150.2
 
 ### RBAC
 
-**`capacitor`** ClusterRole — grants the Capacitor dashboard read access to: pods, ingresses, deployments, services, secrets, events, configmaps, and all Flux resources (patch).
-
 **`disk-cleanup`** ClusterRole — grants the maintenance CronJob: read nodes/pods, delete pods, read deployments/daemonsets/replicasets.
 
 **Kyverno webhook patch** ClusterRole — grants Kyverno permission to patch `mutatingwebhookconfigurations` and `validatingwebhookconfigurations`.
@@ -195,7 +193,7 @@ All volumes are `ReadWriteMany`, `100Gi`, backed by SMB shares at `192.168.150.2
 
 | Parameter | Value |
 |---|---|
-| Chart version | v3.4.1 |
+| Chart version | 3.7.2 |
 | Helm repo | https://kyverno.github.io/kyverno/ |
 | Replicas | 3 |
 | Admission controller replicas | 3 |
@@ -274,13 +272,16 @@ All Kustomizations use `interval: 10m`, `prune: true`, source `flux-system` GitR
 
 | Kustomization | Path | Notes |
 |---|---|---|
-| `actions-runner-system` | `./clusters/vollminlab-cluster/actions-runner-system` | |
-| `actions-runner-system-patch` | patch only | Webhook patches |
-| `capacitor` | `flux-system/capacitor` | dependsOn: flux-system |
+| `actions-runner-system` | `./clusters/vollminlab-cluster/actions-runner-system` | ARC runner scale set workloads |
+| `actions-runner-system-runners` | `./clusters/vollminlab-cluster/actions-runner-system` | |
+| `arc-controller` | `./clusters/vollminlab-cluster/arc-controller` | ARC scale set controller |
 | `cert-manager` | `./clusters/vollminlab-cluster/cert-manager` | |
 | `clusterwide` | `./clusters/vollminlab-cluster/clusterwide` | |
+| `cnpg-system` | `./clusters/vollminlab-cluster/cnpg-system` | |
 | `dmz` | `./clusters/vollminlab-cluster/dmz` | |
-| `elastic-system` | `./clusters/vollminlab-cluster/elastic-system` | |
+| `external-dns` | `./clusters/vollminlab-cluster/external-dns` | |
+| `harbor` | `./clusters/vollminlab-cluster/harbor` | |
+| `headlamp` | `./clusters/vollminlab-cluster/flux-system/headlamp/app` | Kubernetes UI with Flux plugin |
 | `homepage` | `./clusters/vollminlab-cluster/homepage` | |
 | `ingress-nginx` | `./clusters/vollminlab-cluster/ingress-nginx` | |
 | `kube-system` | `./clusters/vollminlab-cluster/kube-system` | |
@@ -291,54 +292,67 @@ All Kustomizations use `interval: 10m`, `prune: true`, source `flux-system` GitR
 | `longhorn-system` | `./clusters/vollminlab-cluster/longhorn-system` | |
 | `mediastack` | `./clusters/vollminlab-cluster/mediastack` | |
 | `metallb-system` | `./clusters/vollminlab-cluster/metallb-system` | |
-| `monitoring` | `./clusters/vollminlab-cluster/monitoring` | Placeholder — not deployed |
+| `minio` | `./clusters/vollminlab-cluster/minio` | |
+| `monitoring` | `./clusters/vollminlab-cluster/monitoring` | kube-prometheus-stack, Loki, Promtail |
 | `policy-reporter` | `./clusters/vollminlab-cluster/kyverno` | |
 | `policy-reporter-patch` | patch only | |
 | `portainer` | `./clusters/vollminlab-cluster/portainer` | |
+| `renovate` | `./clusters/vollminlab-cluster/renovate` | |
 | `sealed-secrets` | `./clusters/vollminlab-cluster/sealed-secrets` | |
+| `shlink` | `./clusters/vollminlab-cluster/shlink` | |
+| `velero` | `./clusters/vollminlab-cluster/velero` | |
 
-### Capacitor (Flux UI Dashboard)
+### Headlamp (Kubernetes UI)
 
 | Parameter | Value |
 |---|---|
-| Image | `ghcr.io/gimlet-io/capacitor:v0.4.8` |
-| Chart | onechart v0.73.0 (gimlet.io) |
-| Ingress | `capacitor.vollminlab.com` |
+| Chart | headlamp v0.41.0 (kubernetes-sigs.github.io/headlamp) |
+| Namespace | flux-system |
+| Ingress | `headlamp.vollminlab.com` |
 | TLS | wildcard-tls |
-| Port | 9000 |
-| CPU | req: 100m, limits: 200m |
+| Plugin | headlamp-plugin-flux v0.6.0 (init container) |
+| CPU | req: 150m, limits: 500m |
 | Memory | req: 256Mi, limits: 512Mi |
-| Security | runAsNonRoot, runAsUser=100, readOnlyRootFilesystem, drop=ALL, seccompProfile=RuntimeDefault |
 
-### HelmRepositories
+### Repository Sources
 
-| Name | Type | URL |
+| Name | Type | URL / OCI ref |
 |---|---|---|
-| arc-repo | HelmRepository | https://actions-runner-controller.github.io/actions-runner-controller |
-| capacitor-repo | HelmRepository | https://gimlet.io/onechart/ |
+| arc-controller-repo | OCIRepository | oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller (tag: 0.14.0) |
+| arc-runners-repo | OCIRepository | oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set (tag: 0.14.0) |
+| bazarr-repo | HelmRepository | https://k8s-home-lab.github.io/helm-charts/ |
 | cert-manager-repo | HelmRepository | https://charts.jetstack.io |
-| elastic-repo | HelmRepository | https://helm.elastic.co |
-| homepage-repo | HelmRepository | https://jameswynn.github.io/helm-charts/ |
+| cnpg-repo | HelmRepository | https://cloudnative-pg.github.io/charts |
+| external-dns-repo | HelmRepository | https://kubernetes-sigs.github.io/external-dns/ |
+| grafana-repo | HelmRepository | https://grafana.github.io/helm-charts |
+| harbor-repo | HelmRepository | https://helm.goharbor.io |
+| headlamp-repo | HelmRepository | https://kubernetes-sigs.github.io/headlamp/ |
+| homepage-repo | HelmRepository | https://jameswynn.github.io/helm-charts |
 | ingress-nginx-repo | HelmRepository | https://kubernetes.github.io/ingress-nginx |
-| kyverno-repo | HelmRepository | https://kyverno.github.io/kyverno/ |
-| kyverno-policyreporter-repo | HelmRepository | https://kyverno.github.io/policy-reporter/ |
+| jellyfin-repo | HelmRepository | https://jellyfin.github.io/jellyfin-helm/ |
+| kyverno-repo | HelmRepository | https://kyverno.github.io/kyverno |
+| kyverno-policyreporter-repo | HelmRepository | https://kyverno.github.io/policy-reporter |
 | local-path-provisioner-repo | GitRepository | https://github.com/rancher/local-path-provisioner (tag: v0.0.35) |
 | longhorn-repo | HelmRepository | https://charts.longhorn.io |
-| metallb-repo | HelmRepository | https://metallb.universe.tf |
+| metallb-repo | HelmRepository | https://metallb.github.io/metallb |
 | metrics-server-repo | HelmRepository | https://kubernetes-sigs.github.io/metrics-server/ |
 | minecraft-repo | HelmRepository | https://itzg.github.io/minecraft-server-charts/ |
-| overseerr-repo | OCIRepository | — |
-| portainer-repo | HelmRepository | https://portainer.io/helm |
-| prowlarr-repo | OCIRepository | — |
-| radarr-repo | OCIRepository | — |
-| sabnzbd-repo | OCIRepository | — |
-| sealed-secrets-repo | HelmRepository | https://sealed-secrets.dev |
+| minio-repo | HelmRepository | https://charts.min.io/ |
+| overseerr-repo | OCIRepository | oci://oci.trueforge.org/truecharts/overseerr |
+| plex-repo | OCIRepository | oci://oci.trueforge.org/truecharts/plex |
+| portainer-repo | HelmRepository | https://portainer.github.io/k8s |
+| prometheus-community-repo | HelmRepository | https://prometheus-community.github.io/helm-charts |
+| prowlarr-repo | OCIRepository | oci://oci.trueforge.org/truecharts/prowlarr |
+| radarr-repo | OCIRepository | oci://oci.trueforge.org/truecharts/radarr |
+| renovate-repo | OCIRepository | oci://ghcr.io/renovatebot/charts/renovate |
+| sabnzbd-repo | OCIRepository | oci://oci.trueforge.org/truecharts/sabnzbd |
+| sealed-secrets-repo | HelmRepository | https://bitnami-labs.github.io/sealed-secrets |
+| shlink-repo | HelmRepository | https://charts.christianhuth.de |
 | smb-csi-driver-repo | HelmRepository | https://raw.githubusercontent.com/kubernetes-csi/csi-driver-smb/master/charts |
-| sonarr-repo | OCIRepository | — |
-| tautulli-repo | HelmRepository | — |
-| bazarr-repo | HelmRepository | — |
-| bitnami-repo | HelmRepository | — |
-| minecraft-repo | HelmRepository | https://itzg.github.io/minecraft-server-charts/ |
+| sonarr-repo | OCIRepository | oci://oci.trueforge.org/truecharts/sonarr |
+| tautulli-repo | HelmRepository | https://k8s-at-home.com/charts/ |
+| velero-repo | HelmRepository | https://vmware-tanzu.github.io/helm-charts |
+| vollminlab-repo | OCIRepository | oci://harbor.vollminlab.com/vollminlab/charts/shlink-ingress-controller |
 
 ---
 
@@ -348,7 +362,7 @@ All Kustomizations use `interval: 10m`, `prune: true`, source `flux-system` GitR
 
 | Parameter | Value |
 |---|---|
-| Chart version | v4.12.0 |
+| Chart version | 4.15.1 |
 | Helm repo | https://kubernetes.github.io/ingress-nginx |
 | Default SSL certificate | `cert-manager/wildcard-tls` |
 
@@ -356,7 +370,7 @@ All Kustomizations use `interval: 10m`, `prune: true`, source `flux-system` GitR
 
 | Parameter | Value |
 |---|---|
-| Chart version | v1.16.3 |
+| Chart version | v1.20.2 |
 | Helm repo | https://charts.jetstack.io |
 | DNS01 recursive nameservers only | true |
 | DNS01 recursive nameservers | `10.96.0.10:53` |
@@ -381,7 +395,7 @@ All ingresses use `ingressClassName: nginx`, TLS termination via `wildcard-tls`,
 | Hostname | Backend | Port | Namespace | TLS Secret |
 |---|---|---|---|---|
 | `homepage.vollminlab.com` | homepage | 3000 | homepage | wildcard-tls |
-| `capacitor.vollminlab.com` | capacitor | 9000 | flux-system | wildcard-tls |
+| `headlamp.vollminlab.com` | headlamp | 4466 | flux-system | wildcard-tls |
 | `longhorn.vollminlab.com` | longhorn-frontend | 80 | longhorn-system | wildcard-tls |
 | `policyreporter.vollminlab.com` | policy-reporter-ui | 8080 | kyverno | wildcard-tls |
 | `radarr.vollminlab.com` | radarr | 7878 | mediastack | wildcard-tls |
@@ -418,7 +432,7 @@ All ingresses use `ingressClassName: nginx`, TLS termination via `wildcard-tls`,
 
 | Parameter | Value |
 |---|---|
-| Chart version | v1.17.0 |
+| Chart version | 1.20.1 |
 | Helm repo | https://raw.githubusercontent.com/kubernetes-csi/csi-driver-smb/master/charts |
 | NAS address | `192.168.150.2` |
 | SMB shares | movies, tv, completed-downloads, incomplete-downloads |
@@ -620,22 +634,13 @@ Two separate tunnels are deployed — one per externally-accessible media servic
 
 | Parameter | Value |
 |---|---|
-| Chart version | v3.12.2 |
+| Chart version | 3.13.0 |
 | Helm repo | https://kubernetes-sigs.github.io/metrics-server/ |
 | kubelet-insecure-tls | true |
 | kubelet preferred address types | InternalIP, Hostname, InternalDNS |
 | Metric resolution | 15s |
 | CPU | req: 50m, limits: 200m |
 | Memory | req: 64Mi, limits: 128Mi |
-
-### ECK Operator (Elasticsearch)
-
-| Parameter | Value |
-|---|---|
-| Chart version | v2.16.1 |
-| Helm repo | https://helm.elastic.co |
-| Webhook | enabled |
-| Log verbosity | 1 |
 
 ### Shlink (URL Shortener)
 
@@ -667,7 +672,7 @@ Two separate tunnels are deployed — one per externally-accessible media servic
 | Slug | Destination |
 |---|---|
 | homepage | https://homepage.vollminlab.com |
-| capacitor | https://capacitor.vollminlab.com |
+| headlamp | https://headlamp.vollminlab.com |
 | longhorn | https://longhorn.vollminlab.com |
 | policyreporter | https://policyreporter.vollminlab.com |
 | radarr | https://radarr.vollminlab.com |
@@ -702,30 +707,32 @@ Two separate tunnels are deployed — one per externally-accessible media servic
 
 ---
 
-### Actions Runner Controller
+### Actions Runner Controller (ARC v2)
+
+**Controller** (`arc-controller` namespace):
 
 | Parameter | Value |
 |---|---|
-| Chart version | v0.23.7 |
-| Helm repo | https://actions-runner-controller.github.io/actions-runner-controller |
+| Chart | gha-runner-scale-set-controller v0.14.0 (OCIRepository) |
+| Replicas | 2 |
+| Watches namespace | actions-runner-system |
+| Controller CPU | req: 50m, limits: 500m |
+| Controller memory | req: 64Mi, limits: 256Mi |
+
+**Runner scale set** (`actions-runner-system` namespace):
+
+| Parameter | Value |
+|---|---|
+| Chart | gha-runner-scale-set v0.14.0 (OCIRepository) |
+| Scale set name | vollminlab |
+| GitHub scope | org (github.com/vollminlab) |
 | Auth | GitHub App (sealed secret: `arc-githubapp-secret`) |
-| Sync period | 1m |
-| Leader election | enabled |
-| Manager replicas | 3 |
-| Manager resources | req: 50m/64Mi, limits: 200m/128Mi |
-| Container mode | kubernetes |
-| Anti-affinity | preferred (weight 100) |
-
-**RunnerDeployments** — 2 pools, 5 total replicas:
-
-| Pool | Runner label | Replicas | Repository | Image | CPU | Memory |
-|---|---|---|---|---|---|---|
-| pool-1 | vollminlab-1 | 3 | svollmi1/k8s-vollminlab-cluster | summerwind/actions-runner:ubuntu-22.04 | req 500m / limits 2000m | req 512Mi / limits 2Gi |
-| pool-3 | vollminlab-3 | 2 | svollmi1/k8s-vollminlab-cluster | summerwind/actions-runner:ubuntu-22.04 | req 500m / limits 2000m | req 512Mi / limits 2Gi |
-
-Pool-1 has 3 replicas to support concurrent CI jobs. Pool-2 (`vollminlab-2`) was removed — no CI jobs used that label.
-
-Runners are ephemeral (`RUNNER_EPHEMERAL=true`). `RUNNER_WAIT_FOR_DOCKERD_SECONDS=120`.
+| Min runners | 4 |
+| Max runners | 10 |
+| Runner image | `ghcr.io/actions/actions-runner:2.332.0` |
+| DinD sidecar | `docker:26-dind` (privileged, tcp://localhost:2375) |
+| Runner CPU | req: 500m, limits: 2000m |
+| Runner memory | req: 512Mi, limits: 2Gi |
 
 ---
 
@@ -964,4 +971,4 @@ The `dmz` namespace is a security boundary for internet-exposed workloads. Full 
 
 ### Self-Hosted Runners (ARC)
 
-CI runs on self-hosted runners in `actions-runner-system`. 2 pools, 5 total replicas. Jobs target runner labels `vollminlab-1` (pool-1, 3 replicas) and `vollminlab-3` (pool-3, 2 replicas).
+CI runs on self-hosted runners via ARC v2 (gha-runner-scale-set) in `actions-runner-system`. Scale set name: `vollminlab`. Min 4 / max 10 runners. Jobs target the `vollminlab` runner group label.


### PR DESCRIPTION
## Summary

- Remove all references to decommissioned components: Capacitor, ECK Operator (elastic-system), and ARC v1 RunnerDeployments
- Add all namespaces/apps that were missing from docs: `arc-controller`, `cnpg-system`, `external-dns`, `harbor`, `headlamp`, `minio`, `renovate`, `shlink`, `velero`
- Update stale chart versions: Kyverno (v3.4.1→3.7.2), ingress-nginx (v4.12.0→4.15.1), cert-manager (v1.16.3→v1.20.2), metrics-server (v3.12.2→3.13.0), SMB CSI (v1.17.0→1.20.1), ARC (v0.23.7→0.14.0)
- Fix `require-labels` policy incorrectly documented as enforce/Block — it is audit-only
- Rebuild repository sources table from ground truth (35 sources; was 27 with duplicates and phantom entries like `bitnami-repo`, `capacitor-repo`, `elastic-repo`)
- Replace ARC v1 section with accurate ARC v2 gha-runner-scale-set configuration (org-scoped, min 4/max 10 runners, DinD sidecar)
- Replace Capacitor section with Headlamp (chart v0.41.0, headlamp-plugin-flux v0.6.0)
- Strip scaffolding comments from portainer configmap
- Update `.claude/rules/kyverno.md` category table: Capacitor→Headlamp, ECK→kube-prometheus-stack/Grafana/Loki, add external-dns to networking

🤖 Generated with [Claude Code](https://claude.com/claude-code)