### PR TITLE
fix: set Recreate deployment strategy on RWO PVC workloads

### DIFF
--- a/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
@@ -9,6 +9,9 @@ metadata:
     category: storage
 data:
   values.yaml: |
+    updateStrategy:
+      type: Recreate
+
     externalURL: https://harbor.vollminlab.com
 
     expose:

--- a/clusters/vollminlab-cluster/mediastack/jellyfin/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/jellyfin/app/configmap.yaml
@@ -9,6 +9,8 @@ metadata:
     category: media
 data:
   values.yaml: |
+    deploymentStrategy:
+      type: Recreate
     persistence:
       config:
         existingClaim: pvc-jellyfin-config

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -45,6 +45,8 @@ data:
 
     grafana:
       enabled: true
+      deploymentStrategy:
+        type: Recreate
       ingress:
         enabled: false
       admin:


### PR DESCRIPTION
## Summary

Grafana, Jellyfin, and Harbor (registry + jobservice) all attach ReadWriteOnce PVCs. The default `RollingUpdate` strategy causes a stuck rollout: the old pod holds the PVC, the new pod can't attach it, and the deployment deadlocks until the old pod is manually deleted (as happened with Grafana today after PR #561).

**Changes:**
- `kube-prometheus-stack`: `grafana.deploymentStrategy.type: Recreate`
- `jellyfin`: `deploymentStrategy.type: Recreate`
- `harbor`: `updateStrategy.type: Recreate` (covers both registry and jobservice deployments)

**Drawback:** Brief downtime (~10–30s) during chart upgrades instead of zero-downtime rolling replacement. Acceptable for a homelab — and better than a silent stuck rollout requiring manual intervention.

**Already correct (no change needed):** arr stack (Radarr, Sonarr, Bazarr, Prowlarr, SABnzbd), Audiobookshelf, MinIO, Portainer — all already had `Recreate` set by their charts. CNPG clusters and StatefulSets are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)