### PR TITLE
fix: enable PKCE for MinIO OIDC

### DIFF
--- a/clusters/vollminlab-cluster/minio/minio/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/minio/minio/app/configmap.yaml
@@ -63,6 +63,10 @@ data:
       redirectUri: "https://minio.vollminlab.com/oauth_callback"
       displayName: "Authentik"
 
+    extraEnvVars:
+      - name: MINIO_IDENTITY_OPENID_PKCE_ENABLED
+        value: "on"
+
     makeBucketJob:
       resources:
         requests:


### PR DESCRIPTION
## Summary

- Add `MINIO_IDENTITY_OPENID_PKCE_ENABLED: "on"` via `extraEnvVars` — the MinIO Helm chart's `oidc` section has no native PKCE field
- Same root cause as the Grafana PKCE fix (PR #508): Authentik requires a PKCE code challenge by default; MinIO wasn't sending one

🤖 Generated with [Claude Code](https://claude.com/claude-code)