### PR TITLE
fix(harbor-tf): import pre-existing robot accounts into Terraform state

### DIFF
--- a/terraform/harbor/imports.tf
+++ b/terraform/harbor/imports.tf
@@ -12,3 +12,13 @@ import {
   to = harbor_project.vollminlab
   id = "/projects/4"
 }
+
+import {
+  to = harbor_robot_account.github_actions
+  id = "2"
+}
+
+import {
+  to = harbor_robot_account.cluster_pull
+  id = "4"
+}


### PR DESCRIPTION
## Summary

- Adds `import` blocks for `harbor_robot_account.github_actions` (id=2) and `harbor_robot_account.cluster_pull` (id=4) to `terraform/harbor/imports.tf`
- The `harbor-config` tofu workspace was stuck in `TerraformAppliedFail` with 409 CONFLICT errors because both robot accounts exist in Harbor's database but were not in Terraform state
- Robot IDs confirmed via direct DB query: `vollminlab+github-actions` = id 2, `vollminlab+cluster-pull` = id 4

## Why this unblocks b2-exporter builds

The `HARBOR_USERNAME` / `HARBOR_PASSWORD` GitHub Actions secrets reference the `github-actions` robot account. The `unauthorized` error in the build means those secrets may need to be refreshed — but first the workspace needs to be healthy so Terraform manages the account. Once the import succeeds, we can verify the credentials are current.