### PR TITLE
fix(authentik): raise CPU limits and worker probe tolerances

### DIFF
--- a/clusters/vollminlab-cluster/authentik/authentik/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/authentik/authentik/app/configmap.yaml
@@ -29,7 +29,7 @@ data:
           cpu: 100m
           memory: 768Mi
         limits:
-          cpu: 500m
+          cpu: 1000m
           memory: 1Gi
 
     worker:
@@ -42,5 +42,11 @@ data:
           cpu: 100m
           memory: 512Mi
         limits:
-          cpu: 500m
+          cpu: 1000m
           memory: 768Mi
+      livenessProbe:
+        timeoutSeconds: 10
+        failureThreshold: 5
+      readinessProbe:
+        timeoutSeconds: 10
+        failureThreshold: 5


### PR DESCRIPTION
## Summary

- Raise server and worker CPU limits from `500m` → `1000m` (k8sworker03 has 4 CPUs, plenty of headroom)
- Increase worker liveness/readiness probe `timeoutSeconds: 3 → 10` and `failureThreshold: 3 → 5`

## Root cause

The worker was hitting its 500m CPU limit during bursts of `event_trigger_handler` tasks (many firing in rapid succession). When throttled, `ak healthcheck` could not complete within the 3s probe timeout → liveness probe killed the pod → restart loop. The worker accumulated **31 restarts** with `x158 liveness probe timeout` and `x127 readiness probe timeout` events over 2d16h.

The 500m limit is too low for a Python Dramatiq task queue doing concurrent event processing. k8sworker03 has 4 allocatable CPUs so doubling the limit has no scheduling impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)