### PR TITLE
fix(velero): reduce MinIO daily TTL to 14d, extend B2 to 90d, add monthly 1-year snapshots; expand MinIO PVC to 75Gi

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -110,7 +110,7 @@ data:
         schedule: "0 2 * * *"
         useOwnerReferencesInBackup: false
         template:
-          ttl: 720h
+          ttl: 336h
           storageLocation: minio
           defaultVolumesToFsBackup: true
           excludedNamespaces:

--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -125,7 +125,22 @@ data:
         schedule: "0 4 * * *"
         useOwnerReferencesInBackup: false
         template:
-          ttl: 720h
+          ttl: 2160h
+          storageLocation: b2
+          defaultVolumesToFsBackup: true
+          excludedNamespaces:
+            - minio
+            - monitoring
+            - velero
+          resourcePolicy:
+            kind: ConfigMap
+            name: velero-skip-smb-policy
+      monthly-b2:
+        disabled: false
+        schedule: "0 6 1 * *"
+        useOwnerReferencesInBackup: false
+        template:
+          ttl: 8760h
           storageLocation: b2
           defaultVolumesToFsBackup: true
           excludedNamespaces:


### PR DESCRIPTION
## Summary

**Immediate (already applied):** MinIO PVC expanded online 60Gi → 75Gi (now at 73%, 20Gi free, down from 92%).

**Velero retention policy overhaul:**

| Schedule | Before | After | Storage |
|---|---|---|---|
| `daily-full` | 720h (30d) | 336h (14d) | MinIO |
| `daily-b2` | 720h (30d) | 2160h (90d) | Backblaze B2 |
| `monthly-b2` | *(new)* | 8760h (1yr) | Backblaze B2 |

**Root cause:** Velero daily-full was consuming 42Gi of the 54Gi used on MinIO (30 daily × ~1.4Gi each). At that rate the PVC would have filled in 3–4 days.

**Retention rationale:**
- MinIO (local) shortened to 14d — fast restores, no egress, but space-constrained
- B2 daily extended to 90d — cheap off-site storage (~$0.50/month more), broader daily coverage
- B2 monthly added at 1 year — stable restore points without storing 365 daily backups; ~17Gi steady-state on B2 (~$0.10/month)

**Longhorn note:** Worker04 physical headroom blocked expansion beyond 75Gi (100Gi was rejected by Longhorn's minimum-free-space safety check).