### PR TITLE
fix(homepage): correct cloudflare widget type to cloudflared

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -214,7 +214,9 @@ data:
                 href: https://dash.cloudflare.com
                 icon: cloudflare.png
                 widget:
-                  type: cloudflare
+                  type: cloudflared
+                  accountid: "9013108406ddceed8abc1a3e2e21907d"
+                  tunnelid: "d5a68ca0-0460-47f0-b17b-a4043f9fe69c"
                   key: "{{HOMEPAGE_VAR_CLOUDFLARE_API_TOKEN}}"
         - Monitoring & Observability:
             - Policy Reporter:


### PR DESCRIPTION
## Summary

- Fixes "Missing Widget Type: cloudflare" error on the homepage
- `cloudflare` is not a valid widget type in homepage v1.13.1 — the correct type is `cloudflared`
- Added required `accountid` and `tunnelid` fields (using the Authentik tunnel — the SSO gateway)
- Shows Cloudflare Tunnel status (running/stopped) and origin IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)