### PR TITLE
fix(authentik): route tunnel through nginx to fix /start 404 for unauthenticated external users

### DIFF
--- a/clusters/vollminlab-cluster/authentik/authentik/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/authentik/authentik/app/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: authentik-ingress
   namespace: authentik
   annotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     shlink.vollminlab.com/slug: authentik
   labels:

--- a/terraform/cloudflare/tunnels.tf
+++ b/terraform/cloudflare/tunnels.tf
@@ -58,7 +58,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "authentik" {
     ingress = [
       {
         hostname = "authentik.vollminlab.com"
-        service  = "http://authentik-server.authentik.svc.cluster.local:80"
+        service  = "http://ingress-nginx-controller.ingress-nginx.svc.cluster.local:80"
       },
       {
         service = "http_status:404"


### PR DESCRIPTION
## Root cause

The authentik cloudflared tunnel routed **directly** to `authentik-server:80`, bypassing nginx entirely. nginx has the `/outpost.goauthentik.io/ → authentik-proxy:9000` routing rule — but external requests never hit it. They went straight to the Authentik server, which returns 404 for `/outpost.goauthentik.io/start`.

Internal (LAN) requests worked because they go through nginx, which correctly routes to the outpost. This is why the bug only appeared on unauthenticated external sessions (Chrome mobile fresh install, incognito, etc.) — logged-in users never hit `/start`.

## Fix

- `tunnels.tf`: Point the authentik tunnel at `ingress-nginx-controller:80` (same pattern as cloudflared-nginx), so external and internal requests take the same path
- `ingress.yaml`: Disable `ssl-redirect` on the Authentik ingress — tunnel delivers HTTP, nginx doesn't need to redirect (same fix applied to filebrowser in #639)

## Verification

Tested `authentik-proxy:9000/outpost.goauthentik.io/start?rd=https://filebrowser.vollminlab.com/` directly — returns 302 correctly. After this change, external requests will also reach the outpost instead of the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)