### PR TITLE
fix: enable PKCE for Grafana OAuth2 to fix Authentik No Pending Data error

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -72,6 +72,7 @@ data:
           api_url: https://authentik.vollminlab.com/application/o/userinfo/
           role_attribute_path: "contains(groups, 'Grafana Admins') && 'Admin' || 'Viewer'"
           signout_redirect_url: https://authentik.vollminlab.com/application/o/grafana/end-session/
+          use_pkce: true
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
## Summary

- Add `use_pkce: true` to Grafana's `[auth.generic_oauth]` config in the kube-prometheus-stack values ConfigMap

## Why

Authentik anchors the authorization flow context (`PLAN_CONTEXT_PARAMS`) to the `code_challenge` sent in the OAuth2 authorization request. Without PKCE, when Authentik needs to redirect through the login flow and back, the authorization context is lost — resulting in **"Request has been denied. No Pending data."** for any user whose session has expired.

Jellyfin works because its OIDC client sends `code_challenge`/`S256` natively. This change makes Grafana do the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)