### PR TITLE
fix(harbor-tf): remove stale robot account import blocks

### DIFF
--- a/terraform/harbor/imports.tf
+++ b/terraform/harbor/imports.tf
@@ -12,13 +12,3 @@ import {
   to = harbor_project.vollminlab
   id = "/projects/4"
 }
-
-import {
-  to = harbor_robot_account.github_actions
-  id = "2"
-}
-
-import {
-  to = harbor_robot_account.cluster_pull
-  id = "4"
-}


### PR DESCRIPTION
## Summary

- Removes broken `import` blocks for `harbor_robot_account.github_actions` (id=2) and `harbor_robot_account.cluster_pull` (id=4) from `terraform/harbor/imports.tf`
- Both robots were deleted from Harbor during debugging; the stale import blocks caused `TFExecPlanFailed` on every plan cycle
- With the import blocks gone, Terraform will create both robots fresh on next reconcile

## What happens after merge

1. `harbor-config` workspace plans a CREATE for both robot accounts
2. Harbor creates them with auto-generated secrets (Harbor ignores `secret` on creation)
3. On the following reconcile cycle (~10 min), Terraform detects drift in the `secret` field and issues an UPDATE (PATCH) to Harbor — setting each robot's secret to the value from `harbor-tf-credentials`
4. Workspace settles `True — Applied successfully`

If the provider marks `secret` as non-updatable (ForceNew), a manual PATCH via `curl -X PATCH` to `/api/v2.0/robots/{id}` with the correct secret will be needed instead — but that's unlikely given Harbor's PATCH endpoint accepts secret overrides.

The `harbor-vollminlab-pull` imagePullSecret is sealed against the `harbor_cluster_pull_secret` value from `harbor-tf-credentials` and will continue to work once the cluster-pull robot's secret is set correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)