### PR TITLE
fix(monitoring): add Authentik forward-auth to Prometheus and Alertmanager ingresses

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/ingress.yaml
@@ -39,6 +39,10 @@ metadata:
     category: observability
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     shlink.vollminlab.com/slug: prometheus
 spec:
   ingressClassName: nginx
@@ -69,6 +73,10 @@ metadata:
     category: observability
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     shlink.vollminlab.com/slug: alertmanager
 spec:
   ingressClassName: nginx


### PR DESCRIPTION
## Summary

- Adds Authentik proxy forward-auth to `prometheus-ingress` and `alertmanager-ingress`
- Grafana is intentionally excluded — it already has native Authentik OIDC configured
- Uses the same annotation pattern as the rest of the forward-auth sweep (PR #516)

🤖 Generated with [Claude Code](https://claude.com/claude-code)