### PR TITLE
feat(tofu): manage Authentik users in Terraform, add gkroner to groups

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -129,18 +129,18 @@ Control plane certs issued by kubeadm expire annually and require manual renewal
 
 ### 3.1 Authentik — SSO / Identity Provider
 
-**Status:** `in-progress` — design complete, implementation plan ready
+**Status:** `in-progress` — phases 1–5b complete, 5c and 6 remaining
 
-Design doc: `docs/authentik-design.md`. Implementation plan: `docs/superpowers/plans/authentik.md` (local).
+Design doc: `docs/authentik-design.md`.
 
-Four-phase rollout:
-
-- Phase 1: Core infra — shared Redis (`redis` ns), CNPG Cluster CR, Authentik server+worker, cloudflared tunnel for `auth.vollminlab.com`
-- Phase 2: External proxy outpost + Jellyseerr (replaces Overseerr) + Jellyfin OIDC
-- Phase 3: Native OIDC — Grafana, Harbor, Headlamp, Portainer, Audiobookshelf, MinIO
-- Phase 4: Forward-auth sweep — Longhorn, Homepage, arr stack, Tautulli, Shlink Web, Policy Reporter
-
-Plex → Jellyfin migration is part of Phase 2 (Jellyseerr replaces Overseerr; Plex decommissioned after Jellyfin stable).
+- **Phase 1** `done` — Core infra: shared Redis (`redis` ns), CNPG Cluster CR, Authentik server+worker, cloudflared tunnel for `auth.vollminlab.com`
+- **Phase 2** `done` — External proxy outpost + Jellyseerr (replaces Overseerr) + Jellyfin OIDC. Plex decommissioned; Jellyfin stable.
+- **Phase 3** `done` — Native OIDC: Grafana, Harbor, Headlamp, Portainer, Audiobookshelf, MinIO
+- **Phase 4** `done` — Forward-auth sweep: Longhorn, Homepage, arr stack, Tautulli, Shlink Web, Policy Reporter
+- **Phase 5a** `done` — tofu-controller deployed in `tofu` ns; MinIO `terraform-state` bucket + scoped IAM user (PRs #539)
+- **Phase 5b** `done` — Full Authentik config under OpenTofu IaC: groups, users, OAuth2/proxy providers, scope mappings, applications, outpost, Portainer OAuth settings. All existing objects imported into state. Client secrets sealed. (PRs #542, #546)
+- **Phase 5c** `planned` — Extend IaC to MinIO (buckets, IAM), Harbor (OIDC, projects, robot accounts), and Grafana (OAuth, notification policies, contact points). Add `terraform fmt` + `tofu validate` CI workflow for `terraform/` PRs (self-hosted provider handling required for `portainer/portainer`).
+- **Phase 6** `planned` — NPM-proxied external services via Authentik `auth_request`: Pi-hole, TrueNAS, HAProxy, NPM itself. vCenter via native OIDC.
 
 ---
 

--- a/terraform/authentik/data.tf
+++ b/terraform/authentik/data.tf
@@ -22,10 +22,3 @@ data "authentik_property_mapping_provider_scope" "offline_access" {
   managed = "goauthentik.io/providers/oauth2/scope-offline_access"
 }
 
-data "authentik_user" "vollmin" {
-  username = "vollmin"
-}
-
-data "authentik_user" "jvollmin" {
-  username = "jvollmin"
-}

--- a/terraform/authentik/groups.tf
+++ b/terraform/authentik/groups.tf
@@ -1,44 +1,44 @@
 resource "authentik_group" "audiobookshelf_admins" {
   name  = "Audiobookshelf Admins"
-  users = [data.authentik_user.vollmin.id]
+  users = [authentik_user.vollmin.id]
 }
 
 resource "authentik_group" "audiobookshelf_users" {
   name  = "Audiobookshelf Users"
-  users = [data.authentik_user.jvollmin.id]
+  users = toset([authentik_user.jvollmin.id, authentik_user.gkroner.id])
 }
 
 resource "authentik_group" "grafana_admins" {
   name  = "Grafana Admins"
-  users = [data.authentik_user.vollmin.id]
+  users = [authentik_user.vollmin.id]
 }
 
 resource "authentik_group" "harbor_admins" {
   name  = "Harbor Admins"
-  users = [data.authentik_user.vollmin.id]
+  users = [authentik_user.vollmin.id]
 }
 
 resource "authentik_group" "headlamp_admins" {
   name  = "Headlamp Admins"
-  users = [data.authentik_user.vollmin.id]
+  users = [authentik_user.vollmin.id]
 }
 
 resource "authentik_group" "jellyfin_admins" {
   name  = "Jellyfin Admins"
-  users = [data.authentik_user.vollmin.id]
+  users = [authentik_user.vollmin.id]
 }
 
 resource "authentik_group" "jellyfin_users" {
   name  = "Jellyfin Users"
-  users = toset([data.authentik_user.jvollmin.id, data.authentik_user.vollmin.id])
+  users = toset([authentik_user.jvollmin.id, authentik_user.vollmin.id, authentik_user.gkroner.id])
 }
 
 resource "authentik_group" "minio_admins" {
   name  = "MinIO Admins"
-  users = [data.authentik_user.vollmin.id]
+  users = [authentik_user.vollmin.id]
 }
 
 resource "authentik_group" "portainer_admins" {
   name  = "Portainer Admins"
-  users = [data.authentik_user.vollmin.id]
+  users = [authentik_user.vollmin.id]
 }

--- a/terraform/authentik/imports.tf
+++ b/terraform/authentik/imports.tf
@@ -1,3 +1,19 @@
+# Users
+import {
+  to = authentik_user.vollmin
+  id = "8"
+}
+
+import {
+  to = authentik_user.jvollmin
+  id = "9"
+}
+
+import {
+  to = authentik_user.gkroner
+  id = "11"
+}
+
 # Groups
 import {
   to = authentik_group.audiobookshelf_admins

--- a/terraform/authentik/users.tf
+++ b/terraform/authentik/users.tf
@@ -5,7 +5,9 @@ resource "authentik_user" "vollmin" {
   is_active = true
 
   lifecycle {
-    ignore_changes = [password]
+    # password: users set their own via Authentik's reset flow, Terraform never touches it
+    # groups: managed from the authentik_group side; ignore here to avoid conflict
+    ignore_changes = [password, groups]
   }
 }
 
@@ -16,7 +18,7 @@ resource "authentik_user" "jvollmin" {
   is_active = true
 
   lifecycle {
-    ignore_changes = [password]
+    ignore_changes = [password, groups]
   }
 }
 
@@ -27,6 +29,6 @@ resource "authentik_user" "gkroner" {
   is_active = true
 
   lifecycle {
-    ignore_changes = [password]
+    ignore_changes = [password, groups]
   }
 }

--- a/terraform/authentik/users.tf
+++ b/terraform/authentik/users.tf
@@ -1,0 +1,32 @@
+resource "authentik_user" "vollmin" {
+  username  = "vollmin"
+  name      = "Scott Vollmin"
+  email     = "scottvollmin@gmail.com"
+  is_active = true
+
+  lifecycle {
+    ignore_changes = [password]
+  }
+}
+
+resource "authentik_user" "jvollmin" {
+  username  = "jvollmin"
+  name      = "Justin Vollmin"
+  email     = "vollmi91@gmail.com"
+  is_active = true
+
+  lifecycle {
+    ignore_changes = [password]
+  }
+}
+
+resource "authentik_user" "gkroner" {
+  username  = "gkroner"
+  name      = "Garrett Kroner"
+  email     = "gkroner@gmail.com"
+  is_active = true
+
+  lifecycle {
+    ignore_changes = [password]
+  }
+}


### PR DESCRIPTION
## Summary

- Converts existing users from `data` sources to managed `authentik_user` resources — user accounts are now DR-safe
- Adds a new user to **Jellyfin Users** and **Audiobookshelf Users**
- Passwords are excluded via `lifecycle { ignore_changes = [password] }` — Terraform never touches existing passwords; new users set their own via Authentik's password-reset flow
- Group memberships excluded via `ignore_changes = [groups]` on the user resource — memberships are managed declaratively from the `authentik_group` side
- Adds import blocks for all three users

## Why this matters

Previously, group memberships were managed in Terraform but user accounts were only referenced as data sources. Any UI-added group membership was reverted on the next 10-minute reconciliation cycle. This PR makes the full picture consistent: accounts + memberships both declared in git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)