### PR TITLE
fix(flux): add dependsOn sealed-secrets to all SealedSecret-using kustomizations

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/actions-runner-system-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/actions-runner-system-kustomization.yaml
@@ -16,3 +16,5 @@ spec:
     name: flux-system
   targetNamespace: actions-runner-system
   timeout: 2m
+  dependsOn:
+    - name: sealed-secrets

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/authentik-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/authentik-kustomization.yaml
@@ -16,3 +16,4 @@ spec:
     name: flux-system
   dependsOn:
     - name: cnpg-system
+    - name: sealed-secrets

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/dmz-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/dmz-kustomization.yaml
@@ -16,3 +16,5 @@ spec:
     name: flux-system
   wait: true
   timeout: 5m
+  dependsOn:
+    - name: sealed-secrets

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/external-dns-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/external-dns-kustomization.yaml
@@ -21,3 +21,5 @@ spec:
       kind: Deployment
       name: external-dns
       namespace: external-dns
+  dependsOn:
+    - name: sealed-secrets

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/harbor-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/harbor-kustomization.yaml
@@ -18,3 +18,4 @@ spec:
   dependsOn:
     - name: cnpg-system
     - name: longhorn-system
+    - name: sealed-secrets

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/headlamp-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/headlamp-kustomization.yaml
@@ -16,3 +16,5 @@ spec:
     name: flux-system
   targetNamespace: flux-system
   timeout: 2m
+  dependsOn:
+    - name: sealed-secrets

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/homepage-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/homepage-kustomization.yaml
@@ -16,3 +16,5 @@ spec:
     name: flux-system
   targetNamespace: homepage
   timeout: 2m
+  dependsOn:
+    - name: sealed-secrets

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/mediastack-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/mediastack-kustomization.yaml
@@ -16,3 +16,5 @@ spec:
     name: flux-system
   targetNamespace: mediastack
   timeout: 2m
+  dependsOn:
+    - name: sealed-secrets

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/minio-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/minio-kustomization.yaml
@@ -15,3 +15,5 @@ spec:
     kind: GitRepository
     name: flux-system
   timeout: 10m
+  dependsOn:
+    - name: sealed-secrets

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/monitoring-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/monitoring-kustomization.yaml
@@ -16,3 +16,5 @@ spec:
     name: flux-system
   targetNamespace: monitoring
   timeout: 2m
+  dependsOn:
+    - name: sealed-secrets

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/shlink-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/shlink-kustomization.yaml
@@ -17,3 +17,4 @@ spec:
   timeout: 10m
   dependsOn:
     - name: cnpg-system
+    - name: sealed-secrets

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/velero-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/velero-kustomization.yaml
@@ -17,3 +17,4 @@ spec:
   timeout: 10m
   dependsOn:
     - name: minio
+    - name: sealed-secrets


### PR DESCRIPTION
## Summary

Sweeps all Flux Kustomization CRs that contain SealedSecret resources and adds `dependsOn: - name: sealed-secrets` to prevent a cold-boot/DR race condition where Flux tries to apply SealedSecrets before the sealed-secrets controller is healthy.

**12 kustomizations updated:** actions-runner-system, authentik, dmz, external-dns, harbor, headlamp, homepage, mediastack, minio, monitoring, shlink, velero

`actions-runner-system-runners` is excluded — it already depends on `actions-runner-system` which now carries the sealed-secrets dependency transitively.

This is a no-op on the live cluster (sealed-secrets is always healthy). Only matters on a fresh bootstrap or DR rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)