### PR TITLE
docs(roadmap): mark Phase 5b done, update 5c scope

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -138,8 +138,8 @@ Design doc: `docs/authentik-design.md`.
 - **Phase 3** `done` — Native OIDC: Grafana, Harbor, Headlamp, Portainer, Audiobookshelf, MinIO
 - **Phase 4** `done` — Forward-auth sweep: Longhorn, Homepage, arr stack, Tautulli, Shlink Web, Policy Reporter
 - **Phase 5a** `done` — tofu-controller deployed in `tofu` ns; MinIO `terraform-state` bucket + scoped IAM user (PRs #539)
-- **Phase 5b** `done` — Full Authentik config under OpenTofu IaC: groups, users, OAuth2/proxy providers, scope mappings, applications, outpost, Portainer OAuth settings. All existing objects imported into state. Client secrets sealed. (PRs #542, #546)
-- **Phase 5c** `planned` — Extend IaC to MinIO (buckets, IAM), Harbor (OIDC, projects, robot accounts), and Grafana (OAuth, notification policies, contact points). Add `terraform fmt` + `tofu validate` CI workflow for `terraform/` PRs (self-hosted provider handling required for `portainer/portainer`).
+- **Phase 5b** `done` — Full Authentik config under OpenTofu IaC: groups, users, OAuth2/proxy providers, scope mappings, applications, outpost, Portainer OAuth settings. All existing objects imported into state. Client secrets sealed. Post-merge fixes: cross-namespace refs (`allowCrossNamespaceRefs: true`, PR #547), flux-system NetworkPolicy for tofu→source-controller (PR #548, #549), Authentik provider 2026.2.x schema (`invalidation_flow` required, `redirect_uris`→`allowed_redirect_uris`, portainer `api_user`/`api_password`, PR #550, #551). tofu-controller reconciling cleanly. (PRs #542, #546–#551)
+- **Phase 5c** `planned` — Extend IaC to MinIO (buckets, IAM users/policies), Harbor (OIDC config, projects, robot accounts), and Grafana (OAuth, notification policies, contact points). Add `terraform fmt --check` + `tofu validate` CI workflow for `terraform/**` PRs.
 - **Phase 6** `planned` — NPM-proxied external services via Authentik `auth_request`: Pi-hole, TrueNAS, HAProxy, NPM itself. vCenter via native OIDC.
 
 ---


### PR DESCRIPTION
## Summary

- Marks Phase 5b as done with full PR list (#542, #546–551)
- Documents post-merge fixes: cross-namespace refs, NetworkPolicy (tofu→source-controller), Authentik provider 2026.2.x schema changes
- Updates Phase 5c description (removes outdated self-hosted provider note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)