### PR TITLE
fix(ci): correct OpenTofu install-method arg syntax

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1416,7 +1416,7 @@ jobs:
             echo "✅ OpenTofu already installed: $(tofu version | head -1)"
           else
             echo "📦 Installing OpenTofu..."
-            curl -fsSL https://get.opentofu.org/install-opentofu.sh | sudo env METHOD=standalone sh
+            curl -fsSL https://get.opentofu.org/install-opentofu.sh | sudo sh -s -- --install-method standalone
             tofu version
           fi
 


### PR DESCRIPTION
## Summary

- Fixes the `validate-terraform` CI job that failed on PR #559 with exit code 3 ("Invalid configuration options")
- The OpenTofu install script expects `--install-method standalone` as a CLI flag, not `METHOD=standalone` as an environment variable

**Before:** `curl ... | sudo env METHOD=standalone sh`
**After:** `curl ... | sudo sh -s -- --install-method standalone`

🤖 Generated with [Claude Code](https://claude.com/claude-code)