### PR TITLE
fix: use directory paths in authentik kustomization resources

### DIFF
--- a/clusters/vollminlab-cluster/authentik/kustomization.yaml
+++ b/clusters/vollminlab-cluster/authentik/kustomization.yaml
@@ -1,9 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-metadata:
-  name: authentik
 resources:
   - namespace.yaml
-  - cnpg/app/kustomization.yaml
-  - authentik/app/kustomization.yaml
-  - cloudflared-authentik/app/kustomization.yaml
+  - cnpg/app
+  - authentik/app
+  - cloudflared-authentik/app


### PR DESCRIPTION
## Summary

- `clusters/vollminlab-cluster/authentik/kustomization.yaml` was referencing sub-directories as `cnpg/app/kustomization.yaml` instead of `cnpg/app`
- Kustomize treats the `kustomization.yaml` filename suffix as a raw Kubernetes resource and silently drops it — so only the namespace was created, no HelmRelease, no CNPG Cluster, no cloudflared Deployment
- Fix: reference the directory only, matching the pattern used by every other namespace (e.g. `shlink/app`, `shlink-web/app`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)