### PR TITLE
feat(external-dns): add service source for LoadBalancer A record management

### DIFF
--- a/clusters/vollminlab-cluster/external-dns/external-dns/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/external-dns/external-dns/app/configmap.yaml
@@ -14,6 +14,7 @@ data:
 
     sources:
       - ingress
+      - service
 
     image:
       tag: v0.21.0


### PR DESCRIPTION
## Summary

- Re-adds `service` to external-dns sources now that Pi-hole `app_sudo` is enabled on both Pi-hole instances
- external-dns will manage A records for LoadBalancer services annotated with `external-dns.alpha.kubernetes.io/hostname`
- First consumer: `harbor` service → `harbor.vollminlab.com → 192.168.152.245`

The harbor A record was already updated manually in Pi-hole during the outage window, so external-dns will see it as already correct and make no immediate changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)