### PR TITLE
fix(minio): scope homepage-monitor to least-privilege read-only policy

### DIFF
--- a/terraform/minio/imports.tf
+++ b/terraform/minio/imports.tf
@@ -63,11 +63,6 @@ import {
 }
 
 import {
-  to = minio_iam_user_policy_attachment.homepage_monitor
-  id = "homepage-monitor/consoleAdmin"
-}
-
-import {
   to = minio_iam_user_policy_attachment.tofu_svc
   id = "tofu-svc/tofu-state-policy"
 }

--- a/terraform/minio/policies.tf
+++ b/terraform/minio/policies.tf
@@ -31,6 +31,20 @@ resource "minio_iam_policy" "velero" {
   })
 }
 
+resource "minio_iam_policy" "homepage_monitor" {
+  name = "homepage-monitor-policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetBucketLocation", "s3:GetBucketPolicy", "s3:ListAllMyBuckets", "s3:ListBucket"]
+        Resource = ["arn:aws:s3:::*"]
+      },
+    ]
+  })
+}
+
 resource "minio_iam_policy" "tofu_state" {
   name = "tofu-state-policy"
   policy = jsonencode({

--- a/terraform/minio/users.tf
+++ b/terraform/minio/users.tf
@@ -3,8 +3,6 @@ resource "minio_iam_user" "cnpg_svc" {
   lifecycle { ignore_changes = [secret] }
 }
 
-# TODO: consoleAdmin is over-privileged for a read-only homepage widget.
-# Pre-existing state imported as-is — scope down to readonly in a follow-up PR.
 resource "minio_iam_user" "homepage_monitor" {
   name = "homepage-monitor"
   lifecycle { ignore_changes = [secret] }
@@ -25,10 +23,9 @@ resource "minio_iam_user_policy_attachment" "cnpg_svc" {
   policy_name = minio_iam_policy.cnpg.name
 }
 
-# TODO: Replace consoleAdmin with a scoped read-only policy (follow-up PR).
 resource "minio_iam_user_policy_attachment" "homepage_monitor" {
   user_name   = minio_iam_user.homepage_monitor.name
-  policy_name = "consoleAdmin"
+  policy_name = minio_iam_policy.homepage_monitor.name
 }
 
 resource "minio_iam_user_policy_attachment" "tofu_svc" {


### PR DESCRIPTION
## Summary

- Adds `homepage-monitor-policy` — a scoped IAM policy granting `s3:GetBucketLocation`, `s3:GetBucketPolicy`, `s3:ListAllMyBuckets`, `s3:ListBucket` on `arn:aws:s3:::*`
- Replaces the `consoleAdmin` policy attachment on `homepage-monitor` with the new scoped policy
- Removes the stale `homepage-monitor/consoleAdmin` import block from `imports.tf` (Terraform will destroy that attachment and create the new one)

Closes the follow-up TODO left in #559 — the pre-existing `consoleAdmin` over-privilege carried forward as-is during the Phase 5c IaC import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)