### PR TITLE
fix(terraform): lifecycle ignore_changes on quality profiles; remove tunnel config imports

### DIFF
--- a/terraform/cloudflare/imports.tf
+++ b/terraform/cloudflare/imports.tf
@@ -24,22 +24,6 @@ import {
   id = "9013108406ddceed8abc1a3e2e21907d/51eeb142-e2fe-4153-8ed2-585d3c5ac018"
 }
 
-# Tunnel configurations
-import {
-  to = cloudflare_zero_trust_tunnel_cloudflared_config.vollminlab_authentik
-  id = "9013108406ddceed8abc1a3e2e21907d/d5a68ca0-0460-47f0-b17b-a4043f9fe69c"
-}
-
-import {
-  to = cloudflare_zero_trust_tunnel_cloudflared_config.vollminlab_audiobookshelf
-  id = "9013108406ddceed8abc1a3e2e21907d/01ca47d0-b545-4ee4-9fb0-2ae1f74c0e9c"
-}
-
-import {
-  to = cloudflare_zero_trust_tunnel_cloudflared_config.vollminlab_jellyfin
-  id = "9013108406ddceed8abc1a3e2e21907d/51eeb142-e2fe-4153-8ed2-585d3c5ac018"
-}
-
 # DNS CNAME records
 import {
   to = cloudflare_dns_record.authentik

--- a/terraform/cloudflare/tunnels.tf
+++ b/terraform/cloudflare/tunnels.tf
@@ -8,16 +8,25 @@
 resource "cloudflare_zero_trust_tunnel_cloudflared" "vollminlab_authentik" {
   account_id = var.cloudflare_account_id
   name       = "vollminlab-Authentik"
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 resource "cloudflare_zero_trust_tunnel_cloudflared" "vollminlab_audiobookshelf" {
   account_id = var.cloudflare_account_id
   name       = "vollminlab-Audiobookshelf"
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 resource "cloudflare_zero_trust_tunnel_cloudflared" "vollminlab_jellyfin" {
   account_id = var.cloudflare_account_id
   name       = "vollminlab-Jellyfin"
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 # ---------------------------------------------------------------------------

--- a/terraform/radarr/providers.tf
+++ b/terraform/radarr/providers.tf
@@ -1,4 +1,4 @@
 provider "radarr" {
-  url     = "http://radarr.mediastack.svc.cluster.local"
+  url     = "http://radarr.mediastack.svc.cluster.local:7878"
   api_key = var.radarr_api_key
 }

--- a/terraform/radarr/quality-profiles.tf
+++ b/terraform/radarr/quality-profiles.tf
@@ -122,6 +122,9 @@ resource "radarr_quality_profile" "any" {
       qualities = [{ id = 31, name = "Remux-2160p", source = "bluray", resolution = 2160 }]
     },
   ]
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 # Profile: SD (id=2) — SD and WEB 480p / Bluray 480p/576p allowed, no upgrade
@@ -184,6 +187,9 @@ resource "radarr_quality_profile" "sd" {
       qualities = [{ id = 21, name = "Bluray-576p", source = "bluray", resolution = 576 }]
     },
   ]
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 # Profile: HD-720p (id=3) — 720p qualities only, no upgrade
@@ -214,6 +220,9 @@ resource "radarr_quality_profile" "hd_720p" {
       qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
     },
   ]
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 # Profile: HD-1080p (id=4) — 1080p qualities only, no upgrade
@@ -248,6 +257,9 @@ resource "radarr_quality_profile" "hd_1080p" {
       qualities = [{ id = 30, name = "Remux-1080p", source = "bluray", resolution = 1080 }]
     },
   ]
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 # Profile: Ultra-HD (id=5) — 4K qualities only, no upgrade
@@ -282,6 +294,9 @@ resource "radarr_quality_profile" "ultra_hd" {
       qualities = [{ id = 31, name = "Remux-2160p", source = "bluray", resolution = 2160 }]
     },
   ]
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 # Profile: HD - 720p/1080p (id=6) — 720p and 1080p qualities, no upgrade
@@ -332,4 +347,7 @@ resource "radarr_quality_profile" "hd_720p_1080p" {
       qualities = [{ id = 30, name = "Remux-1080p", source = "bluray", resolution = 1080 }]
     },
   ]
+  lifecycle {
+    ignore_changes = all
+  }
 }

--- a/terraform/sonarr/providers.tf
+++ b/terraform/sonarr/providers.tf
@@ -1,4 +1,4 @@
 provider "sonarr" {
-  url     = "http://sonarr.mediastack.svc.cluster.local"
+  url     = "http://sonarr.mediastack.svc.cluster.local:8989"
   api_key = var.sonarr_api_key
 }

--- a/terraform/sonarr/quality-profiles.tf
+++ b/terraform/sonarr/quality-profiles.tf
@@ -101,6 +101,9 @@ resource "sonarr_quality_profile" "any" {
       qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
     },
   ]
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 # Profile: SD (id=2) — SD qualities allowed (SDTV, WEB 480p, DVD, Bluray 480p/576p), no upgrade
@@ -199,6 +202,9 @@ resource "sonarr_quality_profile" "sd" {
       qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
     },
   ]
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 # Profile: HD-720p (id=3) — 720p qualities allowed (HDTV-720p, WEB 720p, Bluray-720p), no upgrade
@@ -297,6 +303,9 @@ resource "sonarr_quality_profile" "hd_720p" {
       qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
     },
   ]
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 # Profile: HD-1080p (id=4) — 1080p qualities allowed (HDTV-1080p, WEB 1080p, Bluray-1080p), no upgrade
@@ -395,6 +404,9 @@ resource "sonarr_quality_profile" "hd_1080p" {
       qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
     },
   ]
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 # Profile: Ultra-HD (id=5) — 4K qualities allowed (HDTV-2160p, WEB 2160p, Bluray-2160p), no upgrade
@@ -493,6 +505,9 @@ resource "sonarr_quality_profile" "ultra_hd" {
       qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
     },
   ]
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 # Profile: HD - 720p/1080p (id=6) — 720p and 1080p qualities allowed, no upgrade
@@ -591,4 +606,7 @@ resource "sonarr_quality_profile" "hd_720p_1080p" {
       qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
     },
   ]
+  lifecycle {
+    ignore_changes = all
+  }
 }


### PR DESCRIPTION
## Summary

- **Radarr/Sonarr quality profiles**: provider returns `null` for single-quality group `name` after apply, causing "inconsistent result" errors. Added `lifecycle { ignore_changes = all }` to all 12 quality profile resources so Terraform tracks them without drift-managing.

- **Cloudflare tunnel configs**: importing existing tunnel configs brings in state with `ingress` attribute, but our config uses `ingress_rule`. The v5 provider then PUTs an empty ingress list (HTTP 400). Removed the 3 tunnel config import blocks so Terraform CREATEs (not updates) them — the CREATE path correctly maps `ingress_rule` → API `ingress`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)