### PR TITLE
fix: reduce velero early-morning alert noise

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -173,6 +173,7 @@ data:
         etcd: true
       disabled:
         KubeClientCertificateExpiration: true
+        KubeJobFailed: true
 
     kube-state-metrics:
       podLabels:

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -99,6 +99,18 @@ spec:
             summary: "Velero daily-full backup partially failed"
             description: "A daily-full backup has PartiallyFailed in the last 26 hours. Check velero backup describe."
 
+        - alert: KubeJobFailed
+          expr: |
+            (kube_job_failed{namespace!="velero"} > 0)
+              or
+            (kube_job_failed{namespace="velero", job_name!~".*-kopia-maintain.*"} > 0)
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete"
+            description: "Job {{ $labels.namespace }}/{{ $labels.job_name }} failed. Removing failed job after investigation should clear this alert."
+
         - alert: VeleroBackupMetricMissing
           expr: |
             absent(velero_backup_last_status{schedule="velero-daily-full"}) == 1

--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -116,6 +116,7 @@ data:
           excludedNamespaces:
             - minio
             - monitoring
+            - velero
           resourcePolicy:
             kind: ConfigMap
             name: velero-skip-smb-policy
@@ -130,6 +131,7 @@ data:
           excludedNamespaces:
             - minio
             - monitoring
+            - velero
           resourcePolicy:
             kind: ConfigMap
             name: velero-skip-smb-policy


### PR DESCRIPTION
## Summary

- Add `velero` to `excludedNamespaces` on both backup schedules (`daily-full`, `daily-b2`) — Velero was trying to FSB-backup its own maintenance job pods (in `Succeeded`/`Failed` state), generating warnings that caused `PartiallyFailed` backup status
- Disable the default `KubeJobFailed` alert rule via `defaultRules.disabled` and replace it with a custom variant that excludes `*-kopia-maintain-*` jobs in the `velero` namespace, preventing stale maintenance job objects from firing spurious early-morning alerts

**Trade-off:** Velero schedule/backup catalog CRs will no longer be included in backups. In a DR scenario Velero config is restored from GitOps; the backup data itself remains in MinIO/B2 regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)