### PR TITLE
Fix MinIO PVC size drift (20Gi chart vs 60Gi actual)

### DIFF
--- a/clusters/vollminlab-cluster/minio/minio/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/minio/minio/app/configmap.yaml
@@ -28,7 +28,7 @@ data:
     persistence:
       enabled: true
       storageClass: "longhorn"
-      size: 20Gi
+      size: 60Gi
 
     service:
       type: ClusterIP


### PR DESCRIPTION
## Summary

- Updates MinIO persistence `size` from `20Gi` → `60Gi` to match the actual PVC capacity

The PVC was expanded online to 60Gi at some point but the chart value was never updated. This went unnoticed until PR #500 (CPU right-sizing) triggered a Helm upgrade, which tried to patch the PVC back to 20Gi and failed:

> `spec.resources.requests.storage: Forbidden: field can not be less than status.capacity`

No functional change — the PVC remains at 60Gi. This just keeps Helm in sync with reality so future upgrades don't fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)