### PR TITLE
fix: add auth-snippet to seerr forward-auth ingress

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/seerr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/seerr/app/ingress.yaml
@@ -8,6 +8,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
     nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
     nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/auth-snippet: |
+      proxy_set_header X-Original-URL $scheme://$http_host$request_uri;
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     shlink.vollminlab.com/slug: seerr
   labels:


### PR DESCRIPTION
## Summary
- Adds missing `nginx.ingress.kubernetes.io/auth-snippet` annotation to the seerr ingress
- Without `proxy_set_header X-Original-URL`, the authentik proxy outpost cannot relay the original request URI — post-auth redirects land on `/` instead of the page the user was trying to reach

🤖 Generated with [Claude Code](https://claude.com/claude-code)