### PR TITLE
fix(homepage): polish layout and fix MinIO NOT FOUND badge

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -117,6 +117,17 @@ data:
                   username: "{{HOMEPAGE_VAR_TRUENAS_USERNAME}}"
                   password: "{{HOMEPAGE_VAR_TRUENAS_PASSWORD}}"
                   enablePools: true
+            - Authentik:
+                description: Identity provider and SSO
+                href: https://authentik.vollminlab.com/if/admin/
+                icon: authentik.png
+                namespace: authentik
+                app: authentik
+                widget:
+                  type: authentik
+                  url: http://authentik-server.authentik.svc.cluster.local
+                  key: "{{HOMEPAGE_VAR_AUTHENTIK_API_KEY}}"
+                  version: 2
             - vCenter:
                 description: VMware vCenter Server
                 href: https://vcenter.vollminlab.com
@@ -140,17 +151,6 @@ data:
                 icon: minio.png
                 namespace: minio
                 app: minio
-            - Authentik:
-                description: Identity provider and SSO
-                href: https://authentik.vollminlab.com/if/admin/
-                icon: authentik.png
-                namespace: authentik
-                app: authentik
-                widget:
-                  type: authentik
-                  url: http://authentik-server.authentik.svc.cluster.local
-                  key: "{{HOMEPAGE_VAR_AUTHENTIK_API_KEY}}"
-                  version: 2
             - Longhorn:
                 description: Kubernetes storage management
                 href: https://longhorn.vollminlab.com
@@ -274,7 +274,7 @@ data:
                 description: Package manager community
                 href: https://community.chocolatey.org
                 icon: mdi-package-variant
-        - Personal/External:
+        - Personal:
             - Yahoo Fantasy Football:
                 description: Yahoo Fantasy Football
                 href: https://football.fantasysports.yahoo.com/
@@ -320,7 +320,7 @@ data:
           Web Links:
             style: row
             columns: 4
-          Personal/External:
+          Personal:
             style: row
             columns: 5
         providers:

--- a/clusters/vollminlab-cluster/minio/minio/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/minio/minio/app/configmap.yaml
@@ -14,6 +14,7 @@ data:
     existingSecret: "minio-credentials"
 
     podLabels:
+      app.kubernetes.io/name: minio
       env: production
       category: storage
 


### PR DESCRIPTION
## Summary

- **MinIO NOT FOUND badge**: Homepage's Kubernetes status service queries by `app.kubernetes.io/name`, but MinIO pods only had `app=minio`. Added `app.kubernetes.io/name: minio` to the MinIO pod labels so the badge now resolves correctly.
- **Infrastructure layout**: Moved Authentik (tall widget card) to position 2, directly after TrueNAS (also a tall widget card). Both land in grid row 1, leaving row 2 as three uniform short cards (Harbor, MinIO, Longhorn) — no more height mismatch between rows.
- **Section rename**: "Personal/External" → "Personal" for cleaner display (removes the slash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)