### PR TITLE
Right-size CPU and memory requests on k8sworker03 workloads

### DIFF
--- a/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
@@ -57,6 +57,15 @@ data:
       credentials:
         existingSecret: harbor-core-credentials
 
+    trivy:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 64Mi
+        limits:
+          cpu: 500m
+          memory: 256Mi
+
     podLabels:
       app: harbor
       env: production

--- a/clusters/vollminlab-cluster/minio/minio/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/minio/minio/app/configmap.yaml
@@ -19,7 +19,7 @@ data:
 
     resources:
       requests:
-        cpu: 250m
+        cpu: 150m
         memory: 512Mi
       limits:
         cpu: 1000m

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -32,7 +32,7 @@ data:
             memory: 1Gi
           limits:
             cpu: 2000m
-            memory: 2Gi
+            memory: 3Gi
         storageSpec:
           volumeClaimTemplate:
             spec:

--- a/clusters/vollminlab-cluster/monitoring/loki/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/loki/app/configmap.yaml
@@ -67,7 +67,7 @@ data:
 
       resources:
         requests:
-          cpu: 250m
+          cpu: 50m
           memory: 256Mi
         limits:
           cpu: 1000m


### PR DESCRIPTION
## Summary

k8sworker03 was at 99% CPU requests and 76% memory requests. The descheduler cannot rebalance because the only underutilized nodes carry the `dmz=true` taint. All changes are grounded in 7-day Prometheus metrics (max working set and CFS throttle rates).

**CPU reductions (saves ~460m on k8sworker03):**
- Loki: 250m → 50m (7d max 21m, 0.1% throttle peak)
- MinIO: 250m → 150m (7d max 101m, 1.6% throttle peak)
- Harbor Trivy: 200m → 100m (7d max 1m, 0% throttle)
- Prometheus CPU request **intentionally left at 500m** — was deliberately raised 2 days ago due to CFS throttling under rule evaluation load; load-bearing

**Memory changes:**
- Prometheus limit: 2Gi → 3Gi — 7d max hit 1.99Gi against the old 2Gi ceiling; OOM risk without headroom
- Harbor Trivy request: 512Mi → 64Mi, limit: 1Gi → 256Mi — 7d max was 11Mi; chart default was massively over-provisioned, saves ~448Mi of reserved memory
- Loki and MinIO memory left unchanged — actual usage exceeds their requests, so raising would add node pressure; limits have sufficient headroom

**Expected outcome:** k8sworker03 CPU requests drop from ~99% to ~88%; memory requests drop from ~76% to ~70%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)