### PR TITLE
fix: relax descheduler CPU thresholds to allow rebalancing

### DIFF
--- a/clusters/vollminlab-cluster/kube-system/descheduler/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kube-system/descheduler/app/configmap.yaml
@@ -36,11 +36,11 @@ data:
             - name: LowNodeUtilization
               args:
                 thresholds:
-                  cpu: 20
+                  cpu: 40
                   memory: 50
                   pods: 20
                 targetThresholds:
-                  cpu: 50
+                  cpu: 70
                   memory: 75
                   pods: 50
           plugins:


### PR DESCRIPTION
## Summary

- CPU threshold of 20% was too tight — all nodes run 25–35% CPU, so no node qualified as under-utilized and no evictions fired despite k8sworker03 at 80% memory
- Raises CPU threshold: 20% → 40% (under-utilized) and 50% → 70% (over-utilized)
- Memory thresholds unchanged: 50% / 75%

After merge, descheduler will evict pods from k8sworker03 (>75% memory) and reschedule on nodes below 40% CPU / 50% memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)