### PR TITLE
fix: route /outpost.goauthentik.io through nginx to authentik-proxy

### DIFF
--- a/clusters/vollminlab-cluster/authentik/authentik/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/authentik/authentik/app/ingress.yaml
@@ -17,6 +17,13 @@ spec:
     - host: authentik.vollminlab.com
       http:
         paths:
+          - path: /outpost.goauthentik.io
+            pathType: Prefix
+            backend:
+              service:
+                name: authentik-proxy
+                port:
+                  number: 9000
           - path: /
             pathType: Prefix
             backend:


### PR DESCRIPTION
## Summary
- Forward-auth redirects to `authentik.vollminlab.com/outpost.goauthentik.io/start?rd=...` were returning "Not Found" because the Authentik ingress routed all traffic to `authentik-server`
- Add `/outpost.goauthentik.io` path (higher specificity than `/`) routing to `authentik-proxy:9000` so nginx correctly delivers those requests to the outpost

🤖 Generated with [Claude Code](https://claude.com/claude-code)