### PR TITLE
revert(external-dns): remove service source (Pi-hole v6 app_sudo required)

### DIFF
--- a/clusters/vollminlab-cluster/external-dns/external-dns/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/external-dns/external-dns/app/configmap.yaml
@@ -14,7 +14,6 @@ data:
 
     sources:
       - ingress
-      - service
 
     image:
       tag: v0.21.0


### PR DESCRIPTION
## Summary

Emergency revert. Adding `service` to external-dns sources caused a CrashLoopBackOff because the Pi-hole v6 API requires `webserver.api.app_sudo=true` for any configuration modification by external apps. Without it, the API returns 403 and external-dns exits fatally.

**To re-enable this properly:**
1. On the Pi-hole host: `pihole-FTL --config webserver.api.app_sudo true && sudo systemctl restart pihole-FTL`
2. Re-add `service` to external-dns sources

**Harbor A record:** Still needs manual update from `192.168.152.244` → `192.168.152.245` in Pi-hole's local DNS settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)