### PR TITLE
fix(cloudflare-tf): rename ingress_rule → ingress (CF provider v5)

### DIFF
--- a/terraform/cloudflare/tunnels.tf
+++ b/terraform/cloudflare/tunnels.tf
@@ -55,7 +55,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "authentik" {
   tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.authentik.id
 
   config = {
-    ingress_rule = [
+    ingress = [
       {
         hostname = "authentik.vollminlab.com"
         service  = "http://authentik-server.authentik.svc.cluster.local:80"
@@ -72,7 +72,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "audiobookshelf" {
   tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.audiobookshelf.id
 
   config = {
-    ingress_rule = [
+    ingress = [
       {
         hostname = "audiobookshelf.vollminlab.com"
         service  = "http://audiobookshelf.mediastack.svc.cluster.local:10223"
@@ -89,7 +89,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "jellyfin" {
   tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.jellyfin.id
 
   config = {
-    ingress_rule = [
+    ingress = [
       {
         hostname = "jellyfin.vollminlab.com"
         service  = "http://jellyfin.mediastack.svc.cluster.local:8096"
@@ -106,7 +106,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "nginx" {
   tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.nginx.id
 
   config = {
-    ingress_rule = [
+    ingress = [
       {
         hostname = "filebrowser.vollminlab.com"
         service  = "http://ingress-nginx-controller.ingress-nginx.svc.cluster.local:80"


### PR DESCRIPTION
## Summary

- `cloudflare_zero_trust_tunnel_cloudflared_config` in CF provider v5.19.1 uses `ingress` not `ingress_rule`
- Wrong attribute name caused provider to send empty ingress lists → 400 "no ingress rules" on all 4 tunnel configs
- All 4 new tunnels exist in CF (created by PR #635 apply) but have no ingress config until this merges

## Urgency

External access to authentik, audiobookshelf, and jellyfin is down. cloudflared pods were scaled to 0 to allow old tunnel deletion. This fix + follow-up sealed token PR is needed to restore access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)