### PR TITLE
fix(harbor): use numeric project path IDs for Terraform import blocks

### DIFF
--- a/terraform/harbor/imports.tf
+++ b/terraform/harbor/imports.tf
@@ -5,10 +5,10 @@ import {
 
 import {
   to = harbor_project.library
-  id = "/api/v2.0/projects/library"
+  id = "/projects/1"
 }
 
 import {
   to = harbor_project.vollminlab
-  id = "/api/v2.0/projects/vollminlab"
+  id = "/projects/4"
 }


### PR DESCRIPTION
## Summary

- Changes `harbor_project.library` import ID from `/api/v2.0/projects/library` → `/projects/1`
- Changes `harbor_project.vollminlab` import ID from `/api/v2.0/projects/vollminlab` → `/projects/4`

**Root cause:** The `goharbor/harbor` provider's `GetID` function strips `/api` and `/v2.0` from the Location response header before storing state IDs. So even though Harbor returns `Location: /api/v2.0/projects/1`, the provider stores `/projects/1`. The import block ID must match what the provider stores in state — a numeric path, not a name-based path.

Verified: `GET https://harbor.vollminlab.com/projects/1` and `/projects/4` both return 200.

Fourth fix attempt; root cause confirmed by reading provider source (`client.go` `GetID` function).

🤖 Generated with [Claude Code](https://claude.com/claude-code)