### PR TITLE
fix: increase authentik worker CPU limit to 500m

### DIFF
--- a/clusters/vollminlab-cluster/authentik/authentik/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/authentik/authentik/app/configmap.yaml
@@ -39,8 +39,8 @@ data:
         category: security
       resources:
         requests:
-          cpu: 50m
+          cpu: 100m
           memory: 256Mi
         limits:
-          cpu: 300m
+          cpu: 500m
           memory: 512Mi


### PR DESCRIPTION
## Summary

- Worker hit 31% CPU throttling (CPUThrottlingHigh alert) during initial startup and blueprint processing
- Raises CPU limit from 300m → 500m (matching the server container)
- Raises CPU request from 50m → 100m to better reflect actual baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)