### PR TITLE
Enable ingress-nginx snippet annotations for Authentik auth-snippet

### DIFF
--- a/clusters/vollminlab-cluster/ingress-nginx/ingress-nginx/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/ingress-nginx/ingress-nginx/app/configmap.yaml
@@ -10,5 +10,7 @@ metadata:
 data:
   values.yaml: |
     controller:
+      config:
+        allow-snippet-annotations: "true"
       extraArgs:
         default-ssl-certificate: cert-manager/wildcard-tls


### PR DESCRIPTION
## Summary

- Adds `allow-snippet-annotations: "true"` to the ingress-nginx controller config
- Required for Authentik proxy authentication via `nginx.ingress.kubernetes.io/auth-snippet`

The default has been `false` since ingress-nginx v1.9 to protect multi-tenant clusters where untrusted users could inject arbitrary NGINX directives. This cluster is single-tenant and all Ingress resources are operator-controlled, so the risk does not apply.

Without this, the Seerr (and any future Authentik-protected) ingress dry-run fails with: `admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: nginx.ingress.kubernetes.io/auth-snippet annotation cannot be used. Snippet directives are disabled by the Ingress administrator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)