### PR TITLE
fix(harbor): use full API path as harbor_project import ID

### DIFF
--- a/terraform/harbor/imports.tf
+++ b/terraform/harbor/imports.tf
@@ -5,10 +5,10 @@ import {
 
 import {
   to = harbor_project.library
-  id = "library"
+  id = "/api/v2.0/projects/library"
 }
 
 import {
   to = harbor_project.vollminlab
-  id = "vollminlab"
+  id = "/api/v2.0/projects/vollminlab"
 }


### PR DESCRIPTION
## Summary

Third attempt at fixing `harbor-config` Terraform CR import failures. Root cause now confirmed.

**How goharbor/harbor stores project IDs:** The provider uses `ImportStatePassthroughContext`, meaning the import ID is passed directly as `d.Id()`. The provider then calls `GET d.Id()` verbatim in the Read function. When a project is created, the provider extracts the ID from the `Location` response header — which is a full API path like `/api/v2.0/projects/library`.

**Previous attempts:**
1. `"1"` / `"4"` — numeric IDs, provider did `GET "1"` → 404
2. `"library"` / `"vollminlab"` — names, provider did `GET "library"` → 404
3. `/api/v2.0/projects/library` / `/api/v2.0/projects/vollminlab` — full paths ✓

Confirmed by reading the provider source (`resource_project.go`) and testing the path format against the Harbor API from inside the `tofu` namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)