### PR TITLE
feat(homepage): add custom CSS to equalize card heights on desktop

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -545,6 +545,13 @@ data:
             key: CLOUDFLARE_API_TOKEN
       - name: HOMEPAGE_ALLOWED_HOSTS
         value: "homepage.vollminlab.com,localhost,127.0.0.1"
+    persistence:
+      custom-css:
+        enabled: true
+        type: configMap
+        name: homepage-custom-css
+        mountPath: /app/config/custom.css
+        subPath: custom.css
     resources:
       requests:
         cpu: 100m

--- a/clusters/vollminlab-cluster/homepage/homepage/app/homepage-custom-css-configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/homepage-custom-css-configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: homepage-custom-css
+  namespace: homepage
+  labels:
+    app: homepage
+    env: production
+    category: apps
+data:
+  custom.css: |
+    li.service {
+      display: flex;
+      flex-direction: column;
+    }
+
+    li.service > .service-card {
+      flex: 1;
+    }

--- a/clusters/vollminlab-cluster/homepage/homepage/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/kustomization.yaml
@@ -6,7 +6,8 @@ metadata:
 resources:
   - configmap.yaml
   - helmrelease.yaml
-  - ingress.yaml
+  - homepage-custom-css-configmap.yaml
   - homepage-env-vars-sealedsecret.yaml
+  - ingress.yaml
   - rbac.yaml
   - pihole-watchdog-cronjob.yaml


### PR DESCRIPTION
## Summary

- Adds `homepage-custom-css` ConfigMap with two CSS rules that make service cards fill their grid cell height via flexbox stretch
- Mounts the ConfigMap at `/app/config/custom.css` via the chart's `persistence` block in Helm values
- Wires the new ConfigMap into the kustomization resources list

## Problem

Homepage uses CSS Grid per service group. The grid equalizes `li.service` cell heights within each row correctly — but `.service-card` (display:block) only grows to its content height, leaving empty space below cards that have no widget. This makes TrueNAS/Backblaze/Jellyfin visually tower over vCenter/Portainer/Longhorn in the same row on desktop.

Confirmed via DOM inspection: `li.service` height=184px (equalized ✓), `div.service-card` height=60px for vCenter vs 176px for TrueNAS in the same row.

## Fix

```css
li.service {
  display: flex;
  flex-direction: column;
}

li.service > .service-card {
  flex: 1;
}
```

The existing `mb-2` margin on `.service-card` acts as the row gap — card content fills `cell-height − 8px` for all cards in a row.

## Verified

- `helm template` renders correct `volumeMount` at `/app/config/custom.css` with `subPath` and `configMap` volume pointing to `homepage-custom-css`
- `kubectl kustomize` renders 11 manifests cleanly