### PR TITLE
docs(roadmap): mark Phase 3.0 PKI as done

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -113,7 +113,7 @@ Cluster upgraded from Flux v2.4.0 to v2.8.6 via two hops (PRs #423, #426, #428).
 
 ### 3.0 PKI — Automated Certificate Lifecycle
 
-**Status:** `in-progress`
+**Status:** `done` — PR #540
 
 Control plane certs issued by kubeadm expire annually and require manual renewal on each control plane node. This became an incident on 2026-04-14 when all certs expired simultaneously.
 


### PR DESCRIPTION
Marks Phase 3.0 as `done` following the merge of PR #540 (automated control plane cert monitoring and renewal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)