### PR TITLE
fix(velero): reduce daily-full MinIO TTL from 14d to 7d

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -110,7 +110,7 @@ data:
         schedule: "0 2 * * *"
         useOwnerReferencesInBackup: false
         template:
-          ttl: 336h
+          ttl: 168h
           storageLocation: minio
           defaultVolumesToFsBackup: true
           excludedNamespaces:


### PR DESCRIPTION
## Summary

- Reduces `daily-full` schedule TTL from 336h (14d) to 168h (7d)
- MinIO PVC was at 86% (64Gi/74Gi) with 44Gi consumed by 21 daily-full backups accumulating from the previous 30d→14d change
- At steady state with 14d retention, velero alone would exceed PVC capacity; 7d caps it at ~7 backups (~15Gi velero)
- Also manually deleted the 7 oldest April backup objects (Apr 23–30) to allow kopia GC to reclaim space within 24h
- B2 daily (90d) and monthly (1yr) schedules are unchanged — full long-term coverage preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)