### PR TITLE
fix(sonarr): ignore quality_groups drift on all quality profiles

### DIFF
--- a/terraform/sonarr/quality-profiles.tf
+++ b/terraform/sonarr/quality-profiles.tf
@@ -10,6 +10,7 @@ resource "sonarr_quality_profile" "any" {
   name            = "Any"
   upgrade_allowed = false
   cutoff          = 1 # upgrade_allowed = false, cutoff irrelevant
+  lifecycle { ignore_changes = [quality_groups] }
 
   quality_groups = [
     {
@@ -108,6 +109,7 @@ resource "sonarr_quality_profile" "sd" {
   name            = "SD"
   upgrade_allowed = false
   cutoff          = 1 # upgrade_allowed = false, cutoff irrelevant
+  lifecycle { ignore_changes = [quality_groups] }
 
   quality_groups = [
     {
@@ -206,6 +208,7 @@ resource "sonarr_quality_profile" "hd_720p" {
   name            = "HD-720p"
   upgrade_allowed = false
   cutoff          = 4 # upgrade_allowed = false, cutoff irrelevant
+  lifecycle { ignore_changes = [quality_groups] }
 
   quality_groups = [
     {
@@ -304,6 +307,7 @@ resource "sonarr_quality_profile" "hd_1080p" {
   name            = "HD-1080p"
   upgrade_allowed = false
   cutoff          = 9 # upgrade_allowed = false, cutoff irrelevant
+  lifecycle { ignore_changes = [quality_groups] }
 
   quality_groups = [
     {
@@ -402,6 +406,7 @@ resource "sonarr_quality_profile" "ultra_hd" {
   name            = "Ultra-HD"
   upgrade_allowed = false
   cutoff          = 16 # upgrade_allowed = false, cutoff irrelevant
+  lifecycle { ignore_changes = [quality_groups] }
 
   quality_groups = [
     {
@@ -500,6 +505,7 @@ resource "sonarr_quality_profile" "hd_720p_1080p" {
   name            = "HD - 720p/1080p"
   upgrade_allowed = false
   cutoff          = 4 # upgrade_allowed = false, cutoff irrelevant
+  lifecycle { ignore_changes = [quality_groups] }
 
   quality_groups = [
     {


### PR DESCRIPTION
## Summary

- `devopsarr/sonarr` provider returns null for `quality_groups[].name` and `id` after apply on single-quality groups, causing a perpetual apply loop
- Added `lifecycle { ignore_changes = [quality_groups] }` to all 6 quality profiles (`any`, `sd`, `hd_720p`, `hd_1080p`, `ultra_hd`, `hd_720p_1080p`)
- Same upstream provider bug as radarr, fixed in #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)