### PR TITLE
fix: set AUTHENTIK_HOST_BROWSER on proxy outpost to public URL

### DIFF
--- a/clusters/vollminlab-cluster/authentik/authentik-proxy/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/authentik/authentik-proxy/app/deployment.yaml
@@ -25,6 +25,8 @@ spec:
           env:
             - name: AUTHENTIK_HOST
               value: http://authentik-server.authentik.svc.cluster.local:80
+            - name: AUTHENTIK_HOST_BROWSER
+              value: https://authentik.vollminlab.com
             - name: AUTHENTIK_INSECURE
               value: "true"
             - name: AUTHENTIK_TOKEN


### PR DESCRIPTION
## Summary
- Forward-auth redirects were sending browsers to `authentik-server.authentik.svc.cluster.local` (internal Kubernetes DNS, unresolvable by browsers)
- Root cause: `AUTHENTIK_HOST_BROWSER` was unset, so the outpost used `AUTHENTIK_HOST` (the internal service URL) for both backend API calls and browser-facing login redirects
- Fix: add `AUTHENTIK_HOST_BROWSER: https://authentik.vollminlab.com` — backend traffic stays on the internal path, browser redirects use the public hostname

🤖 Generated with [Claude Code](https://claude.com/claude-code)