### PR TITLE
fix: reduce Prometheus rule eval throttling

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -27,7 +27,7 @@ data:
             category: observability
         resources:
           requests:
-            cpu: 250m
+            cpu: 500m
             memory: 1Gi
           limits:
             cpu: 1000m

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -14,7 +14,7 @@ spec:
     # Raw series are retained for ~2h (head block); aggregates carry the long-term signal.
     # Drops: instance, scope, subresource, component, group, version — keeps verb+resource+le.
     - name: apiserver.recording.rules
-      interval: 2m
+      interval: 5m
       rules:
         - record: verb_resource:apiserver_request_duration_seconds_bucket:rate5m
           expr: |
@@ -35,7 +35,7 @@ spec:
             )
 
     - name: etcd.recording.rules
-      interval: 2m
+      interval: 5m
       rules:
         - record: operation_type:etcd_request_duration_seconds_bucket:rate5m
           expr: |


### PR DESCRIPTION
## Summary

- Raise Prometheus CPU request 250m → 500m (limit stays at 1000m) to reduce the throttling gap that caused occasional rule evaluation overruns
- Extend `apiserver.recording.rules` and `etcd.recording.rules` evaluation interval 2m → 5m — gives high-cardinality histogram aggregations more wall-clock time per slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)