### PR TITLE
feat: forward-auth sweep — all remaining services behind Authentik

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/ingress.yaml
@@ -6,6 +6,10 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     shlink.vollminlab.com/slug: homepage
   labels:
     app: homepage

--- a/clusters/vollminlab-cluster/kyverno/policyreporter/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/kyverno/policyreporter/app/ingress.yaml
@@ -6,6 +6,10 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: "Policy Reporter"
     gethomepage.dev/description: "Kubernetes policy reporting"

--- a/clusters/vollminlab-cluster/longhorn-system/longhorn/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn/app/ingress.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: longhorn-system
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: "Longhorn"
     gethomepage.dev/description: "Kubernetes storage management"

--- a/clusters/vollminlab-cluster/mediastack/bazarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr/app/configmap.yaml
@@ -21,6 +21,8 @@ data:
       PUID: "568"
       PGID: "568"
       UMASK: "002"
+      BAZARR__AUTH__USERNAME: ""
+      BAZARR__AUTH__PASSWORD: ""
     persistence:
       config:
         enabled: true

--- a/clusters/vollminlab-cluster/mediastack/bazarr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr/app/ingress.yaml
@@ -6,6 +6,10 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     shlink.vollminlab.com/slug: bazarr
   labels:
     app: bazarr

--- a/clusters/vollminlab-cluster/mediastack/prowlarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/prowlarr/app/configmap.yaml
@@ -18,6 +18,8 @@ data:
       app: prowlarr
       env: production
       category: media
+    env:
+      PROWLARR__AUTH__METHOD: "External"
     terminationGracePeriodSeconds: 60
     lifecycle:
       preStop:

--- a/clusters/vollminlab-cluster/mediastack/prowlarr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/prowlarr/app/ingress.yaml
@@ -6,6 +6,10 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     shlink.vollminlab.com/slug: prowlarr
   labels:
     app: prowlarr

--- a/clusters/vollminlab-cluster/mediastack/radarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/radarr/app/configmap.yaml
@@ -38,6 +38,8 @@ data:
       app: radarr
       env: production
       category: media
+    env:
+      RADARR__AUTH__METHOD: "External"
     securityContext:
       runAsUser: 568
       runAsGroup: 568

--- a/clusters/vollminlab-cluster/mediastack/radarr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/radarr/app/ingress.yaml
@@ -6,6 +6,10 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     shlink.vollminlab.com/slug: radarr
   labels:
     app: radarr

--- a/clusters/vollminlab-cluster/mediastack/sabnzbd/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sabnzbd/app/configmap.yaml
@@ -36,3 +36,7 @@ data:
     env:
       - name: SABNZBD__HOST_WHITELIST_ENTRIES
         value: sabnzbd.vollminlab.com,localhost,127.0.0.1
+      - name: SABNZBD__USERNAME
+        value: ""
+      - name: SABNZBD__PASSWORD
+        value: ""

--- a/clusters/vollminlab-cluster/mediastack/sabnzbd/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sabnzbd/app/ingress.yaml
@@ -6,6 +6,10 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     shlink.vollminlab.com/slug: sabnzbd
   labels:
     app: sabnzbd

--- a/clusters/vollminlab-cluster/mediastack/sonarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sonarr/app/configmap.yaml
@@ -33,6 +33,8 @@ data:
       app: sonarr
       env: production
       category: media
+    env:
+      SONARR__AUTH__METHOD: "External"
     securityContext:
       runAsUser: 568
       runAsGroup: 568

--- a/clusters/vollminlab-cluster/mediastack/sonarr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sonarr/app/ingress.yaml
@@ -6,6 +6,10 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     shlink.vollminlab.com/slug: sonarr
   labels:
     app: sonarr

--- a/clusters/vollminlab-cluster/mediastack/tautulli/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/tautulli/app/ingress.yaml
@@ -6,6 +6,10 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     shlink.vollminlab.com/slug: tautulli
   labels:
     app: tautulli

--- a/clusters/vollminlab-cluster/shlink/shlink-web/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink-web/app/ingress.yaml
@@ -9,6 +9,10 @@ metadata:
     category: apps
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     shlink.vollminlab.com/slug: shlink
 spec:
   ingressClassName: nginx


### PR DESCRIPTION
## Summary
- Forward-auth annotations added to all 10 non-OIDC services: Longhorn, Homepage, Radarr, Sonarr, Bazarr, Prowlarr, SABnzbd, Tautulli, Shlink Web, Policy Reporter
- Per-app auth disabled for arr stack (Radarr, Sonarr, Prowlarr via `AUTH__METHOD=External`; Bazarr via empty credentials) and SABnzbd (empty username/password)
- Homepage, Tautulli, Shlink Web, Policy Reporter have no built-in auth — forward-auth is the sole gate
- Shlink API ingress (`vollm.in`, `go.vollminlab.com`) intentionally untouched — auth would break link resolution
- Authentik UI prerequisite completed out-of-band: 10 portal applications created via API with walkxcode dashboard icons; domain-level forward-auth provider verified active

Phase 4 of 4 — Authentik rollout complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)