### PR TITLE
fix(minio): expand PVC to 100Gi, reduce CNPG retention to 14d

### DIFF
--- a/clusters/vollminlab-cluster/authentik/cnpg/app/cluster.yaml
+++ b/clusters/vollminlab-cluster/authentik/cnpg/app/cluster.yaml
@@ -42,4 +42,4 @@ spec:
       wal:
         compression: gzip
         maxParallel: 2
-    retentionPolicy: "30d"
+    retentionPolicy: "14d"

--- a/clusters/vollminlab-cluster/harbor/harbor-db/app/cluster.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor-db/app/cluster.yaml
@@ -42,4 +42,4 @@ spec:
       wal:
         compression: gzip
         maxParallel: 2
-    retentionPolicy: "30d"
+    retentionPolicy: "14d"

--- a/clusters/vollminlab-cluster/mediastack/jellystat-db/app/cluster.yaml
+++ b/clusters/vollminlab-cluster/mediastack/jellystat-db/app/cluster.yaml
@@ -42,4 +42,4 @@ spec:
       wal:
         compression: gzip
         maxParallel: 2
-    retentionPolicy: "30d"
+    retentionPolicy: "14d"

--- a/clusters/vollminlab-cluster/minio/minio/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/minio/minio/app/configmap.yaml
@@ -29,7 +29,7 @@ data:
     persistence:
       enabled: true
       storageClass: "longhorn"
-      size: 60Gi
+      size: 100Gi
 
     service:
       type: ClusterIP

--- a/clusters/vollminlab-cluster/shlink/shlink-db/app/cluster.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink-db/app/cluster.yaml
@@ -42,4 +42,4 @@ spec:
       wal:
         compression: gzip
         maxParallel: 2
-    retentionPolicy: "30d"
+    retentionPolicy: "14d"


### PR DESCRIPTION
## Summary

- Expand MinIO PVC 75Gi → 100Gi (PVC patch already applied; configmap corrected from stale 60Gi value)
- Reduce CNPG backup retention 30d → 14d on authentik-db, harbor-db, jellystat-db, shlink-db

## Root cause

MinIO PVC hit 98% (72Gi/74Gi) from two compounding sources:
- **Velero kopia**: ~45Gi across 19 namespace repos. Old 30-day TTL backups still within expiry window; will self-clear by ~May 31 as TTL was previously reduced to 14d
- **CNPG backups**: ~23Gi across 4 databases at 30d retention (authentik-db alone: 12Gi)

## Disk pressure verification

All three Longhorn replica nodes (workers 02, 03, 04) confirmed safe post-expansion. Worker01 replica was evicted to worker03 (150+ GiB free) to satisfy Longhorn capacity checks.

Expected storage after retention changes settle (~2 weeks):
| Source | Now | ~2 weeks |
|--------|-----|----------|
| Velero kopia | 45G | ~22G (old backups expire) |
| CNPG backups | 23G | ~11G (14d retention) |
| Total | ~71G | ~35G of 100G (~35% used) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)