### PR TITLE
Fix ingress-nginx ExternalAuth risk level for Authentik

### DIFF
--- a/clusters/vollminlab-cluster/ingress-nginx/ingress-nginx/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/ingress-nginx/ingress-nginx/app/configmap.yaml
@@ -12,5 +12,6 @@ data:
     controller:
       config:
         allow-snippet-annotations: "true"
+        annotations-risk-level: Critical
       extraArgs:
         default-ssl-certificate: cert-manager/wildcard-tls


### PR DESCRIPTION
## Summary

- Adds `annotations-risk-level: Critical` to the ingress-nginx controller config

ingress-nginx v1.9+ classifies the `ExternalAuth` annotation group (`auth-url`, `auth-signin`, `auth-snippet`) as `Critical` risk and blocks it by default. Without this setting, any Ingress using Authentik proxy auth fails the admission webhook with:

> `annotation group ExternalAuth contains risky annotation based on ingress configuration`

This follows #502 which enabled `allow-snippet-annotations`. Both settings are needed for Authentik SSO to work with ingress-nginx on this cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)