### PR TITLE
fix(homepage): rename work portal service to generic label

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -283,7 +283,7 @@ data:
                 description: ESPN Fantasy Football
                 href: https://www.espn.com/fantasy/football/
                 icon: mdi-football-helmet
-            - D.E. Shaw Access:
+            - Work Portal:
                 description: Work access portal
                 href: https://access-cloud.deshaw.com
                 icon: si-citrix


### PR DESCRIPTION
## Summary

- Renames the work portal service entry to a generic label

🤖 Generated with [Claude Code](https://claude.com/claude-code)