### PR TITLE
fix: enable Minecraft whitelist and lock down server access

### DIFF
--- a/clusters/vollminlab-cluster/dmz/minecraft/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/dmz/minecraft/app/configmap.yaml
@@ -60,6 +60,8 @@ data:
       serviceType: NodePort
       nodePort: 32565
       externalTrafficPolicy: Local
+      whitelist: "svollmi1,Brainsteen,FenycFur,mattgutkin,Dirtbikedemon01,Forgonploxi,Gurty,Plasmaticmofo2"
+      ops: "svollmi1"
       # Set maxWorldSize to prevent duplicate MAX_WORLD_SIZE env var in Helm deployment
       # NOTE: This sets the env var, but server.properties must be manually set to 29999984
       # The server.properties file is in a PVC and persists across restarts
@@ -71,6 +73,7 @@ data:
     extraEnv:
       SIMULATION_DISTANCE: "6"
       PLUGINS: "https://cdn.modrinth.com/data/swbUV1cr/versions/lfk408pd/bluemap-5.13-spigot.jar"
+      OVERRIDE_WHITELIST: "TRUE"
     # RCON password from secret (itzg/minecraft-server supports RCON_PASSWORD env var)
     # Note: The Helm chart may need extraEnvVars or envFrom instead - check chart docs
     extraEnvVars:


### PR DESCRIPTION
## Summary

- Server was griefed by player `reallydrained` (hacked client, active May 5–10) who used fly hacks, speed hacks, and attempted `/op`
- Enable whitelist enforcement with 8 approved players
- Add `OVERRIDE_WHITELIST=TRUE` so `whitelist.json` is regenerated cleanly on every start, removing any griefed-in entries

**Whitelist:** svollmi1, Brainsteen, FenycFur, mattgutkin, Dirtbikedemon01, Forgonploxi, Gurty, Plasmaticmofo2

This PR is paired with a Velero world rollback to the May 4 snapshot (pre-griefing) being executed out-of-band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)