### PR TITLE
chore(homepage): fix layout — column counts and split Tools group

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -163,7 +163,7 @@ data:
                 icon: prometheus.png
                 namespace: monitoring
                 app: prometheus
-        - Documentation & Tools:
+        - Tools:
             - Homepage:
                 description: This dashboard
                 href: https://homepage.vollminlab.com
@@ -186,6 +186,7 @@ data:
                 description: This Kubernetes cluster repo
                 href: https://github.com/vollminlab/k8s-vollminlab-cluster
                 icon: github.png
+        - Web Links:
             - ChatGPT:
                 description: AI Assistant
                 href: https://chatgpt.com
@@ -229,6 +230,28 @@ data:
         title: "VollminLab Dashboard"
         subtitle: "HomeLab Services & Infrastructure"
         logo: null
+        layout:
+          Media Stack:
+            style: row
+            columns: 3
+          Infrastructure:
+            style: row
+            columns: 3
+          Networking:
+            style: row
+            columns: 5
+          Monitoring & Observability:
+            style: row
+            columns: 3
+          Tools:
+            style: row
+            columns: 4
+          Web Links:
+            style: row
+            columns: 4
+          Personal/External:
+            style: row
+            columns: 5
         providers:
           longhorn:
             url: https://longhorn.vollminlab.com


### PR DESCRIPTION
## Summary

- Adds `settings.layout` with explicit column counts per group — fixes uneven tile rows
- Splits `Documentation & Tools` into `Tools` (cluster tools) and `Web Links`

| Group | Columns | Grid |
|---|---|---|
| Media Stack | 3 | 3×3 |
| Infrastructure | 3 | 1×3 |
| Networking | 5 | 1×5 |
| Monitoring & Observability | 3 | 1×3 |
| Tools | 4 | 1×4 |
| Web Links | 4 | 1×4 |
| Personal/External | 5 | 1×5 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)