### PR TITLE
fix(homepage): use direct Kyverno logo URL for Policy Reporter icon

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -201,7 +201,7 @@ data:
             - Policy Reporter:
                 description: Kubernetes policy reporting
                 href: https://policyreporter.vollminlab.com
-                icon: kyverno.png
+                icon: https://raw.githubusercontent.com/kyverno/kyverno/main/img/logo.png
                 namespace: kyverno
                 app: policy-reporter-ui
             - Grafana:


### PR DESCRIPTION
## Summary

- `kyverno.png` does not exist in the selfhst icons library, resulting in a broken image for the Policy Reporter tile
- Switched to the official Kyverno logo served directly from the Kyverno GitHub repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)