### PR TITLE
fix(arc-runners): allow egress to Harbor MetalLB VIP for image push

### DIFF
--- a/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/networkpolicy.yaml
@@ -40,6 +40,13 @@ spec:
       ports:
         - port: 6443
           protocol: TCP
+    # Harbor registry — MetalLB VIP is RFC1918 so must be explicitly allowed.
+    - to:
+        - ipBlock:
+            cidr: 192.168.152.244/32
+      ports:
+        - port: 443
+          protocol: TCP
     # Public internet — GitHub, OCI registries, apt mirrors, etc.
     # All RFC 1918 ranges blocked to prevent accessing internal cluster services.
     - to:


### PR DESCRIPTION
## Summary

- Adds explicit egress rule to `arc-runners-egress` NetworkPolicy for Harbor's MetalLB VIP (`192.168.152.244:443`)
- The existing policy blocks all `192.168.0.0/16` traffic on 443/80, which includes Harbor's VIP — causing `docker login` to time out from GHA runner pods
- Discovered when the first `b2-exporter/v1.0.0` build failed with `context deadline exceeded` against `harbor.vollminlab.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)