### PR TITLE
fix: use internal DNS for jellystat widget URL

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -44,7 +44,7 @@ data:
                 app: jellystat
                 widget:
                   type: jellystat
-                  url: https://jellystat.vollminlab.com
+                  url: http://jellystat.mediastack.svc.cluster.local:3000
                   key: "{{HOMEPAGE_VAR_JELLYSTAT_API_KEY}}"
             - Sonarr:
                 description: TV show collection manager


### PR DESCRIPTION
## Summary

- Jellystat widget `url` was pointing at the external HTTPS ingress, which routes through Authentik forward-auth and returns an HTML login page instead of JSON
- Changed to `http://jellystat.mediastack.svc.cluster.local:3000` (same pattern as all other media stack widgets)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)