### PR TITLE
fix: add OIDC ClusterRoleBinding for Headlamp Authentik SSO

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/headlamp/app/clusterrolebinding.yaml
+++ b/clusters/vollminlab-cluster/flux-system/headlamp/app/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-oidc-admins
+  labels:
+    app: headlamp
+    env: production
+    category: core
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: User
+    name: "oidc:scottvollmin@gmail.com"
+    apiGroup: rbac.authorization.k8s.io

--- a/clusters/vollminlab-cluster/flux-system/headlamp/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/headlamp/app/kustomization.yaml
@@ -4,6 +4,7 @@ metadata:
   name: headlamp-app
   namespace: flux-system
 resources:
+  - clusterrolebinding.yaml
   - configmap.yaml
   - helmrelease.yaml
   - headlamp-oidc-sealedsecret.yaml


### PR DESCRIPTION
## Summary

- Add `ClusterRoleBinding` mapping `oidc:scottvollmin@gmail.com` → `cluster-admin` for Headlamp OIDC login
- Kube-apiserver on all 3 control plane nodes has been manually patched with `--oidc-issuer-url`, `--oidc-client-id`, `--oidc-username-claim=email`, and `--oidc-username-prefix=oidc:` flags to accept Authentik JWTs
- Together these two changes enable Authentik SSO for Headlamp — previously OIDC callback succeeded but k8s API rejected the token with 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)