### PR TITLE
chore: unignore docs/superpowers and commit pending design specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 # Claude Code runtime artifacts
 .codex
 .worktrees/
-docs/superpowers/
 session-report-*.html
 
 # macOS

--- a/docs/superpowers/specs/filebrowser-design.md
+++ b/docs/superpowers/specs/filebrowser-design.md
@@ -1,0 +1,167 @@
+# FileBrowser — File Drop Service Design
+
+**Date:** 2026-05-17
+**Status:** Approved
+
+## Overview
+
+Deploy FileBrowser in the `mediastack` namespace as a general-purpose file drop service. External users upload files via browser to a dedicated TrueNAS SMB share. Authentication is handled entirely by Authentik (forward-auth via nginx), with FileBrowser running in proxy auth mode — no second login prompt. Files land on the SMB share and are accessible from Windows at `\\smb.vollminlab.com\FileBrowser\`.
+
+## Architecture
+
+```
+Friend's browser
+      │
+      ▼
+Cloudflare Tunnel (vollminlab-FileBrowser)
+      │  routes to ingress-nginx-controller.ingress-nginx.svc.cluster.local:80
+      ▼
+nginx ingress (filebrowser.vollminlab.com)
+      │  auth-request → Authentik outpost (vollminlab-proxy)
+      │  injects X-authentik-username header on success
+      ▼
+FileBrowser service (mediastack)
+      │  reads X-authentik-username, looks up user in its DB
+      ▼
+pvc-filebrowser → SMB share //192.168.150.2/FileBrowser
+      │
+      ▼
+TrueNAS dataset: FileBrowser
+  └── Audiobooks/     ← friend uploads here
+  └── (future use cases as subfolders)
+```
+
+## Components
+
+### 1. TrueNAS (manual)
+
+- Create ZFS dataset `FileBrowser` on the same pool as `audiobooks`, `movies`, etc.
+- Enable SMB share named `FileBrowser`
+- Create `Audiobooks/` subfolder inside it
+- Permissions: uid=568, gid=568 (matches all other SMB mounts in the cluster)
+
+### 2. Cloudflare Tunnel (tofu — `terraform/cloudflare/tunnels.tf`)
+
+New resources following the existing `vollminlab_audiobookshelf` pattern:
+
+```hcl
+resource "cloudflare_zero_trust_tunnel_cloudflared" "vollminlab_filebrowser" {
+  account_id = var.cloudflare_account_id
+  name       = "vollminlab-FileBrowser"
+  lifecycle { ignore_changes = all }
+}
+
+resource "cloudflare_zero_trust_tunnel_cloudflared_config" "vollminlab_filebrowser" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.vollminlab_filebrowser.id
+  lifecycle { ignore_changes = all }
+
+  config = {
+    ingress_rule = [
+      {
+        hostname = "filebrowser.vollminlab.com"
+        service  = "http://ingress-nginx-controller.ingress-nginx.svc.cluster.local:80"
+      },
+      {
+        service = "http_status:404"
+      },
+    ]
+  }
+}
+```
+
+**Note:** Unlike audiobookshelf/jellyfin (which use OIDC and route directly to the app service), this tunnel routes through nginx so Authentik forward-auth can inject the `X-authentik-username` header. FileBrowser's proxy auth mode depends on this header being present.
+
+### 3. Kubernetes resources (`clusters/vollminlab-cluster/`)
+
+| File | Location | Purpose |
+|---|---|---|
+| `pv-filebrowser.yaml` | `clusterwide/` | PV for SMB share `//192.168.150.2/FileBrowser` |
+| `pvc-filebrowser.yaml` | `mediastack/pvcs/` | PVC binding to above PV, `ReadWriteMany` |
+| `helmrelease.yaml` | `mediastack/filebrowser/app/` | FileBrowser HelmRelease |
+| `configmap.yaml` | `mediastack/filebrowser/app/` | Helm values (proxy auth config) |
+| `ingress.yaml` | `mediastack/filebrowser/app/` | Ingress with Authentik forward-auth annotations + shlink slug `filebrowser` |
+| `cloudflared-filebrowser-tunnel-credentials-sealedsecret.yaml` | `mediastack/cloudflared-filebrowser/app/` | Tunnel token SealedSecret |
+| `deployment.yaml` | `mediastack/cloudflared-filebrowser/app/` | cloudflared Deployment (mirrors audiobookshelf pattern) |
+
+Both Flux index files must be updated:
+- `flux-system/flux-kustomizations/kustomization.yaml` — add `filebrowser` and `cloudflared-filebrowser` entries
+- `flux-system/repositories/kustomization.yaml` — add FileBrowser HelmRepository entry
+
+#### FileBrowser proxy auth configuration
+
+FileBrowser is configured via `settings.json` at startup. Key values:
+
+```json
+{
+  "authMethod": "proxy",
+  "authHeader": "X-authentik-username"
+}
+```
+
+This is set via Helm values in `configmap.yaml`.
+
+#### Helm chart
+
+Use the `gabe565/filebrowser` chart (`https://charts.gabe565.com`). Confirm latest pinned version before committing.
+
+### 4. Authentik (tofu — `terraform/authentik/`)
+
+**`applications.tf`** — add:
+```hcl
+resource "authentik_application" "filebrowser" {
+  name            = "FileBrowser"
+  slug            = "filebrowser"
+  meta_launch_url = "https://filebrowser.vollminlab.com"
+  open_in_new_tab = false
+}
+```
+
+**`dns.tf`** — add CNAME record pointing to the tunnel:
+```hcl
+resource "cloudflare_dns_record" "filebrowser" {
+  zone_id = var.cloudflare_zone_id
+  name    = "filebrowser.vollminlab.com"
+  type    = "CNAME"
+  content = "${cloudflare_zero_trust_tunnel_cloudflared.vollminlab_filebrowser.id}.cfargotunnel.com"
+  proxied = true
+  ttl     = 1
+}
+```
+
+**`users.tf`** — add the friend's Authentik user (name/email TBD at implementation time, following the `chavelock` pattern with `lifecycle { ignore_changes = [password, groups] }`).
+
+The friend's Authentik user must be granted access to the `filebrowser` application via the existing policy/binding mechanism.
+
+### 5. FileBrowser user bootstrap (one-time, post-deploy)
+
+FileBrowser does not auto-provision users on proxy auth — the username from the header must already exist in FileBrowser's database. After the service is running, create two users via the FileBrowser admin API:
+
+| Username | Role | Scope | Permissions |
+|---|---|---|---|
+| `vollmin` | Admin | `/` | All |
+| `<friend-username>` | User | `/Audiobooks/` | Upload only (no delete/rename) |
+
+Usernames must exactly match the Authentik usernames (what `X-authentik-username` will contain).
+
+## Access model
+
+| Who | Entry point | What they see |
+|---|---|---|
+| You | `https://filebrowser.vollminlab.com` | Full file manager for all of `FileBrowser/` |
+| Friend | `https://filebrowser.vollminlab.com` | Only `Audiobooks/` folder, upload only |
+| You (Windows) | `\\smb.vollminlab.com\FileBrowser\` | Direct SMB access, move files anywhere |
+
+## Adding future use cases
+
+To add a new drop folder (e.g. `Photos`):
+1. Create the subfolder in TrueNAS under the `FileBrowser` dataset
+2. Add a new Authentik user (tofu) for the new sender
+3. Bootstrap a FileBrowser user scoped to the new subfolder via the API
+4. Share `https://filebrowser.vollminlab.com` — the user sees only their folder
+
+No new Kubernetes resources, no new tunnels, no new ingresses.
+
+## Open questions
+
+- Friend's name, username, and email for the Authentik user entry (needed at implementation time)

--- a/docs/superpowers/specs/homepage-b2-cloudflare-design.md
+++ b/docs/superpowers/specs/homepage-b2-cloudflare-design.md
@@ -1,0 +1,129 @@
+# Homepage: Backblaze B2 Metrics + Cloudflare Widget
+
+## Overview
+
+Add two new entries to the Homepage dashboard:
+
+1. **Backblaze B2** — a `prometheus` widget showing Velero bucket size and file count, backed by a new custom Prometheus exporter that queries the B2 API.
+2. **Cloudflare** — a native `cloudflare` widget showing zone requests, bandwidth, and threats blocked over the past 24h.
+
+Both entries fit into existing sections without changing column counts for those sections.
+
+---
+
+## B2 Prometheus Exporter
+
+### Architecture
+
+A new `Deployment` in the `monitoring` namespace runs a Python HTTP server that:
+
+- Queries the Backblaze B2 API on startup and then every 30 minutes (internal goroutine/thread)
+- Sums `contentLength` across all file versions in the configured bucket via `b2sdk`
+- Caches the result in memory
+- Serves the cached result immediately on every Prometheus scrape via `/metrics`
+
+This prevents B2 from being hammered on every scrape interval (default 15s).
+
+### Metrics
+
+| Metric | Labels | Description |
+|--------|--------|-------------|
+| `b2_bucket_bytes_total` | `bucket` | Total bytes stored in the B2 bucket |
+| `b2_bucket_file_count_total` | `bucket` | Total number of file versions in the B2 bucket |
+
+### Container Image
+
+- Base image: `python:3.12-slim`
+- Dependencies: `b2sdk`, `prometheus_client`
+- Script (~50 lines) baked into the image
+- Built and pushed to `harbor.vollminlab.com/library/b2-exporter:<tag>`
+
+### Kubernetes Resources
+
+All resources in `monitoring` namespace.
+
+| Resource | Name | Notes |
+|----------|------|-------|
+| Deployment | `b2-exporter` | Single replica, no PVC |
+| SealedSecret | `b2-exporter-credentials` | `B2_APPLICATION_KEY_ID`, `B2_APPLICATION_KEY`, `B2_BUCKET_NAME` |
+| Service | `b2-exporter` | Port 8080 (metrics) |
+| ServiceMonitor | `b2-exporter` | Labels matching kube-prometheus-stack selector |
+
+Labels on all resources: `app: b2-exporter`, `env: production`, `category: observability`
+
+### Credentials
+
+A B2 Application Key scoped to the Velero bucket with `listFiles`, `readFiles` capabilities. Stored in 1Password as **"B2 Exporter App Key"** (Homelab vault), sealed into `b2-exporter-credentials-sealedsecret.yaml`.
+
+### Flux Wiring
+
+- Add `- b2-exporter/app` to `clusters/vollminlab-cluster/monitoring/kustomization.yaml`
+- The existing `monitoring-kustomization.yaml` Flux CR already covers the whole monitoring namespace — no new Flux Kustomization CR needed
+- No new HelmRepository needed (plain Kubernetes manifests, not Helm-based)
+
+### Grafana
+
+Once the ServiceMonitor is active, metrics are available in Prometheus immediately. A new panel can be added to the existing Velero Grafana dashboard showing B2 bucket size over time.
+
+---
+
+## Homepage Changes
+
+### Backblaze entry — Infrastructure section
+
+Infrastructure currently has 7 items at 4 columns (row 2 has one empty slot). Adding Backblaze fills it to exactly 2 clean rows of 4 — no column count change needed.
+
+```yaml
+- Backblaze:
+    description: B2 offsite backup storage
+    href: https://secure.backblaze.com/b2_buckets.htm
+    icon: backblaze.png
+    widget:
+      type: prometheus
+      url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+      query: b2_bucket_bytes_total
+      format:
+        type: bytes
+        scale: 1000000000
+        suffix: GB
+```
+
+No changes to `Infrastructure` column count (stays at 4).
+
+### Cloudflare entry — Networking section
+
+Networking currently has 5 items at 5 columns (1 clean row). Adding Cloudflare makes 6 items. Column count changes from **5 → 3** (2 rows of 3).
+
+```yaml
+- Cloudflare:
+    description: DNS and CDN
+    href: https://dash.cloudflare.com
+    icon: cloudflare.png
+    widget:
+      type: cloudflare
+      key: "{{HOMEPAGE_VAR_CLOUDFLARE_API_TOKEN}}"
+```
+
+### New env var in SealedSecret
+
+`homepage-env-vars` SealedSecret gains one new key: `CLOUDFLARE_API_TOKEN`.
+
+A new `HOMEPAGE_VAR_CLOUDFLARE_API_TOKEN` env var is added to the `env:` list in `configmap.yaml`.
+
+---
+
+## Secrets Summary
+
+| Secret name | Namespace | Keys | Source in 1Password |
+|-------------|-----------|------|---------------------|
+| `b2-exporter-credentials` | `monitoring` | `B2_APPLICATION_KEY_ID`, `B2_APPLICATION_KEY`, `B2_BUCKET_NAME` | "B2 Exporter App Key" |
+| `homepage-env-vars` (updated) | `homepage` | + `CLOUDFLARE_API_TOKEN` | "Cloudflare Homepage Token" |
+
+---
+
+## Layout Impact Summary
+
+| Section | Before | After | Column change |
+|---------|--------|-------|---------------|
+| Infrastructure | 7 items, 4 cols | 8 items, 4 cols | None |
+| Networking | 5 items, 5 cols | 6 items, 3 cols | 5 → 3 |


### PR DESCRIPTION
## Summary

- Remove `docs/superpowers/` from `.gitignore` so design specs are version controlled alongside the rest of the repo docs
- Add two previously local-only specs: `filebrowser-design.md` and `homepage-b2-cloudflare-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)