### PR TITLE
feat(shlink): redirect bare 'vl' hostname to vollm.in for LAN short URLs

### DIFF
--- a/clusters/vollminlab-cluster/shlink/shlink/app/ingress-vl.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink/app/ingress-vl.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: shlink-vl-ingress
+  namespace: shlink
+  labels:
+    app: shlink
+    env: production
+    category: apps
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      return 301 https://vollm.in$request_uri;
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - vl
+      secretName: vl-tls
+  rules:
+    - host: vl
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: shlink-shlink-backend
+                port:
+                  number: 8080

--- a/clusters/vollminlab-cluster/shlink/shlink/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink/app/ingress.yaml
@@ -20,9 +20,6 @@ spec:
     - hosts:
         - vollm.in
       secretName: vollm-in-tls
-    - hosts:
-        - vl
-      secretName: vl-tls
   rules:
     - host: go.vollminlab.com
       http:
@@ -45,16 +42,6 @@ spec:
                 port:
                   number: 8080
     - host: vollm.in
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: shlink-shlink-backend
-                port:
-                  number: 8080
-    - host: vl
       http:
         paths:
           - path: /

--- a/clusters/vollminlab-cluster/shlink/shlink/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink/app/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - helmrelease.yaml
   - configmap.yaml
   - ingress.yaml
+  - ingress-vl.yaml
   - vl-certificate.yaml
   - vollm-in-certificate.yaml
   - shlink-credentials-sealedsecret.yaml

--- a/terraform/authentik/groups.tf
+++ b/terraform/authentik/groups.tf
@@ -5,7 +5,7 @@ resource "authentik_group" "audiobookshelf_admins" {
 
 resource "authentik_group" "audiobookshelf_users" {
   name  = "Audiobookshelf Users"
-  users = toset([authentik_user.jvollmin.id, authentik_user.gkroner.id])
+  users = toset([authentik_user.jvollmin.id, authentik_user.gkroner.id, authentik_user.chavelock.id])
 }
 
 resource "authentik_group" "grafana_admins" {
@@ -30,7 +30,7 @@ resource "authentik_group" "jellyfin_admins" {
 
 resource "authentik_group" "jellyfin_users" {
   name  = "Jellyfin Users"
-  users = toset([authentik_user.jvollmin.id, authentik_user.vollmin.id, authentik_user.gkroner.id])
+  users = toset([authentik_user.jvollmin.id, authentik_user.vollmin.id, authentik_user.gkroner.id, authentik_user.chavelock.id])
 }
 
 resource "authentik_group" "minio_admins" {

--- a/terraform/authentik/imports.tf
+++ b/terraform/authentik/imports.tf
@@ -14,6 +14,11 @@ import {
   id = "11"
 }
 
+import {
+  to = authentik_user.chavelock
+  id = "12"
+}
+
 # Groups
 import {
   to = authentik_group.audiobookshelf_admins

--- a/terraform/authentik/users.tf
+++ b/terraform/authentik/users.tf
@@ -32,3 +32,14 @@ resource "authentik_user" "gkroner" {
     ignore_changes = [password, groups]
   }
 }
+
+resource "authentik_user" "chavelock" {
+  username  = "chavelock"
+  name      = "chavelock"
+  email     = "havelock17@gmail.com"
+  is_active = true
+
+  lifecycle {
+    ignore_changes = [password, groups]
+  }
+}


### PR DESCRIPTION
## Summary

- Splits the bare `vl` hostname out of the main shlink ingress into a dedicated `shlink-vl-ingress`
- The new ingress uses `nginx.ingress.kubernetes.io/server-snippet` to issue a `301 https://vollm.in$request_uri` redirect for all requests on the `vl` host
- `vl.vollminlab.com`, `go.vollminlab.com`, and `vollm.in` continue to route directly to Shlink as before

**Result:** Typing `vl/headlamp` (or any other slug) in a LAN browser will resolve via Pi-hole and redirect to `vollm.in/headlamp` → the full service URL, without needing to own a short TLD.