### PR TITLE
feat: add descheduler with LowNodeUtilization policy

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/descheduler-helmrepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/descheduler-helmrepository.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: descheduler-repo
+  namespace: flux-system
+  labels:
+    app: descheduler
+    env: production
+    category: core
+spec:
+  url: https://kubernetes-sigs.github.io/descheduler/
+  interval: 12h

--- a/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - bazarr-helmrepository.yaml
   - cert-manager-helmrepository.yaml
   - cnpg-helmrepository.yaml
+  - descheduler-helmrepository.yaml
   - external-dns-helmrepository.yaml
   - grafana-helmrepository.yaml
   - harbor-helmrepository.yaml

--- a/clusters/vollminlab-cluster/kube-system/descheduler/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kube-system/descheduler/app/configmap.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: descheduler-values
+  namespace: kube-system
+  labels:
+    app: descheduler
+    env: production
+    category: core
+data:
+  values.yaml: |
+    kind: CronJob
+    schedule: "*/30 * * * *"
+
+    podLabels:
+      app: descheduler
+      env: production
+      category: core
+
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
+
+    deschedulerPolicy:
+      profiles:
+        - name: default
+          pluginConfig:
+            - name: DefaultEvictor
+              args:
+                evictLocalStoragePods: false
+                nodeFit: true
+            - name: LowNodeUtilization
+              args:
+                thresholds:
+                  cpu: 20
+                  memory: 50
+                  pods: 20
+                targetThresholds:
+                  cpu: 50
+                  memory: 75
+                  pods: 50
+          plugins:
+            balance:
+              enabled:
+                - LowNodeUtilization
+            filter:
+              enabled:
+                - DefaultEvictor

--- a/clusters/vollminlab-cluster/kube-system/descheduler/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/kube-system/descheduler/app/helmrelease.yaml
@@ -1,0 +1,23 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: descheduler
+  namespace: kube-system
+  labels:
+    app: descheduler
+    env: production
+    category: core
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: descheduler
+      version: "0.35.1"
+      sourceRef:
+        kind: HelmRepository
+        name: descheduler-repo
+        namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: descheduler-values
+      valuesKey: values.yaml

--- a/clusters/vollminlab-cluster/kube-system/descheduler/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/kube-system/descheduler/app/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - configmap.yaml

--- a/clusters/vollminlab-cluster/kube-system/kustomization.yaml
+++ b/clusters/vollminlab-cluster/kube-system/kustomization.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kube-system
 resources:
   - namespace.yaml
+  - ./descheduler/app
   - ./etcd-defrag/app
   - ./metrics-server/app
   - ./smb-csi-driver/app


### PR DESCRIPTION
## Summary

- Adds the [Descheduler](https://github.com/kubernetes-sigs/descheduler) to `kube-system` using the official Helm chart v0.35.1
- Runs as a CronJob every 30 minutes
- `LowNodeUtilization` policy: evicts pods from nodes above **75% memory** and reschedules them on nodes below **50% memory**
- Motivation: k8sworker03 reached 81% memory after Authentik deployment while other nodes sit at ~40%

## Policy thresholds

| Direction | CPU | Memory | Pods |
|-----------|-----|--------|------|
| Under-utilized (receive pods) | <20% | <50% | <20 |
| Over-utilized (evict pods) | >50% | >75% | >50 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)