### PR TITLE
fix(filebrowser): switch port 80→8080 for non-root container

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/filebrowser/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/filebrowser/app/configmap.yaml
@@ -10,7 +10,7 @@ metadata:
 data:
   settings.json: |
     {
-      "port": 80,
+      "port": 8080,
       "baseURL": "",
       "address": "",
       "log": "stdout",

--- a/clusters/vollminlab-cluster/mediastack/filebrowser/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/filebrowser/app/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - name: FB_AUTH_HEADER
               value: X-authentik-username
           ports:
-            - containerPort: 80
+            - containerPort: 8080
           volumeMounts:
             - name: config
               mountPath: /config

--- a/clusters/vollminlab-cluster/mediastack/filebrowser/app/service.yaml
+++ b/clusters/vollminlab-cluster/mediastack/filebrowser/app/service.yaml
@@ -14,4 +14,4 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: 80
+      targetPort: 8080


### PR DESCRIPTION
## Summary

- `filebrowser/filebrowser` runs as `uid=1000` and cannot bind to port 80 (Linux restricts ports < 1024 to root), causing `Error: listen tcp :80: bind: permission denied` crash loop
- Switches `settings.json`, `containerPort`, and `service targetPort` all to 8080

🤖 Generated with [Claude Code](https://claude.com/claude-code)