### PR TITLE
fix(harbor): use wildcard cert for TLS and automate A record via external-dns

### DIFF
--- a/clusters/vollminlab-cluster/external-dns/external-dns/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/external-dns/external-dns/app/configmap.yaml
@@ -14,6 +14,7 @@ data:
 
     sources:
       - ingress
+      - service
 
     image:
       tag: v0.21.0

--- a/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
@@ -28,6 +28,7 @@ data:
           httpsPort: 443
         annotations:
           metallb.universe.tf/loadBalancerIPs: "192.168.152.245"
+          external-dns.alpha.kubernetes.io/hostname: harbor.vollminlab.com
         sourceRanges: []
 
     existingSecretAdminPassword: harbor-admin-credentials

--- a/clusters/vollminlab-cluster/harbor/harbor/app/harbor-tls-certificate.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor/app/harbor-tls-certificate.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: harbor
 spec:
   secretName: harbor-tls
-  commonName: harbor.vollminlab.com
+  commonName: "*.vollminlab.com"
   dnsNames:
-    - harbor.vollminlab.com
+    - "*.vollminlab.com"
   issuerRef:
     name: letsencrypt-cloudflare
     kind: ClusterIssuer


### PR DESCRIPTION
## Summary

- **harbor-tls-certificate.yaml**: Change cert request from `harbor.vollminlab.com` to `*.vollminlab.com`. Pi-hole's local `address=` entry for `harbor.vollminlab.com` causes dnsmasq to return empty NOERROR for `_acme-challenge.harbor.vollminlab.com` TXT queries (acts as zone authority, doesn't forward to unbound). The wildcard cert's ACME challenge lands at `_acme-challenge.vollminlab.com` which has no Pi-hole local entry, resolves correctly through unbound → Cloudflare. Confirmed via live cluster query: `_acme-challenge.vollminlab.com` returns 8 TXT records; `_acme-challenge.harbor.vollminlab.com` returns empty.
- **harbor/configmap.yaml**: Add `external-dns.alpha.kubernetes.io/hostname: harbor.vollminlab.com` annotation to the LoadBalancer service. Without this, external-dns (sources: ingress only) has no source for the hostname after the Ingress was pruned — the Pi-hole A record would stay at `192.168.152.244` (nginx VIP) indefinitely.
- **external-dns/configmap.yaml**: Add `service` to sources alongside `ingress`. Required for the above annotation to be picked up. With `policy: upsert-only`, external-dns will upsert `harbor.vollminlab.com → 192.168.152.245` on its next 1-minute interval once Harbor's LoadBalancer IP is assigned.

**Manual step required (Pi-hole host):** To fix the root cause for any future per-hostname certs, add to `/etc/dnsmasq.d/99-acme-challenges.conf`:
```
server=/_acme-challenge.vollminlab.com/127.0.0.1#5335
```
Then `pihole restartdns`. This tells dnsmasq to forward `_acme-challenge.*vollminlab.com` queries directly to unbound, bypassing local zone authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)