### PR TITLE
feat(authentik-tf): add chavelock user with audiobookshelf and jellyfin access

### DIFF
--- a/terraform/authentik/groups.tf
+++ b/terraform/authentik/groups.tf
@@ -5,7 +5,7 @@ resource "authentik_group" "audiobookshelf_admins" {
 
 resource "authentik_group" "audiobookshelf_users" {
   name  = "Audiobookshelf Users"
-  users = toset([authentik_user.jvollmin.id, authentik_user.gkroner.id])
+  users = toset([authentik_user.jvollmin.id, authentik_user.gkroner.id, authentik_user.chavelock.id])
 }
 
 resource "authentik_group" "grafana_admins" {
@@ -30,7 +30,7 @@ resource "authentik_group" "jellyfin_admins" {
 
 resource "authentik_group" "jellyfin_users" {
   name  = "Jellyfin Users"
-  users = toset([authentik_user.jvollmin.id, authentik_user.vollmin.id, authentik_user.gkroner.id])
+  users = toset([authentik_user.jvollmin.id, authentik_user.vollmin.id, authentik_user.gkroner.id, authentik_user.chavelock.id])
 }
 
 resource "authentik_group" "minio_admins" {

--- a/terraform/authentik/imports.tf
+++ b/terraform/authentik/imports.tf
@@ -14,6 +14,11 @@ import {
   id = "11"
 }
 
+import {
+  to = authentik_user.chavelock
+  id = "12"
+}
+
 # Groups
 import {
   to = authentik_group.audiobookshelf_admins

--- a/terraform/authentik/users.tf
+++ b/terraform/authentik/users.tf
@@ -32,3 +32,14 @@ resource "authentik_user" "gkroner" {
     ignore_changes = [password, groups]
   }
 }
+
+resource "authentik_user" "chavelock" {
+  username  = "chavelock"
+  name      = "chavelock"
+  email     = "havelock17@gmail.com"
+  is_active = true
+
+  lifecycle {
+    ignore_changes = [password, groups]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `chavelock` (havelock17@gmail.com) as a managed Authentik user in `users.tf`
- Imports the existing pk=12 account (created via akshell) into Terraform state via `imports.tf`
- Adds chavelock to `Audiobookshelf Users` and `Jellyfin Users` groups in `groups.tf` for SSO access to both services

🤖 Generated with [Claude Code](https://claude.com/claude-code)