### PR TITLE
fix(mediastack): add fsGroup: 1000 to filebrowser pod for Longhorn volume write access

### DIFF
--- a/clusters/vollminlab-cluster/clusterwide/pv-audiobooks-incoming.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/pv-audiobooks-incoming.yaml
@@ -8,7 +8,7 @@ metadata:
     category: media
 spec:
   capacity:
-    storage: 100Gi
+    storage: 250Gi
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain

--- a/clusters/vollminlab-cluster/clusterwide/pv-misc-incoming.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/pv-misc-incoming.yaml
@@ -8,7 +8,7 @@ metadata:
     category: media
 spec:
   capacity:
-    storage: 100Gi
+    storage: 250Gi
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain

--- a/clusters/vollminlab-cluster/mediastack/filebrowser/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/filebrowser/app/deployment.yaml
@@ -21,6 +21,8 @@ spec:
         category: apps
         app.kubernetes.io/name: filebrowser
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: filebrowser
           image: filebrowser/filebrowser:v2.63.3

--- a/clusters/vollminlab-cluster/mediastack/pvcs/pvc-audiobooks-incoming.yaml
+++ b/clusters/vollminlab-cluster/mediastack/pvcs/pvc-audiobooks-incoming.yaml
@@ -12,6 +12,6 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 100Gi
+      storage: 250Gi
   volumeName: pv-audiobooks-incoming
   storageClassName: smb

--- a/clusters/vollminlab-cluster/mediastack/pvcs/pvc-misc-incoming.yaml
+++ b/clusters/vollminlab-cluster/mediastack/pvcs/pvc-misc-incoming.yaml
@@ -12,6 +12,6 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 100Gi
+      storage: 250Gi
   volumeName: pv-misc-incoming
   storageClassName: smb


### PR DESCRIPTION
FileBrowser pod is crashing with `open /config/database.db: permission denied`.

Root cause: `filebrowser/filebrowser:v2.63.3` runs as UID/GID 1000. The Longhorn PVC root directory is `755 root:root`, so UID 1000 can read but not write.

Fix: `securityContext.fsGroup: 1000` on the pod spec causes Kubernetes to chown the volume to GID 1000 on mount, giving the container write access to create its SQLite database.