### PR TITLE
fix(harbor): use project name as import ID for harbor_project

### DIFF
--- a/terraform/authentik/outpost.tf
+++ b/terraform/authentik/outpost.tf
@@ -7,18 +7,18 @@ resource "authentik_outpost" "vollminlab_proxy" {
   ]
 
   config = jsonencode({
-    authentik_host               = "https://authentik.vollminlab.com/"
-    authentik_host_insecure      = false
-    authentik_host_browser       = ""
-    log_level                    = "info"
-    object_naming_template       = "ak-outpost-%(name)s"
-    refresh_interval             = "minutes=5"
-    container_image              = null
-    docker_network               = null
-    docker_map_ports             = true
-    docker_labels                = null
-    kubernetes_replicas          = 1
-    kubernetes_namespace         = "authentik"
+    authentik_host                   = "https://authentik.vollminlab.com/"
+    authentik_host_insecure          = false
+    authentik_host_browser           = ""
+    log_level                        = "info"
+    object_naming_template           = "ak-outpost-%(name)s"
+    refresh_interval                 = "minutes=5"
+    container_image                  = null
+    docker_network                   = null
+    docker_map_ports                 = true
+    docker_labels                    = null
+    kubernetes_replicas              = 1
+    kubernetes_namespace             = "authentik"
     kubernetes_ingress_annotations   = {}
     kubernetes_ingress_secret_name   = "authentik-outpost-tls"
     kubernetes_ingress_class_name    = null

--- a/terraform/harbor/imports.tf
+++ b/terraform/harbor/imports.tf
@@ -5,10 +5,10 @@ import {
 
 import {
   to = harbor_project.library
-  id = "1"
+  id = "library"
 }
 
 import {
   to = harbor_project.vollminlab
-  id = "4"
+  id = "vollminlab"
 }


### PR DESCRIPTION
## Summary

Fixes `harbor-config` Terraform CR failing with "Cannot import non-existent remote object" for both `harbor_project.library` and `harbor_project.vollminlab`.

**Root cause:** The `goharbor/harbor` provider imports `harbor_project` by **project name** (string), not by numeric project ID. The original import blocks used `id = "1"` and `id = "4"`, which were treated as name lookups — no projects named `"1"` or `"4"` exist, hence the 404.

**Fix:** Changed to `id = "library"` and `id = "vollminlab"`.

The projects and their IDs were confirmed via the Harbor API before this fix:
```
project_id: 1  name: library
project_id: 4  name: vollminlab
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)