### PR TITLE
fix(kyverno): exclude K8s 1.33 ServiceCIDR/IPAddress from webhook

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
@@ -223,10 +223,17 @@ data:
         - '[PriorityClass,*,*]'
         - '[RuntimeClass,*,*]'
         - '[Lease,*,*]'
+        # Kubernetes 1.33 new networking types — Kyverno 1.18 returns 400 for unknown types,
+        # which causes kube-apiserver to crash on startup when creating the default ServiceCIDR.
+        # matchConditions below also excludes these at the apiserver level (belt-and-suspenders).
+        - '[ServiceCIDR,*,*]'
+        - '[IPAddress,*,*]'
       # namespaceSelector can't exclude cluster-scoped resources; CEL evaluated by apiserver before any Kyverno connection
       matchConditions:
         - name: exclude-auth-review-resources
           expression: "!(request.resource.resource in ['subjectaccessreviews', 'selfsubjectaccessreviews', 'selfsubjectrulesreviews', 'tokenreviews'])"
+        - name: exclude-k8s133-network-resources
+          expression: "!(request.resource.resource in ['servicecidrs', 'ipaddresses'])"
 
     serviceMonitor:
       enabled: true


### PR DESCRIPTION
## Summary

- Adds `ServiceCIDR` and `IPAddress` to Kyverno's `resourceFilters` and a new `matchConditions` CEL expression
- Prevents `kube-apiserver` from crashing on startup during K8s 1.33 upgrade

## Root cause

Kyverno 1.18's `validate.kyverno.svc-fail` webhook matches all resources (`apiGroups: *`, `resources: *`). Kubernetes 1.33 introduced `ServiceCIDR` and `IPAddress` in `networking.k8s.io/v1`. Kyverno returns 400 for unknown types, causing the apiserver's `start-service-ip-repair-controllers` PostStartHook to fail on every startup — crashing k8scp01 and k8scp02 after the 1.32→1.33 hop.

## Fix (two layers)

| Layer | Mechanism | Where |
|-------|-----------|-------|
| Inner | `resourceFilters` — Kyverno allows these resources without policy evaluation | config.resourceFilters |
| Outer | `matchConditions` CEL expression — apiserver never calls Kyverno for these types | config.matchConditions |

The `matchConditions` layer is the definitive fix: the apiserver evaluates the CEL expression before making any webhook call, so Kyverno is never invoked for ServiceCIDR/IPAddress.

## Hot-fix applied

Live cluster was already patched (ConfigMap and webhook updated, admission controller scaled down/up) — k8scp01 and k8scp02 are Ready. This PR makes the fix permanent via Flux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)