### PR TITLE
fix(arc-runners): allow Harbor egress via namespace selector, not VIP ipBlock

### DIFF
--- a/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/networkpolicy.yaml
@@ -40,12 +40,16 @@ spec:
       ports:
         - port: 6443
           protocol: TCP
-    # Harbor registry — dedicated LoadBalancer VIP; excluded from internet rule (RFC 1918).
+    # Harbor registry — target harbor namespace pods directly.
+    # Calico evaluates NetworkPolicy after kube-proxy DNAT, so ipBlock on the
+    # LoadBalancer VIP (192.168.152.245) never matches — the destination is already
+    # rewritten to the harbor-nginx pod IP (172.18.x.x) before Calico sees the packet.
     - to:
-        - ipBlock:
-            cidr: 192.168.152.245/32
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: harbor
       ports:
-        - port: 443
+        - port: 8443
           protocol: TCP
     # Public internet — GitHub, OCI registries, apt mirrors, etc.
     # All RFC 1918 ranges blocked to prevent accessing internal cluster services.


### PR DESCRIPTION
## Summary

- Replaces dead `ipBlock: 192.168.152.245/32` Harbor egress rule with a `namespaceSelector` targeting the `harbor` namespace on port 8443
- Root cause: Calico evaluates NetworkPolicy egress rules **after kube-proxy DNAT** — the LoadBalancer VIP is never visible to Calico, the packet already has `172.18.x.x:8443` (harbor-nginx pod) as the destination
- Same issue as the existing DNS rule fix (which targets CoreDNS pods directly for the same reason)
- This unblocks the b2-exporter GitHub Actions build workflow, which was failing at `docker login harbor.vollminlab.com` with `context deadline exceeded`

## Technical detail

Harbor service: `443 → targetPort 8443 → harbor-nginx pod (172.18.26.93)`. The `172.18.x.x` range falls in `172.16.0.0/12` (RFC 1918), which is explicitly excluded from the internet egress rule and had no dedicated allow. The `namespaceSelector` rule matches the post-DNAT pod destination correctly.