### PR TITLE
fix(homepage): use headlamp.png icon for Headlamp

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -240,7 +240,7 @@ data:
             - Headlamp:
                 description: Kubernetes + Flux dashboard
                 href: https://headlamp.vollminlab.com
-                icon: kubernetes.png
+                icon: headlamp.png
                 namespace: flux-system
                 app: headlamp
             - Shlink:


### PR DESCRIPTION
## Summary

- Headlamp was using `kubernetes.png` as a fallback; `headlamp.png` exists in the selfhst icons library

🤖 Generated with [Claude Code](https://claude.com/claude-code)