### PR TITLE
fix(sonarr): add missing port 8989 to provider URL

### DIFF
--- a/terraform/sonarr/providers.tf
+++ b/terraform/sonarr/providers.tf
@@ -1,4 +1,4 @@
 provider "sonarr" {
-  url     = "http://sonarr.mediastack.svc.cluster.local"
+  url     = "http://sonarr.mediastack.svc.cluster.local:8989"
   api_key = var.sonarr_api_key
 }


### PR DESCRIPTION
## Summary

- `sonarr.mediastack.svc.cluster.local` was missing `:8989`, defaulting to port 80
- Every quality profile read timed out (`dial tcp ...:80: i/o timeout`)
- Same root cause as radarr fixed in #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)