### PR TITLE
fix(tofu): broaden flux-system NetworkPolicy to allow tofu namespace ingress

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/allow-tofu-source-controller-networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/flux-system/allow-tofu-source-controller-networkpolicy.yaml
@@ -8,9 +8,7 @@ metadata:
     env: production
     category: core
 spec:
-  podSelector:
-    matchLabels:
-      app: source-controller
+  podSelector: {}
   policyTypes:
     - Ingress
   ingress:
@@ -18,6 +16,3 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: tofu
-      ports:
-        - protocol: TCP
-          port: 80

--- a/clusters/vollminlab-cluster/flux-system/allow-tofu-source-controller-networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/flux-system/allow-tofu-source-controller-networkpolicy.yaml
@@ -8,7 +8,9 @@ metadata:
     env: production
     category: core
 spec:
-  podSelector: {}
+  podSelector:
+    matchLabels:
+      app: source-controller
   policyTypes:
     - Ingress
   ingress:
@@ -16,3 +18,6 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: tofu
+      ports:
+        - protocol: TCP
+          port: 9090


### PR DESCRIPTION
## Summary

- Fixes the `allow-tofu-source-controller` NetworkPolicy in `flux-system` to use the correct container port (`9090`) instead of the service port (`80`)
- Restores the least-privilege selector: targets only `app: source-controller` pods on port 9090

## Root cause

NetworkPolicy `ports` fields match on **container ports**, not service ports. The `source-controller` service maps `:80` → container `:9090` (named `http`). The original policy from PR #548 specified `port: 80`, which matched no container, so Calico correctly evaluated it and allowed nothing — causing `i/o timeout` from tofu runner pods.

Verified working: curl from a tofu-namespace pod to `source-controller.flux-system.svc.cluster.local` returns 200 with the targeted policy applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)