### PR TITLE
fix(homepage): replace MDI placeholders with real brand icons in personal section

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -273,12 +273,12 @@ data:
             - Chocolatey:
                 description: Package manager community
                 href: https://community.chocolatey.org
-                icon: mdi-package-variant
+                icon: si-chocolatey
         - Personal:
             - Yahoo Fantasy Football:
                 description: Yahoo Fantasy Football
                 href: https://football.fantasysports.yahoo.com/
-                icon: mdi-football
+                icon: yahoo.png
             - ESPN Fantasy Football:
                 description: ESPN Fantasy Football
                 href: https://www.espn.com/fantasy/football/
@@ -286,15 +286,15 @@ data:
             - D.E. Shaw Access:
                 description: Work access portal
                 href: https://access-cloud.deshaw.com
-                icon: mdi-briefcase
+                icon: si-citrix
             - GroupMe:
                 description: Group messaging web
                 href: https://web.groupme.com/chats
-                icon: mdi-message-text
+                icon: si-groupme
             - MakerWorld:
                 description: 3D printing community
                 href: https://makerworld.com/en
-                icon: mdi-printer-3d
+                icon: si-bambulab
       settings:
         theme: dark
         favicon: null


### PR DESCRIPTION
## Summary

- Chocolatey: `mdi-package-variant` → `si-chocolatey`
- Yahoo Fantasy Football: `mdi-football` → `yahoo.png` (selfhst)
- D.E. Shaw Access: `mdi-briefcase` → `si-citrix`
- GroupMe: `mdi-message-text` → `si-groupme`
- MakerWorld: `mdi-printer-3d` → `si-bambulab` (Bambu Lab parent brand)

ESPN has no publicly available icon; `mdi-football-helmet` retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)