### PR TITLE
feat(authentik): add haproxydmz application entry + fix homepage HAProxy URLs

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -200,14 +200,14 @@ data:
                   password: "{{HOMEPAGE_VAR_NPM_PASSWORD}}"
             - HAProxy Internal Stats:
                 description: Load balancer statistics
-                href: http://haproxyvip.vollminlab.com:8404/stats
+                href: https://haproxy.vollminlab.com/stats
                 icon: haproxy.png
-                ping: http://haproxyvip.vollminlab.com:8404/stats
+                ping: https://haproxy.vollminlab.com/stats
             - HAProxy DMZ Stats:
                 description: Load balancer statistics
-                href: http://haproxydmzvip.vollminlab.com:8404/stats
+                href: https://haproxydmz.vollminlab.com/stats
                 icon: haproxy.png
-                ping: http://haproxydmzvip.vollminlab.com:8404/stats
+                ping: https://haproxydmz.vollminlab.com/stats
             - Cloudflare (Authentik):
                 description: Cloudflare tunnel — SSO gateway
                 href: https://dash.cloudflare.com

--- a/terraform/authentik/applications.tf
+++ b/terraform/authentik/applications.tf
@@ -35,6 +35,13 @@ resource "authentik_application" "haproxy" {
   open_in_new_tab = false
 }
 
+resource "authentik_application" "haproxydmz" {
+  name            = "HAProxy DMZ"
+  slug            = "haproxydmz"
+  meta_launch_url = "https://haproxydmz.vollminlab.com"
+  open_in_new_tab = false
+}
+
 resource "authentik_application" "harbor" {
   name              = "Harbor"
   slug              = "harbor"


### PR DESCRIPTION
## Summary
- Adds `authentik_application.haproxydmz` for HAProxy DMZ stats page (missed from #620)
- Updates homepage HAProxy widget URLs from direct VIP endpoints to HTTPS NPM-proxied URLs
  - `http://haproxyvip.vollminlab.com:8404/stats` → `https://haproxy.vollminlab.com/stats`
  - `http://haproxydmzvip.vollminlab.com:8404/stats` → `https://haproxydmz.vollminlab.com/stats`

🤖 Generated with [Claude Code](https://claude.com/claude-code)