### PR TITLE
fix(cert-manager): use public DNS for DNS-01 propagation checks

### DIFF
--- a/clusters/vollminlab-cluster/cert-manager/cert-manager/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/cert-manager/cert-manager/app/configmap.yaml
@@ -11,7 +11,7 @@ data:
   values.yaml: |
     extraArgs:
       - --dns01-recursive-nameservers-only
-      - --dns01-recursive-nameservers=10.96.0.10:53
+      - --dns01-recursive-nameservers=1.1.1.1:53,8.8.8.8:53
     prometheus:
       enabled: true
       servicemonitor:


### PR DESCRIPTION
## Summary

- Changes `--dns01-recursive-nameservers` from `10.96.0.10:53` (CoreDNS) to `1.1.1.1:53,8.8.8.8:53` (Cloudflare/Google public DNS)

**Root cause:** cert-manager uses CoreDNS to verify that ACME DNS-01 TXT challenges have propagated. CoreDNS forwards to Pi-hole, which has local A records for `vollminlab.com` and treats it as a local zone — meaning dnsmasq never forwards `_acme-challenge.harbor.vollminlab.com` TXT queries upstream to Cloudflare's authoritative nameservers. The propagation check always fails.

**Fix:** Point cert-manager directly at public recursive resolvers (1.1.1.1 and 8.8.8.8) that will actually query Cloudflare's authoritative servers and see the TXT record.

**Impact:** The `harbor-tls` Certificate (and any future DNS-01 certs) will be able to complete issuance. No other cert-manager behavior is affected — this only changes where cert-manager checks for TXT record propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)