### PR TITLE
fix(homepage): remove Pi-hole widget API key

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -178,7 +178,6 @@ data:
                   type: pihole
                   url: https://pihole.vollminlab.com
                   version: 6
-                  key: "{{HOMEPAGE_VAR_PIHOLE_API_KEY}}"
             - UDM:
                 description: UniFi Dream Machine
                 href: https://udm.vollminlab.com


### PR DESCRIPTION
## Summary

- Pi-hole has no admin password (Authentik via NPM handles access control) — the homepage Pi-hole v6 widget was POSTing the key to `/api/auth`, receiving `validity: -1`, and crashing with `Cache timeout must be a positive number` → `Unexpected error` in the UI
- The `/api/stats/summary` endpoint is publicly accessible without credentials, so the `key` field is not needed
- Also fixed in NPM (out of band): added a `location /api/ { auth_request off; }` block to the Pi-hole proxy host Advanced Config so the widget bypasses Authentik for API calls while the admin UI remains protected