### PR TITLE
fix: fail CI when OCIRepository apiVersion is not registered on cluster

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -473,14 +473,9 @@ jobs:
                 .metadata.namespace = \"$TEST_NAMESPACE\" |
                   .metadata.name = \"$TEST_NAME\"
               " "$file" | kubectl apply --validate=false -f - 2>&1) || {
-                if echo "$APPLY_OUTPUT" | grep -q "no matches for kind"; then
-                  echo "⚠️ Skipping $file: apiVersion $(yq eval '.apiVersion' "$file") not yet served by cluster (expected during Flux component upgrade)"
-                  sed -i "/^${ORIG_NAME}:/d" "$OCI_MAPPING_FILE"
-                else
-                  echo "❌ Failed to deploy OCIRepository: $file"
-                  echo "$APPLY_OUTPUT"
-                  exit 1
-                fi
+                echo "❌ Failed to deploy OCIRepository: $file"
+                echo "$APPLY_OUTPUT"
+                exit 1
               }
             fi
           done


### PR DESCRIPTION
## Summary

- Removes the `no matches for kind` escape hatch from the OCIRepository apply step in the integration test
- Previously, a failed apply with that error logged a warning and silently continued — this masked the `v1beta2` bug in PR #494 that only surfaced in production
- All OCIRepository apply failures now hard-fail the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)