### PR TITLE
feat(mediastack): split FileBrowser storage into audiobooks-incoming and misc-incoming shares

### DIFF
--- a/clusters/vollminlab-cluster/clusterwide/kustomization.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/kustomization.yaml
@@ -8,8 +8,9 @@ resources:
   - pv-audiobooks.yaml
   - pv-books.yaml
   - pv-completed-downloads.yaml
-  - pv-filebrowser.yaml
+  - pv-audiobooks-incoming.yaml
   - pv-incomplete-downloads.yaml
+  - pv-misc-incoming.yaml
   - pv-movies.yaml
   - pv-tv.yaml
   - storageclass-smb.yaml

--- a/clusters/vollminlab-cluster/clusterwide/pv-audiobooks-incoming.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/pv-audiobooks-incoming.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-audiobooks-incoming
+  labels:
+    app: mediastack
+    env: production
+    category: media
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb
+  csi:
+    driver: smb.csi.k8s.io
+    volumeHandle: audiobooks-incoming
+    volumeAttributes:
+      source: "//192.168.150.2/audiobooks-incoming"
+    nodeStageSecretRef:
+      name: smb-credentials
+      namespace: mediastack
+  mountOptions:
+    - uid=568
+    - gid=568
+    - dir_mode=0755
+    - file_mode=0755

--- a/clusters/vollminlab-cluster/clusterwide/pv-misc-incoming.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/pv-misc-incoming.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: pv-filebrowser
+  name: pv-misc-incoming
   labels:
     app: mediastack
     env: production
@@ -15,9 +15,9 @@ spec:
   storageClassName: smb
   csi:
     driver: smb.csi.k8s.io
-    volumeHandle: filebrowser
+    volumeHandle: misc-incoming
     volumeAttributes:
-      source: "//192.168.150.2/FileBrowser"
+      source: "//192.168.150.2/misc-incoming"
     nodeStageSecretRef:
       name: smb-credentials
       namespace: mediastack

--- a/clusters/vollminlab-cluster/mediastack/filebrowser/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/filebrowser/app/deployment.yaml
@@ -38,8 +38,10 @@ spec:
             - name: settings
               mountPath: /config/settings.json
               subPath: settings.json
-            - name: data
-              mountPath: /srv
+            - name: audiobooks-incoming
+              mountPath: /srv/Audiobooks
+            - name: misc-incoming
+              mountPath: /srv/Misc
           resources:
             requests:
               cpu: 50m
@@ -54,6 +56,9 @@ spec:
         - name: settings
           configMap:
             name: filebrowser-settings
-        - name: data
+        - name: audiobooks-incoming
           persistentVolumeClaim:
-            claimName: pvc-filebrowser
+            claimName: pvc-audiobooks-incoming
+        - name: misc-incoming
+          persistentVolumeClaim:
+            claimName: pvc-misc-incoming

--- a/clusters/vollminlab-cluster/mediastack/pvcs/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/pvcs/kustomization.yaml
@@ -6,7 +6,8 @@ resources:
   - pvc-audiobooks.yaml
   - pvc-books.yaml
   - pvc-completed-downloads.yaml
-  - pvc-filebrowser.yaml
+  - pvc-audiobooks-incoming.yaml
   - pvc-incomplete-downloads.yaml
+  - pvc-misc-incoming.yaml
   - pvc-movies.yaml
   - pvc-tv.yaml

--- a/clusters/vollminlab-cluster/mediastack/pvcs/pvc-audiobooks-incoming.yaml
+++ b/clusters/vollminlab-cluster/mediastack/pvcs/pvc-audiobooks-incoming.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-audiobooks-incoming
+  namespace: mediastack
+  labels:
+    app: mediastack
+    env: production
+    category: media
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Gi
+  volumeName: pv-audiobooks-incoming
+  storageClassName: smb

--- a/clusters/vollminlab-cluster/mediastack/pvcs/pvc-misc-incoming.yaml
+++ b/clusters/vollminlab-cluster/mediastack/pvcs/pvc-misc-incoming.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: pvc-filebrowser
+  name: pvc-misc-incoming
   namespace: mediastack
   labels:
     app: mediastack
@@ -13,5 +13,5 @@ spec:
   resources:
     requests:
       storage: 100Gi
-  volumeName: pv-filebrowser
+  volumeName: pv-misc-incoming
   storageClassName: smb


### PR DESCRIPTION
Replaces the single `pv-filebrowser` / `pvc-filebrowser` with two separate SMB-backed PV+PVC pairs, one per TrueNAS share. The FileBrowser deployment mounts them at `/srv/Audiobooks` and `/srv/Misc` so both folders appear at the root of the file browser UI.

TrueNAS dataset quotas are set on each share independently to cap what can be uploaded.

## Changes

- `pv-filebrowser` → `pv-audiobooks-incoming` (`//192.168.150.2/audiobooks-incoming`) + `pv-misc-incoming` (`//192.168.150.2/misc-incoming`)
- `pvc-filebrowser` → `pvc-audiobooks-incoming` + `pvc-misc-incoming`
- FileBrowser deployment: replaced single `/srv` mount with `/srv/Audiobooks` + `/srv/Misc`

## After merge — updated bootstrap commands

```bash
FILEBROWSER_POD=$(kubectl get pods -n mediastack -l app=filebrowser -o jsonpath='{.items[0].metadata.name}')

kubectl exec -n mediastack $FILEBROWSER_POD -- \
  filebrowser users add vollmin "$(openssl rand -base64 24)" \
  --perm.admin --database /config/database.db

kubectl exec -n mediastack $FILEBROWSER_POD -- \
  filebrowser users add gkroner "$(openssl rand -base64 24)" \
  --scope / \
  --perm.create=true --perm.upload=true \
  --perm.download=true --perm.delete=false --perm.rename=false \
  --perm.modify=false --perm.admin=false \
  --database /config/database.db
```

Note: gkroner's scope is `/` (root) so he sees both `Audiobooks/` and `Misc/`. Storage quotas on the TrueNAS shares are what limit how much he can upload.