### PR TITLE
fix: correct Seerr ingress service name to seerr-seerr-chart

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/seerr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/seerr/app/ingress.yaml
@@ -26,7 +26,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: seerr
+                name: seerr-seerr-chart
                 port:
                   number: 80
   tls:


### PR DESCRIPTION
## Summary
- Seerr was returning 503 because the ingress backend pointed to service `seerr` which does not exist
- The chart (seerr-chart) creates a service named `seerr-seerr-chart` — update ingress to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)