### PR TITLE
fix(filebrowser): use uid/gid=1000 on SMB mounts to unblock ContainerCreating

### DIFF
--- a/clusters/vollminlab-cluster/clusterwide/pv-audiobooks-incoming.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/pv-audiobooks-incoming.yaml
@@ -22,7 +22,7 @@ spec:
       name: smb-credentials
       namespace: mediastack
   mountOptions:
-    - uid=568
-    - gid=568
+    - uid=1000
+    - gid=1000
     - dir_mode=0755
-    - file_mode=0755
+    - file_mode=0644

--- a/clusters/vollminlab-cluster/clusterwide/pv-misc-incoming.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/pv-misc-incoming.yaml
@@ -22,7 +22,7 @@ spec:
       name: smb-credentials
       namespace: mediastack
   mountOptions:
-    - uid=568
-    - gid=568
+    - uid=1000
+    - gid=1000
     - dir_mode=0755
-    - file_mode=0755
+    - file_mode=0644

--- a/clusters/vollminlab-cluster/mediastack/filebrowser/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/filebrowser/app/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       securityContext:
         fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: filebrowser
           image: filebrowser/filebrowser:v2.63.3


### PR DESCRIPTION
## Summary

- SMB PVs (`pv-audiobooks-incoming`, `pv-misc-incoming`) were mounted with `uid=568/gid=568` (TrueNAS apps user). FileBrowser runs as `uid=1000`, so it couldn't write to the shares anyway.
- `fsGroup: 1000` on the pod spec caused kubelet to attempt a recursive `chown` on the CIFS mounts to match GID 1000. CIFS doesn't support chown — kubelet hung indefinitely and the pod was stuck in `ContainerCreating` for 6+ hours.
- Added `fsGroupChangePolicy: OnRootMismatch` so kubelet checks the root dir GID before chowning; with `gid=1000` on the mount, the check passes and the chown is skipped entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)