### PR TITLE
feat: native OIDC integration with Authentik for Grafana, MinIO, Headlamp, Harbor

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -72,6 +72,7 @@ data:
           api_url: https://authentik.vollminlab.com/application/o/userinfo/
           role_attribute_path: "contains(groups, 'Grafana Admins') && 'Admin' || 'Viewer'"
           signout_redirect_url: https://authentik.vollminlab.com/application/o/grafana/end-session/
+          use_pkce: true
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
## Summary

- Wire native OIDC/OAuth2 to Authentik for Grafana, MinIO, Headlamp, and Harbor (Phase 3 of Authentik SSO rollout)
- Add `grafana-oauth-sealedsecret.yaml`, `minio-oidc-sealedsecret.yaml`, and `headlamp-oidc-sealedsecret.yaml` with client secrets sealed via kubeseal
- Enable PKCE (`use_pkce: true`) in Grafana's `[auth.generic_oauth]` config — required for Authentik to preserve authorization flow context through the authentication redirect when the user is not already logged in

## Notes

- Client IDs in ConfigMaps are public values suppressed with `# gitleaks:allow`
- Client secrets are in SealedSecrets only; never in ConfigMaps
- Harbor OIDC is configured via `core.extraEnvVars`; client secret referenced via `secretKeyRef`
- PKCE is required for Grafana because Authentik uses the `code_challenge` to anchor `PLAN_CONTEXT_PARAMS` through the auth redirect — without it, returning from authentication causes "No Pending Data" on the authorization flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)