### PR TITLE
fix(authentik): switch Prometheus and Alertmanager to forward_domain

### DIFF
--- a/.claude/rules/authentik-akshell.md
+++ b/.claude/rules/authentik-akshell.md
@@ -28,12 +28,13 @@ The Authentik outpost (2026.2.2+) uses `X-Forwarded-Host` to match the incoming 
 
 ## Architecture: how forward-auth works here
 
-- **`vollminlab-forward-auth`** — a single `forward_domain` ProxyProvider covering all `*.vollminlab.com`. Assigned to the `vollminlab-proxy` outpost alongside `Prometheus` and `Alertmanager` (which use `forward_single`).
+- **`vollminlab-forward-auth`** — a single `forward_domain` ProxyProvider covering all `*.vollminlab.com`. The only provider assigned to the `vollminlab-proxy` outpost.
 - **Critical**: `external_host` for this provider must be `https://authentik.vollminlab.com`. This controls the OAuth2 callback URL (`https://authentik.vollminlab.com/outpost.goauthentik.io/callback`), which already has an ingress. Do NOT set it to the root domain (`vollminlab.com`) — that domain has no ingress and no TLS cert, so the OAuth2 callback would be unreachable.
 - **Domain matching uses `cookie_domain`, not `external_host`**: The outpost matches `*.vollminlab.com` requests because `cookie_domain=vollminlab.com`. Changing `external_host` to `vollminlab.com` is wrong and breaks OAuth2 callbacks.
 - Every host protected by Authentik nginx annotations **must have an Application entry** in Authentik, even if that Application has `provider_id=None`. Without it the outpost returns 400 → nginx converts to 500.
 - Applications using native SSO (Grafana, Harbor, Headlamp, Jellyfin, MinIO, Portainer, Audiobookshelf) have dedicated OAuth2/OIDC providers (`provider_id != None`).
-- Applications using forward-proxy auth only (Bazarr, Homepage, Longhorn, Policy Reporter, Prowlarr, Radarr, SABnzbd, Shlink, Sonarr, Seerr, Tautulli) have `provider_id=None` — they rely on the domain-wide `vollminlab-forward-auth`.
+- Applications using forward-proxy auth only (Alertmanager, Bazarr, Homepage, Longhorn, Policy Reporter, Prometheus, Prowlarr, Radarr, SABnzbd, Shlink, Sonarr, Seerr, Tautulli) have `provider_id=None` — they rely on the domain-wide `vollminlab-forward-auth`.
+- **Never use `forward_single` ProxyProviders for services behind nginx forward-auth.** The OAuth callback URL (`https://<service>/outpost.goauthentik.io/callback`) hits the auth-annotated ingress, nginx tries to authenticate the callback, gets 401, and loops. Stick to `forward_domain` (`vollminlab-forward-auth`) for all nginx forward-auth services.
 
 ## Known limitation: skip_path_regex does not work for forward-auth
 


### PR DESCRIPTION
## Summary

- Removed `forward_single` ProxyProviders for Prometheus and Alertmanager from the `vollminlab-proxy` outpost via akshell
- Set both Application `provider_id` to `None` — they now rely on `vollminlab-forward-auth` (`forward_domain`, `*.vollminlab.com`)
- Documents the `forward_single` restriction in `authentik-akshell.md` to prevent recurrence

## Root cause

`forward_single` providers set `external_host` to the service URL (e.g. `https://prometheus.vollminlab.com`). After login, Authentik redirects the OAuth2 callback to `https://prometheus.vollminlab.com/outpost.goauthentik.io/callback`. That URL hits the auth-annotated ingress, nginx tries to authenticate the callback request, gets 401, and redirects back to auth-signin — infinite loop.

The `forward_domain` provider's callback goes to `authentik.vollminlab.com/outpost.goauthentik.io/callback` which is already correctly routed to `authentik-proxy:9000` without auth annotations.

## Live fix

Applied via akshell before this PR — outpost has already reconciled and is loading only `vollminlab-forward-auth`. Prometheus and Alertmanager are accessible without looping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)