### PR TITLE
fix(harbor-tf): drop robot account import blocks, let Terraform create them

### DIFF
--- a/terraform/harbor/imports.tf
+++ b/terraform/harbor/imports.tf
@@ -12,13 +12,3 @@ import {
   to = harbor_project.vollminlab
   id = "/projects/4"
 }
-
-import {
-  to = harbor_robot_account.github_actions
-  id = "2"
-}
-
-import {
-  to = harbor_robot_account.cluster_pull
-  id = "4"
-}


### PR DESCRIPTION
## Summary

- Removes the `harbor_robot_account` import blocks added in #604
- The `goharbor/harbor` provider v3.10 cannot import robot accounts by numeric ID — plan fails with "Cannot import non-existent remote object" despite the resources existing at `/api/v2.0/robots/{id}`
- Both robot accounts have been deleted from Harbor; Terraform will create them fresh on next apply
- Secrets in `harbor-tf-credentials` already match 1Password and the `HARBOR_PASSWORD` GitHub Actions secret, so builds are unaffected