### PR TITLE
Right-size ARC runner CPU requests

### DIFF
--- a/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/configmap.yaml
@@ -38,7 +38,7 @@ data:
                 value: tcp://localhost:2375
             resources:
               requests:
-                cpu: 500m
+                cpu: 100m
                 memory: 512Mi
               limits:
                 cpu: 2000m
@@ -53,7 +53,7 @@ data:
             args: ["--host=tcp://0.0.0.0:2375"]
             resources:
               requests:
-                cpu: 200m
+                cpu: 50m
                 memory: 256Mi
               limits:
                 cpu: 2000m


### PR DESCRIPTION
## Summary

- Reduces `runner` container CPU request: 500m → 100m
- Reduces `dind` container CPU request: 200m → 50m
- Total per runner pod: 700m → 150m

Driven by 7-day Prometheus metrics: `runner` peaked at 59m, `dind` at 3m. These pods run Renovate GitOps jobs (YAML diffs, GitHub API calls) — no heavy compute. The 500m/200m requests were chart defaults with no prior tuning.

Limits remain at 2000m each so any unexpectedly heavy job can still burst freely.

**Impact:** Eliminates the recurring `FailedScheduling` churn that fires every ARC cycle when the 4 non-DMZ workers are near capacity. At 150m per pod, all 4 `minRunners` fit comfortably without cycling through failed placements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)