### PR TITLE
fix: correct OCIRepository apiVersion for seerr-repo

### DIFF
--- a/.claude/rules/flux.md
+++ b/.claude/rules/flux.md
@@ -52,7 +52,7 @@ This is what causes Flux to sync the chart source. Without it the HelmRelease ca
 - `metadata.name: [app-name]-repo` — always suffix with `-repo`, no exceptions
 - Named after the **app being deployed**, not the chart author
 - HTTP registry → `kind: HelmRepository` (`source.toolkit.fluxcd.io/v1`)
-- OCI registry → `kind: OCIRepository` (`source.toolkit.fluxcd.io/v1beta2`) — **do not use `HelmRepository type: oci`, it is in maintenance mode**
+- OCI registry → `kind: OCIRepository` (`source.toolkit.fluxcd.io/v1`) — **do not use `HelmRepository type: oci`, it is in maintenance mode**
 - Version is pinned in the `OCIRepository` `spec.ref.tag`, not in the HelmRelease
 
 Copy-paste templates: `docs/runbooks/flux-templates.md`

--- a/clusters/vollminlab-cluster/flux-system/repositories/seerr-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/seerr-ocirepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: seerr-repo


### PR DESCRIPTION
## Summary

- Fixes `OCIRepository` apiVersion from `source.toolkit.fluxcd.io/v1beta2` to `source.toolkit.fluxcd.io/v1` — v1beta2 is not registered on this cluster; every other OCIRepository uses v1
- Corrects the same mistake in `.claude/rules/flux.md` so it doesn't recur

🤖 Generated with [Claude Code](https://claude.com/claude-code)