### PR TITLE
docs: fix remaining audit findings — policy modes, stale app refs, ECK cleanup

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
@@ -213,10 +213,6 @@ data:
         - '[Subscription,*,*]'
         # Velero CRDs — no policies target these
         - '[PodVolumeBackup,*,*]'
-        # Elastic / ECK CRDs — no policies target these
-        - '[AutoOpsAgentPolicy,*,*]'
-        - '[ElasticsearchAutoscaler,*,*]'
-        - '[EnterpriseSearch,*,*]'
         # Kubernetes built-ins with no applicable policies
         - '[Secret,*,*]'
         - '[PodTemplate,*,*]'

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/inject-pod-labels.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/inject-pod-labels.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/description: >-
       Adds app, env, and category labels from the namespace onto bare Pod
       objects at admission time. Targets operator-generated pods (CNPG, ARC
-      runners, ECK, etc.) that are created directly as Pods and bypass any
+      runners, etc.) that are created directly as Pods and bypass any
       Deployment/StatefulSet spec. Uses +(label) syntax so explicit labels
       always win. Kept as a separate policy from inject-namespace-labels
       (which targets controllers) to prevent Kyverno autogen from generating

--- a/docs/cluster-reference.md
+++ b/docs/cluster-reference.md
@@ -210,17 +210,16 @@ All volumes are `ReadWriteMany`, `100Gi`, backed by SMB shares at `192.168.150.2
 | Policy | Mode | Action | Rule |
 |---|---|---|---|
 | `restrict-default` | enforce | validate | Block all workloads in `default` namespace |
-| `restrict-privileged` | audit | validate | Block privileged containers; exempts: kube-system, calico-system, longhorn-system, metallb-system, csi-driver, tigera-operator, ingress-nginx |
-| `restrict-hostpath-usage` | audit | validate | Block hostPath volumes; exempts: kube-system, calico-system, longhorn-system, monitoring, tigera-operator |
-| `restrict-latest-tag` | audit | validate | Block `:latest` image tags on Deployment/StatefulSet/DaemonSet |
-| `restrict-loadbalancer-services` | audit | validate | LoadBalancer type only allowed in `ingress-nginx` and `dmz` namespaces |
+| `restrict-privileged` | enforce | validate | Block privileged containers; exempts: kube-system, calico-system, longhorn-system, metallb-system, csi-driver, tigera-operator, ingress-nginx |
+| `restrict-hostpath-usage` | enforce | validate | Block hostPath volumes; exempts: kube-system, calico-system, longhorn-system, monitoring, tigera-operator |
+| `restrict-latest-tag` | enforce | validate | Block `:latest` image tags on Deployment/StatefulSet/DaemonSet |
+| `restrict-loadbalancer-services` | enforce | validate | LoadBalancer type only allowed in `ingress-nginx` and `dmz` namespaces |
 | `require-standard-labels` | audit | validate | Require `app`, `env`, `category` labels on Deployments, StatefulSets, DaemonSets, Pods, Namespaces, Services; exempts: kube-system, default |
-| `require-resources` | audit | validate | Require CPU/memory requests and limits on all containers; exempts Flux deployments |
+| `require-resources` | enforce | validate | Require CPU/memory requests and limits on all containers; exempts Flux deployments |
 | `dmz-enforce-node-placement` | enforce | mutate | Auto-inject `nodeSelector: role=dmz` and toleration `dmz=Exists:NoSchedule` on all pods in `dmz` namespace |
 | `dmz-restrict-external-access` | enforce | validate | Block `external-access=true` and `internet-egress=true` labels outside `dmz` namespace |
 | `inject-namespace-labels` | — | mutate | Auto-copy `app`, `env`, `category` labels from namespace to workloads; exempts: longhorn-system, flux-system, monitoring |
 | `inject-resource-requirements` | — | mutate | Auto-inject resource limits for Longhorn sidecar containers (CSI attacher, provisioner, resizer, snapshotter, UI, manager, driver) |
-| `force-rescan-on-rollout` | — | mutate | Annotate Deployments/StatefulSets/DaemonSets with `policy.kyverno.io/kyverno-force-rescan` |
 
 **PolicyException: `ignore-flux-core`** — Exempts all Flux controllers and the `kyverno` HelmRelease from all policies.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -141,7 +141,7 @@ sudo cp /etc/kubernetes/admin.conf ~/.kube/config && sudo chown $(id -u):$(id -g
 
 Deploy Authentik as the central IdP:
 
-- OIDC/OAuth2 for all web UIs (Grafana, Longhorn, Capacitor, Homepage, etc.)
+- OIDC/OAuth2 for all web UIs (Grafana, Longhorn, Headlamp, Homepage, etc.)
 - LDAP outpost for apps that don't support OIDC natively
 - Forward Auth proxy for apps with no built-in auth
 - Requires PostgreSQL (Bitnami subchart or shared instance TBD)

--- a/docs/runbooks/homepage.md
+++ b/docs/runbooks/homepage.md
@@ -10,7 +10,7 @@ kubectl get ingress <name> -n <namespace> -o jsonpath='{.metadata.annotations}' 
 ```
 
 Services currently auto-discovered (as of 2026-04-01):
-- **Capacitor** (`flux-system/capacitor-ingress`) → Infrastructure group
+- **Headlamp** (`flux-system/headlamp-ingress`) → Infrastructure group
 - **Longhorn** (`longhorn-system/longhorn-ingress`) → Infrastructure group
 - **MinIO** (`minio/minio-ingress`) → Infrastructure group
 - **Policy Reporter** (`kyverno/policy-reporter-ui`) → Monitoring & Observability group

--- a/docs/superpowers/specs/jellyfin-design.md
+++ b/docs/superpowers/specs/jellyfin-design.md
@@ -102,7 +102,7 @@ resources:
     memory: 2Gi
 ```
 
-CPU transcoding only for initial deployment. Hardware transcoding deferred (requires hostPath or device mount — Kyverno audit-mode violation; must be evaluated separately).
+CPU transcoding only for initial deployment. Hardware transcoding deferred (requires hostPath or device mount — blocked by Kyverno enforce policy; must be evaluated separately).
 
 ## Ingress
 
@@ -168,7 +168,7 @@ docs/roadmap.md                                  — add Jellyfin entry
 
 ## Deferred: hardware transcoding
 
-Requires a device mount (e.g. `/dev/dri`) via hostPath or device plugin. `hostPath` is a Kyverno audit-mode violation in this cluster. Evaluate separately; document the policy impact before enabling.
+Requires a device mount (e.g. `/dev/dri`) via hostPath or device plugin. `hostPath` is blocked by Kyverno enforce policy in this cluster. Evaluate separately; document the policy exception required before enabling.
 
 ## Deferred: Cloudflare Access for browser access
 


### PR DESCRIPTION
## Summary

- Fix five Kyverno policies documented as `audit` but running in `enforce` mode: `restrict-privileged`, `restrict-hostpath-usage`, `restrict-latest-tag`, `restrict-loadbalancer-services`, `require-resources`
- Remove phantom `force-rescan-on-rollout` row from the ClusterPolicies table (policy file does not exist)
- Replace Capacitor with Headlamp in homepage runbook auto-discovery list and roadmap OIDC section
- Fix two jellyfin-design.md sentences that called hostPath an "audit-mode violation" — it is blocked by enforce policy (affects planning for hardware transcoding)
- Drop stale ECK/Elastic CRD exclusions from Kyverno background controller configmap (`AutoOpsAgentPolicy`, `ElasticsearchAutoscaler`, `EnterpriseSearch` — ECK is gone)
- Remove ECK from `inject-pod-labels` description

Note: `docs/superpowers/specs/jellyfin-design.md` is gitignored — the two hostPath fixes there are local only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)