### PR TITLE
fix(tofu): add lifecycle ignore_changes to cloudflare tunnel config resources

### DIFF
--- a/terraform/cloudflare/tunnels.tf
+++ b/terraform/cloudflare/tunnels.tf
@@ -48,6 +48,9 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "vollminlab_authentik
       },
     ]
   }
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 resource "cloudflare_zero_trust_tunnel_cloudflared_config" "vollminlab_audiobookshelf" {
@@ -65,6 +68,9 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "vollminlab_audiobook
       },
     ]
   }
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 resource "cloudflare_zero_trust_tunnel_cloudflared_config" "vollminlab_jellyfin" {
@@ -81,6 +87,9 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "vollminlab_jellyfin"
         service = "http_status:404"
       },
     ]
+  }
+  lifecycle {
+    ignore_changes = all
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `lifecycle { ignore_changes = all }` to all three `cloudflare_zero_trust_tunnel_cloudflared_config` resources
- The Cloudflare v5 provider sends a PUT with an empty ingress list when updating these resources, returning HTTP 400 ("config file doesn't contain any ingress rules")
- Removing the import blocks (PR #578) was insufficient because the resources persist in Terraform state from the earlier import — Terraform still tries to UPDATE them on every plan
- `ignore_changes = all` prevents the spurious update entirely, matching the pattern already applied to the tunnel resources themselves in PR #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)