### PR TITLE
fix(jellystat): correct CNPG initdb database name to jfstat

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/jellystat-db/app/cluster.yaml
+++ b/clusters/vollminlab-cluster/mediastack/jellystat-db/app/cluster.yaml
@@ -19,7 +19,7 @@ spec:
     storageClass: longhorn
   bootstrap:
     initdb:
-      database: jellystat
+      database: jfstat
       owner: jellystat
       secret:
         name: jellystat-db-credentials


### PR DESCRIPTION
## Summary

- Jellystat hardcodes `POSTGRES_DB=jfstat` (the app default); the CNPG cluster was bootstrapped with `database: jellystat`, causing Jellystat to crash on startup with `database "jfstat" does not exist`
- The `jfstat` database was created as a manual hotfix (`CREATE DATABASE jfstat OWNER jellystat` + schema grants) so Jellystat is currently running
- This corrects the bootstrap config so any future cluster re-initialization produces the correct database name

🤖 Generated with [Claude Code](https://claude.com/claude-code)