### PR TITLE
fix(seerr): restore Authentik forward-auth on ingress

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/seerr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/seerr/app/ingress.yaml
@@ -5,6 +5,12 @@ metadata:
   namespace: mediastack
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/auth-snippet: |
+      proxy_set_header X-Forwarded-Host $http_host;
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     shlink.vollminlab.com/slug: seerr
   labels:
     app: seerr


### PR DESCRIPTION
## Summary

- Restores the nginx forward-auth annotations that were removed in #600
- Seerr v3.2.0 does not include OIDC support — PR #1505 is not present in any published image (`develop` tag investigated and also lacks it)
- The OIDC config added to `settings.json` on the config PVC is left in place — it is ignored by the current build but will activate automatically when a future Seerr release ships with OIDC support

🤖 Generated with [Claude Code](https://claude.com/claude-code)