### PR TITLE
feat(mediastack): deploy FileBrowser file drop service

### DIFF
--- a/clusters/vollminlab-cluster/clusterwide/kustomization.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - pv-audiobooks.yaml
   - pv-books.yaml
   - pv-completed-downloads.yaml
+  - pv-filebrowser.yaml
   - pv-incomplete-downloads.yaml
   - pv-movies.yaml
   - pv-tv.yaml

--- a/clusters/vollminlab-cluster/clusterwide/pv-filebrowser.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/pv-filebrowser.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-filebrowser
+  labels:
+    app: mediastack
+    env: production
+    category: media
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb
+  csi:
+    driver: smb.csi.k8s.io
+    volumeHandle: filebrowser
+    volumeAttributes:
+      source: "//192.168.150.2/FileBrowser"
+    nodeStageSecretRef:
+      name: smb-credentials
+      namespace: mediastack
+  mountOptions:
+    - uid=568
+    - gid=568
+    - dir_mode=0755
+    - file_mode=0755

--- a/clusters/vollminlab-cluster/mediastack/cloudflared-filebrowser/app/cloudflared-filebrowser-tunnel-credentials-sealedsecret.yaml
+++ b/clusters/vollminlab-cluster/mediastack/cloudflared-filebrowser/app/cloudflared-filebrowser-tunnel-credentials-sealedsecret.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: cloudflared-filebrowser-tunnel-credentials
+  namespace: mediastack
+spec:
+  encryptedData:
+    tunnel-token: AgBKbfN/3wE1ByjlXA8ps0UCewvoBAxhAf41GPo1kbvltMgqYmog9JZ/v5J8fvj+hU3C+R8hZRc0JqlUQUu5Th/weKE6w90oeFzyVmCEeqtrCzFCAye6d3AtToBxAsgmyGMit9/XyMI2Jq2Zlszw70ZpJxa7HwrcoGlEDgKZjwpS9v2d1WMxtu1C//J2t0NucwwaCXWTfGO+0PECfxRSP3Cs66Jru6A0vhnL5qbrpEWjkGiyB+/fjch8pQejO0Zznio5mS59y9+ltZGAe+9uJrSlP1LKixnTpLYAKzC6bAHTuRVpiNmncxXlIP4ZbR1CsqAOfmheWVKxIrPcQzevKxdOrGFDQTpRSmqK05EPf4BXwBXxdjH7mc18sHvlbvuVrZUB6I3y1t8dURmBBCpPyMoSSte08cKqUUlylsHnDqNr51VZBkBLoGSku9AVFIJxLooXCvmVPbUZIwuciX7jfifBHYPZSwCeJufKPpD5VGUkTF+z8MW77jW9/INQsHeGCpk/LlLTgj15tCO5U6pPMHpupnCUf4BZ1EN20879yZsYID6q342k9eA0YMBWtWQh/z3wORR6XuF00j+CIt4f60LV9VdZ7T0Frxyi7Yr5o611eqPlXPZhJ0R/s8KavXLrUkySm4wuU0HgIigB66QxS+EagHTB4WIUQ6I/zsX33y2Tj+3RCWqmMC1PfxEOI9H+LfINfNI+dsiCFV0if1wORdUkwsAOuzKBCT421bI4suq8iYC7IRwwTE0FUDsqEdmjBo/2hcOubnmxeo8/9CPcQYqelvJ8wdMX4fQRfiNj7AiSKCwQ4tJDcg5K2D8McWSOBupof+vqrx6nfBwjXJEASu/hqaTTo+qJwln8omddhSDPqU1KUwVCtqjaqA4NdHuOVoEEKQ7yCfux5B/jdTMQ4kOyxkf3nWOkTYcG4DikU2fyRTmll4Or8m+y
+  template:
+    metadata:
+      name: cloudflared-filebrowser-tunnel-credentials
+      namespace: mediastack
+      labels:
+        app: cloudflared-filebrowser
+        env: production
+        category: networking

--- a/clusters/vollminlab-cluster/mediastack/cloudflared-filebrowser/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/cloudflared-filebrowser/app/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudflared-filebrowser
+  namespace: mediastack
+  labels:
+    app: cloudflared-filebrowser
+    env: production
+    category: networking
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cloudflared-filebrowser
+  template:
+    metadata:
+      labels:
+        app: cloudflared-filebrowser
+        env: production
+        category: networking
+    spec:
+      containers:
+        - name: cloudflared
+          image: cloudflare/cloudflared:2026.3.0
+          args:
+            - tunnel
+            - --no-autoupdate
+            - run
+          env:
+            - name: TUNNEL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflared-filebrowser-tunnel-credentials
+                  key: tunnel-token
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi

--- a/clusters/vollminlab-cluster/mediastack/cloudflared-filebrowser/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/cloudflared-filebrowser/app/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: cloudflared-filebrowser-app
+resources:
+  - cloudflared-filebrowser-tunnel-credentials-sealedsecret.yaml
+  - deployment.yaml

--- a/clusters/vollminlab-cluster/mediastack/filebrowser/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/filebrowser/app/configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: filebrowser-settings
+  namespace: mediastack
+  labels:
+    app: filebrowser
+    env: production
+    category: apps
+data:
+  settings.json: |
+    {
+      "port": 80,
+      "baseURL": "",
+      "address": "",
+      "log": "stdout",
+      "database": "/config/database.db",
+      "root": "/srv",
+      "signup": false
+    }

--- a/clusters/vollminlab-cluster/mediastack/filebrowser/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/filebrowser/app/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: filebrowser
+  namespace: mediastack
+  labels:
+    app: filebrowser
+    env: production
+    category: apps
+    app.kubernetes.io/name: filebrowser
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: filebrowser
+  template:
+    metadata:
+      labels:
+        app: filebrowser
+        env: production
+        category: apps
+        app.kubernetes.io/name: filebrowser
+    spec:
+      containers:
+        - name: filebrowser
+          image: filebrowser/filebrowser:v2.63.3
+          args: ["--config", "/config/settings.json"]
+          env:
+            - name: FB_AUTH_METHOD
+              value: proxy
+            - name: FB_AUTH_HEADER
+              value: X-authentik-username
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: settings
+              mountPath: /config/settings.json
+              subPath: settings.json
+            - name: data
+              mountPath: /srv
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: pvc-filebrowser-config
+        - name: settings
+          configMap:
+            name: filebrowser-settings
+        - name: data
+          persistentVolumeClaim:
+            claimName: pvc-filebrowser

--- a/clusters/vollminlab-cluster/mediastack/filebrowser/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/filebrowser/app/ingress.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: filebrowser-ingress
+  namespace: mediastack
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/auth-snippet: |
+      proxy_set_header X-Forwarded-Host $http_host;
+    shlink.vollminlab.com/slug: filebrowser
+  labels:
+    app: filebrowser
+    env: production
+    category: apps
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: filebrowser.vollminlab.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: filebrowser
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - filebrowser.vollminlab.com
+      secretName: wildcard-tls

--- a/clusters/vollminlab-cluster/mediastack/filebrowser/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/filebrowser/app/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: filebrowser-app
+resources:
+  - pvc-filebrowser-config.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/clusters/vollminlab-cluster/mediastack/filebrowser/app/pvc-filebrowser-config.yaml
+++ b/clusters/vollminlab-cluster/mediastack/filebrowser/app/pvc-filebrowser-config.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-filebrowser-config
+  namespace: mediastack
+  labels:
+    app: filebrowser
+    env: production
+    category: apps
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: longhorn

--- a/clusters/vollminlab-cluster/mediastack/filebrowser/app/service.yaml
+++ b/clusters/vollminlab-cluster/mediastack/filebrowser/app/service.yaml
@@ -8,6 +8,7 @@ metadata:
     env: production
     category: apps
 spec:
+  type: ClusterIP
   selector:
     app: filebrowser
   ports:

--- a/clusters/vollminlab-cluster/mediastack/filebrowser/app/service.yaml
+++ b/clusters/vollminlab-cluster/mediastack/filebrowser/app/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: filebrowser
+  namespace: mediastack
+  labels:
+    app: filebrowser
+    env: production
+    category: apps
+spec:
+  selector:
+    app: filebrowser
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80

--- a/clusters/vollminlab-cluster/mediastack/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ./cloudflared-audiobookshelf/app
   - ./cloudflared-jellyfin/app
   - ./bazarr-exportarr/app
+  - ./filebrowser/app
   - ./seerr/app
   - ./jellyfin/app
   - ./jellystat-db/app

--- a/clusters/vollminlab-cluster/mediastack/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ./audiobookshelf/app
   - ./bazarr/app
   - ./cloudflared-audiobookshelf/app
+  - ./cloudflared-filebrowser/app
   - ./cloudflared-jellyfin/app
   - ./bazarr-exportarr/app
   - ./filebrowser/app

--- a/clusters/vollminlab-cluster/mediastack/pvcs/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/pvcs/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - pvc-audiobooks.yaml
   - pvc-books.yaml
   - pvc-completed-downloads.yaml
+  - pvc-filebrowser.yaml
   - pvc-incomplete-downloads.yaml
   - pvc-movies.yaml
   - pvc-tv.yaml

--- a/clusters/vollminlab-cluster/mediastack/pvcs/pvc-filebrowser.yaml
+++ b/clusters/vollminlab-cluster/mediastack/pvcs/pvc-filebrowser.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-filebrowser
+  namespace: mediastack
+  labels:
+    app: mediastack
+    env: production
+    category: media
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Gi
+  volumeName: pv-filebrowser
+  storageClassName: smb

--- a/terraform/authentik/applications.tf
+++ b/terraform/authentik/applications.tf
@@ -27,6 +27,12 @@ resource "authentik_application" "filebrowser" {
   open_in_new_tab = false
 }
 
+resource "authentik_policy_binding" "filebrowser_users" {
+  target = authentik_application.filebrowser.uuid
+  group  = authentik_group.filebrowser_users.id
+  order  = 0
+}
+
 resource "authentik_application" "grafana" {
   name              = "Grafana"
   slug              = "grafana"

--- a/terraform/authentik/applications.tf
+++ b/terraform/authentik/applications.tf
@@ -20,6 +20,13 @@ resource "authentik_application" "bazarr" {
   open_in_new_tab = false
 }
 
+resource "authentik_application" "filebrowser" {
+  name            = "FileBrowser"
+  slug            = "filebrowser"
+  meta_launch_url = "https://filebrowser.vollminlab.com"
+  open_in_new_tab = false
+}
+
 resource "authentik_application" "grafana" {
   name              = "Grafana"
   slug              = "grafana"

--- a/terraform/authentik/groups.tf
+++ b/terraform/authentik/groups.tf
@@ -8,6 +8,11 @@ resource "authentik_group" "audiobookshelf_users" {
   users = toset([authentik_user.jvollmin.id, authentik_user.gkroner.id, authentik_user.chavelock.id])
 }
 
+resource "authentik_group" "filebrowser_users" {
+  name  = "FileBrowser Users"
+  users = toset([authentik_user.vollmin.id, authentik_user.gkroner.id])
+}
+
 resource "authentik_group" "grafana_admins" {
   name  = "Grafana Admins"
   users = [authentik_user.vollmin.id]

--- a/terraform/cloudflare/dns.tf
+++ b/terraform/cloudflare/dns.tf
@@ -21,6 +21,15 @@ resource "cloudflare_dns_record" "audiobookshelf" {
   ttl     = 1
 }
 
+resource "cloudflare_dns_record" "filebrowser" {
+  zone_id = var.cloudflare_zone_id
+  name    = "filebrowser.vollminlab.com"
+  type    = "CNAME"
+  content = "${cloudflare_zero_trust_tunnel_cloudflared.vollminlab_filebrowser.id}.cfargotunnel.com"
+  proxied = true
+  ttl     = 1
+}
+
 resource "cloudflare_dns_record" "jellyfin" {
   zone_id = var.cloudflare_zone_id
   name    = "jellyfin.vollminlab.com"

--- a/terraform/cloudflare/tunnels.tf
+++ b/terraform/cloudflare/tunnels.tf
@@ -17,6 +17,12 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "vollminlab_audiobookshelf" 
   lifecycle { ignore_changes = all }
 }
 
+resource "cloudflare_zero_trust_tunnel_cloudflared" "vollminlab_filebrowser" {
+  account_id = var.cloudflare_account_id
+  name       = "vollminlab-FileBrowser"
+  lifecycle { ignore_changes = all }
+}
+
 resource "cloudflare_zero_trust_tunnel_cloudflared" "vollminlab_jellyfin" {
   account_id = var.cloudflare_account_id
   name       = "vollminlab-Jellyfin"
@@ -55,6 +61,24 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "vollminlab_audiobook
       {
         hostname = "audiobookshelf.vollminlab.com"
         service  = "http://audiobookshelf.mediastack.svc.cluster.local:10223"
+      },
+      {
+        service = "http_status:404"
+      },
+    ]
+  }
+}
+
+resource "cloudflare_zero_trust_tunnel_cloudflared_config" "vollminlab_filebrowser" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.vollminlab_filebrowser.id
+  lifecycle { ignore_changes = all }
+
+  config = {
+    ingress_rule = [
+      {
+        hostname = "filebrowser.vollminlab.com"
+        service  = "http://ingress-nginx-controller.ingress-nginx.svc.cluster.local:80"
       },
       {
         service = "http_status:404"


### PR DESCRIPTION
Deploys FileBrowser as a general-purpose authenticated file drop in `mediastack`.

## What's included

**Cloudflare (tofu):** New `vollminlab-FileBrowser` tunnel + DNS CNAME record. Tunnel routes through nginx (not directly to the service) so Authentik forward-auth can inject `X-authentik-username` — required for FileBrowser proxy auth mode.

**Authentik (tofu):** FileBrowser application entry, `FileBrowser Users` group (vollmin + gkroner), and a policy binding so only group members can access the app.

**Kubernetes:**
- Clusterwide SMB PV (`pv-filebrowser`) pointing to `//192.168.150.2/FileBrowser`
- SMB PVC in mediastack (`pvc-filebrowser`)
- FileBrowser Deployment with proxy auth configured via `FB_AUTH_METHOD=proxy` + `FB_AUTH_HEADER=X-authentik-username` env vars
- Longhorn config PVC (1Gi) for the SQLite database
- Service + Ingress with full Authentik forward-auth annotations
- `cloudflared-filebrowser` deployment and kustomization files present but **not yet wired into mediastack/kustomization.yaml** — pending the CF tunnel token being sealed

## Follow-up required before cloudflared deploys

1. Create the `vollminlab-FileBrowser` tunnel manually in Cloudflare Zero Trust → Networks → Tunnels (or wait for tofu to create it post-merge)
2. Copy the tunnel token → store in 1Password as `"FileBrowser Cloudflare Tunnel Token"` (Homelab vault)
3. Seal the token and add `cloudflared-filebrowser-tunnel-credentials-sealedsecret.yaml`
4. Wire `./cloudflared-filebrowser/app` into `mediastack/kustomization.yaml`

## After merge

- TrueNAS: create `FileBrowser` dataset + SMB share + `Audiobooks` subfolder (uid/gid=568)
- Bootstrap users: `filebrowser users add vollmin` (admin) and `filebrowser users add gkroner --scope /Audiobooks`
- Smoke test at `https://filebrowser.vollminlab.com`