### PR TITLE
fix: scope MinIO ServiceMonitor to API service only

### DIFF
--- a/clusters/vollminlab-cluster/minio/minio/app/servicemonitor.yaml
+++ b/clusters/vollminlab-cluster/minio/minio/app/servicemonitor.yaml
@@ -11,6 +11,7 @@ spec:
   selector:
     matchLabels:
       app: minio
+      monitoring: "true"
   endpoints:
     - port: http
       path: /minio/v2/metrics/cluster


### PR DESCRIPTION
## Summary

- Adds `monitoring: "true"` to the ServiceMonitor selector
- The `minio-console` service (port 9001) shares the `app: minio` label but doesn't serve metrics, causing 3 failing scrape targets
- The `minio` API service (port 9000) has `monitoring=true` set by the chart — this selector narrows to that service only

🤖 Generated with [Claude Code](https://claude.com/claude-code)