### PR TITLE
fix(tofu): remove invalid client_secret lifecycle ignore from proxy provider

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'clusters/**'
       - 'bootstrap/**'
+      - 'terraform/**'
       - '.github/workflows/**'
       - '.vscode/**'
       - 'scripts/**'
@@ -21,6 +22,7 @@ on:
     paths:
       - 'clusters/**'
       - 'bootstrap/**'
+      - 'terraform/**'
       - '.github/workflows/**'
       - '.vscode/**'
       - 'scripts/**'

--- a/terraform/authentik/data.tf
+++ b/terraform/authentik/data.tf
@@ -2,6 +2,10 @@ data "authentik_flow" "default_authorization_implicit" {
   slug = "default-provider-authorization-implicit-consent"
 }
 
+data "authentik_flow" "default_provider_invalidation" {
+  slug = "default-provider-invalidation-flow"
+}
+
 data "authentik_certificate_key_pair" "self_signed" {
   name = "authentik Self-signed Certificate"
 }

--- a/terraform/authentik/providers.tf
+++ b/terraform/authentik/providers.tf
@@ -4,7 +4,7 @@ provider "authentik" {
 }
 
 provider "portainer" {
-  endpoint = "https://portainer.vollminlab.com/api"
-  username = "vollmin"
-  password = var.portainer_password
+  endpoint     = "https://portainer.vollminlab.com/api"
+  api_user     = "vollmin"
+  api_password = var.portainer_password
 }

--- a/terraform/authentik/providers_oauth2.tf
+++ b/terraform/authentik/providers_oauth2.tf
@@ -11,10 +11,11 @@ resource "authentik_provider_oauth2" "grafana" {
   client_id          = "rArLch2402M3G4HWq4eqmyt0B2EThCIyX5M6CHFG" # gitleaks:allow
   client_secret      = var.grafana_client_secret
   authorization_flow = data.authentik_flow.default_authorization_implicit.id
+  invalidation_flow  = data.authentik_flow.default_provider_invalidation.id
   signing_key        = data.authentik_certificate_key_pair.self_signed.id
   sub_mode           = "hashed_user_id"
 
-  redirect_uris = [
+  allowed_redirect_uris = [
     {
       matching_mode = "strict"
       url           = "https://grafana.vollminlab.com/login/generic_oauth"
@@ -31,10 +32,11 @@ resource "authentik_provider_oauth2" "headlamp" {
   client_id          = "cUhVNsmF0sJ3RvXKAxlfBXTndNHXhV7HbyPjjQYm" # gitleaks:allow
   client_secret      = var.headlamp_client_secret
   authorization_flow = data.authentik_flow.default_authorization_implicit.id
+  invalidation_flow  = data.authentik_flow.default_provider_invalidation.id
   signing_key        = data.authentik_certificate_key_pair.self_signed.id
   sub_mode           = "hashed_user_id"
 
-  redirect_uris = [
+  allowed_redirect_uris = [
     {
       matching_mode = "strict"
       url           = "https://headlamp.vollminlab.com/oidc-callback"
@@ -52,10 +54,11 @@ resource "authentik_provider_oauth2" "minio" {
   client_id          = "GKq5oNsz9lgsa1kIOCM7uTa4qIBVe6SUsfVjeFCN" # gitleaks:allow
   client_secret      = var.minio_client_secret
   authorization_flow = data.authentik_flow.default_authorization_implicit.id
+  invalidation_flow  = data.authentik_flow.default_provider_invalidation.id
   signing_key        = data.authentik_certificate_key_pair.self_signed.id
   sub_mode           = "hashed_user_id"
 
-  redirect_uris = [
+  allowed_redirect_uris = [
     {
       matching_mode = "strict"
       url           = "https://minio.vollminlab.com/oauth_callback"
@@ -72,10 +75,11 @@ resource "authentik_provider_oauth2" "jellyfin" {
   client_id          = "OTxNz2JtIupVY33uMgUm6qw68r3hRaYiCzbDfa53" # gitleaks:allow
   client_secret      = var.jellyfin_client_secret
   authorization_flow = data.authentik_flow.default_authorization_implicit.id
+  invalidation_flow  = data.authentik_flow.default_provider_invalidation.id
   signing_key        = data.authentik_certificate_key_pair.self_signed.id
   sub_mode           = "hashed_user_id"
 
-  redirect_uris = [
+  allowed_redirect_uris = [
     {
       matching_mode = "strict"
       url           = "https://jellyfin.vollminlab.com/sso/OID/redirect/authentik"
@@ -92,10 +96,11 @@ resource "authentik_provider_oauth2" "harbor" {
   client_id          = "61knXoFusnE1LOVJLSSRZkLtnLFak5NylhhOxDBx" # gitleaks:allow
   client_secret      = var.harbor_client_secret
   authorization_flow = data.authentik_flow.default_authorization_implicit.id
+  invalidation_flow  = data.authentik_flow.default_provider_invalidation.id
   signing_key        = data.authentik_certificate_key_pair.self_signed.id
   sub_mode           = "hashed_user_id"
 
-  redirect_uris = [
+  allowed_redirect_uris = [
     {
       matching_mode = "strict"
       url           = "https://harbor.vollminlab.com/c/oidc/callback"
@@ -112,10 +117,11 @@ resource "authentik_provider_oauth2" "portainer" {
   client_id          = "f7hkfRgncvwxtWo1BwLl86FQo8i3GEJo7dTJhpSi" # gitleaks:allow
   client_secret      = var.portainer_client_secret
   authorization_flow = data.authentik_flow.default_authorization_implicit.id
+  invalidation_flow  = data.authentik_flow.default_provider_invalidation.id
   signing_key        = data.authentik_certificate_key_pair.self_signed.id
   sub_mode           = "hashed_user_id"
 
-  redirect_uris = [
+  allowed_redirect_uris = [
     {
       matching_mode = "strict"
       url           = "https://portainer.vollminlab.com"
@@ -132,10 +138,11 @@ resource "authentik_provider_oauth2" "audiobookshelf" {
   client_id          = "8FBzOT0SL5Kz1brCSW25Uuyr71TvQYvvfsBA9f7I" # gitleaks:allow
   client_secret      = var.audiobookshelf_client_secret
   authorization_flow = data.authentik_flow.default_authorization_implicit.id
+  invalidation_flow  = data.authentik_flow.default_provider_invalidation.id
   signing_key        = data.authentik_certificate_key_pair.self_signed.id
   sub_mode           = "hashed_user_id"
 
-  redirect_uris = [
+  allowed_redirect_uris = [
     {
       matching_mode = "strict"
       url           = "https://audiobookshelf.vollminlab.com/auth/openid/callback"

--- a/terraform/authentik/providers_proxy.tf
+++ b/terraform/authentik/providers_proxy.tf
@@ -2,6 +2,7 @@ resource "authentik_provider_proxy" "vollminlab_forward_auth" {
   name               = "vollminlab-forward-auth"
   external_host      = "https://authentik.vollminlab.com"
   authorization_flow = data.authentik_flow.default_authorization_implicit.id
+  invalidation_flow  = data.authentik_flow.default_provider_invalidation.id
   mode               = "forward_domain"
   cookie_domain      = "vollminlab.com"
 

--- a/terraform/authentik/providers_proxy.tf
+++ b/terraform/authentik/providers_proxy.tf
@@ -6,7 +6,4 @@ resource "authentik_provider_proxy" "vollminlab_forward_auth" {
   mode               = "forward_domain"
   cookie_domain      = "vollminlab.com"
 
-  lifecycle {
-    ignore_changes = [client_secret]
-  }
 }


### PR DESCRIPTION
## Summary

- Removes `lifecycle { ignore_changes = [client_secret] }` from `authentik_provider_proxy.vollminlab_forward_auth`
- `client_secret` is not an attribute on `authentik_provider_proxy` in 2026.2.x — the lifecycle block was a stale carry-over that now causes a plan error

Follow-up to #550.

🤖 Generated with [Claude Code](https://claude.com/claude-code)