### PR TITLE
feat: add /books SMB mount to audiobookshelf

### DIFF
--- a/clusters/vollminlab-cluster/clusterwide/kustomization.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - kyverno-patch-clusterrole.yaml
   - kyverno-patch-clusterrolebinding.yaml
   - pv-audiobooks.yaml
+  - pv-books.yaml
   - pv-completed-downloads.yaml
   - pv-incomplete-downloads.yaml
   - pv-movies.yaml

--- a/clusters/vollminlab-cluster/clusterwide/pv-books.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/pv-books.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-books
+  labels:
+    app: mediastack
+    env: production
+    category: media
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb
+  csi:
+    driver: smb.csi.k8s.io
+    volumeHandle: books
+    volumeAttributes:
+      source: "//192.168.150.2/books"
+    nodeStageSecretRef:
+      name: smb-credentials
+      namespace: mediastack
+  mountOptions:
+    - uid=568
+    - gid=568
+    - dir_mode=0755
+    - file_mode=0755

--- a/clusters/vollminlab-cluster/mediastack/audiobookshelf/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/audiobookshelf/app/configmap.yaml
@@ -18,6 +18,10 @@ data:
         enabled: true
         existingClaim: pvc-audiobooks
         mountPath: /audiobooks
+      books:
+        enabled: true
+        existingClaim: pvc-books
+        mountPath: /books
       metadata:
         enabled: true
         existingClaim: pvc-audiobookshelf-metadata

--- a/clusters/vollminlab-cluster/mediastack/pvcs/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/pvcs/kustomization.yaml
@@ -4,6 +4,7 @@ metadata:
   name: mediastack-pvcs
 resources:
   - pvc-audiobooks.yaml
+  - pvc-books.yaml
   - pvc-completed-downloads.yaml
   - pvc-incomplete-downloads.yaml
   - pvc-movies.yaml

--- a/clusters/vollminlab-cluster/mediastack/pvcs/pvc-books.yaml
+++ b/clusters/vollminlab-cluster/mediastack/pvcs/pvc-books.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-books
+  namespace: mediastack
+  labels:
+    app: mediastack
+    env: production
+    category: media
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Gi
+  volumeName: pv-books
+  storageClassName: smb


### PR DESCRIPTION
## Summary

- Creates `pv-books` (clusterwide) and `pvc-books` (mediastack) pointing at `//192.168.150.2/books`
- Follows the exact same pattern as `pv-audiobooks` / `pvc-audiobooks`
- Mounts the share at `/books` inside the audiobookshelf container

🤖 Generated with [Claude Code](https://claude.com/claude-code)