### PR TITLE
fix(tofu): allow tofu runner pods to reach flux-system source-controller

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/allow-tofu-source-controller-networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/flux-system/allow-tofu-source-controller-networkpolicy.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-tofu-source-controller
+  namespace: flux-system
+  labels:
+    app: flux
+    env: production
+    category: core
+spec:
+  podSelector:
+    matchLabels:
+      app: source-controller
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: tofu
+      ports:
+        - protocol: TCP
+          port: 80

--- a/clusters/vollminlab-cluster/flux-system/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
   - gotk-components.yaml
   - gotk-sync.yaml
   - flux-system-sealedsecret.yaml
+  - allow-tofu-source-controller-networkpolicy.yaml
   - ./repositories
   - ./flux-kustomizations


### PR DESCRIPTION
## Summary

- Adds a `NetworkPolicy` in `flux-system` allowing ingress from the `tofu` namespace to `source-controller` on port 80
- The existing `allow-egress` policy in `flux-system` only permits ingress from within the same namespace — tofu runner pods were timing out trying to download git artifacts

## Root cause

tofu-controller spins up a runner pod in the `tofu` namespace to execute Terraform. The runner downloads the git source artifact from `source-controller.flux-system.svc.cluster.local:80`. The `flux-system` NetworkPolicy blocks all cross-namespace ingress, causing `i/o timeout` after 10 retries.

The new policy is scoped tightly: only `source-controller` pods, only from the `tofu` namespace, only port 80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)