### PR TITLE
feat(readarr): deploy Readarr for book and audiobook management

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
@@ -35,6 +35,7 @@ resources:
   - prometheus-community-helmrepository.yaml
   - prowlarr-ocirepository.yaml
   - radarr-ocirepository.yaml
+  - readarr-ocirepository.yaml
   - renovate-ocirepository.yaml
   - sabnzbd-ocirepository.yaml
   - seerr-ocirepository.yaml

--- a/clusters/vollminlab-cluster/flux-system/repositories/readarr-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/readarr-ocirepository.yaml
@@ -1,0 +1,14 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: readarr-repo
+  namespace: flux-system
+  labels:
+    app: readarr
+    env: production
+    category: media
+spec:
+  url: oci://oci.trueforge.org/truecharts/readarr
+  interval: 5m
+  ref:
+    tag: 26.1.5

--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -75,6 +75,16 @@ data:
                   type: radarr
                   url: http://radarr.mediastack.svc.cluster.local:7878
                   key: "{{HOMEPAGE_VAR_RADARR_API_KEY}}"
+            - Readarr:
+                description: Book and audiobook manager
+                href: https://readarr.vollminlab.com
+                icon: readarr.png
+                namespace: mediastack
+                app: readarr
+                widget:
+                  type: readarr
+                  url: http://readarr.mediastack.svc.cluster.local:8787
+                  key: "{{HOMEPAGE_VAR_READARR_API_KEY}}"
             - Prowlarr:
                 description: Indexer manager
                 href: https://prowlarr.vollminlab.com
@@ -441,6 +451,11 @@ data:
           secretKeyRef:
             name: homepage-env-vars
             key: RADARR_API_KEY
+      - name: HOMEPAGE_VAR_READARR_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: homepage-env-vars
+            key: READARR_API_KEY
       - name: HOMEPAGE_VAR_PROWLARR_API_KEY
         valueFrom:
           secretKeyRef:

--- a/clusters/vollminlab-cluster/mediastack/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - ./jellystat-db/app
   - ./jellystat/app
   - ./prowlarr/app
+  - ./readarr/app
   - ./radarr/app
   - ./sabnzbd/app
   - ./sonarr/app

--- a/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: readarr-values
+  namespace: mediastack
+  labels:
+    app: readarr
+    env: production
+    category: media
+data:
+  values.yaml: |
+    persistence:
+      config:
+        enabled: true
+        existingClaim: pvc-readarr-config
+        mountPath: /config
+      downloads:
+        enabled: true
+        existingClaim: pvc-completed-downloads
+        mountPath: /downloads
+      audiobooks:
+        enabled: true
+        existingClaim: pvc-audiobooks
+        mountPath: /audiobooks
+      books:
+        enabled: true
+        existingClaim: pvc-books
+        mountPath: /books
+    terminationGracePeriodSeconds: 60
+    lifecycle:
+      preStop:
+        exec:
+          command: ["/bin/sh", "-c", "sleep 10"]
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    podLabels:
+      app: readarr
+      env: production
+      category: media
+    env:
+      READARR__AUTH__METHOD: "External"
+    securityContext:
+      runAsUser: 568
+      runAsGroup: 568
+    podSecurityContext:
+      fsGroup: 568
+      fsGroupChangePolicy: "OnRootMismatch"

--- a/clusters/vollminlab-cluster/mediastack/readarr/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/mediastack/readarr/app/helmrelease.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: readarr
+  namespace: mediastack
+  labels:
+    app: readarr
+    env: production
+    category: media
+spec:
+  interval: 5m
+  chartRef:
+    kind: OCIRepository
+    name: readarr-repo
+    namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: readarr-values
+      valuesKey: values.yaml

--- a/clusters/vollminlab-cluster/mediastack/readarr/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/readarr/app/ingress.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: readarr-ingress
+  namespace: mediastack
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=https://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/auth-snippet: |
+      proxy_set_header X-Forwarded-Host $http_host;
+    shlink.vollminlab.com/slug: readarr
+  labels:
+    app: readarr
+    env: production
+    category: media
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: readarr.vollminlab.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: readarr
+                port:
+                  number: 8787
+  tls:
+    - hosts:
+        - readarr.vollminlab.com
+      secretName: wildcard-tls

--- a/clusters/vollminlab-cluster/mediastack/readarr/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/readarr/app/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: readarr-app
+resources:
+  - configmap.yaml
+  - helmrelease.yaml
+  - ingress.yaml
+  - pvc-readarr-config.yaml

--- a/clusters/vollminlab-cluster/mediastack/readarr/app/pvc-readarr-config.yaml
+++ b/clusters/vollminlab-cluster/mediastack/readarr/app/pvc-readarr-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-readarr-config
+  namespace: mediastack
+  labels:
+    app: readarr
+    env: production
+    category: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/clusters/vollminlab-cluster/tofu/readarr-config/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/tofu/readarr-config/app/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: readarr-config
+  labels:
+    app: tofu-controller
+    env: production
+    category: core
+resources:
+  - readarr-tf-credentials-sealedsecret.yaml
+  - terraform-cr.yaml

--- a/clusters/vollminlab-cluster/tofu/readarr-config/app/terraform-cr.yaml
+++ b/clusters/vollminlab-cluster/tofu/readarr-config/app/terraform-cr.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: infra.contrib.fluxcd.io/v1alpha2
+kind: Terraform
+metadata:
+  name: readarr-config
+  namespace: tofu
+  labels:
+    app: tofu-controller
+    env: production
+    category: core
+spec:
+  interval: 10m
+  approvePlan: auto
+  path: ./terraform/readarr
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  backendConfig:
+    customConfiguration: |
+      backend "s3" {
+        bucket                      = "terraform-state"
+        key                         = "readarr/terraform.tfstate"
+        region                      = "us-east-1"
+        endpoint                    = "http://minio.minio.svc.cluster.local:9000"
+        force_path_style            = true
+        skip_credentials_validation = true
+        skip_metadata_api_check     = true
+        skip_region_validation      = true
+      }
+  backendConfigsFrom:
+    - kind: Secret
+      name: tofu-minio-credentials
+  varsFrom:
+    - kind: Secret
+      name: readarr-tf-credentials

--- a/terraform/authentik/applications.tf
+++ b/terraform/authentik/applications.tf
@@ -158,6 +158,13 @@ resource "authentik_application" "radarr" {
   open_in_new_tab = false
 }
 
+resource "authentik_application" "readarr" {
+  name            = "Readarr"
+  slug            = "readarr"
+  meta_launch_url = "https://readarr.vollminlab.com"
+  open_in_new_tab = false
+}
+
 resource "authentik_application" "sabnzbd" {
   name            = "SABnzbd"
   slug            = "sabnzbd"

--- a/terraform/readarr/download-clients.tf
+++ b/terraform/readarr/download-clients.tf
@@ -1,0 +1,12 @@
+resource "readarr_download_client_sabnzbd" "sabnzbd" {
+  name                       = "SABnzbd"
+  enable                     = true
+  priority                   = 1
+  host                       = "sabnzbd"
+  port                       = 10097
+  api_key                    = var.sabnzbd_api_key
+  use_ssl                    = false
+  book_category              = "books"
+  remove_completed_downloads = true
+  remove_failed_downloads    = true
+}

--- a/terraform/readarr/providers.tf
+++ b/terraform/readarr/providers.tf
@@ -1,0 +1,4 @@
+provider "readarr" {
+  url     = "http://readarr.mediastack.svc.cluster.local:8787"
+  api_key = var.readarr_api_key
+}

--- a/terraform/readarr/root-folders.tf
+++ b/terraform/readarr/root-folders.tf
@@ -1,21 +1,21 @@
 resource "readarr_root_folder" "audiobooks" {
-  path                             = "/audiobooks"
-  name                             = "Audiobooks"
-  default_metadata_profile_id      = 1
-  default_quality_profile_id       = 1
-  default_monitor_option           = "all"
-  default_monitor_new_item_option  = "all"
-  is_calibre_library               = false
-  output_profile                   = "default"
+  path                            = "/audiobooks"
+  name                            = "Audiobooks"
+  default_metadata_profile_id     = 1
+  default_quality_profile_id      = 1
+  default_monitor_option          = "all"
+  default_monitor_new_item_option = "all"
+  is_calibre_library              = false
+  output_profile                  = "default"
 }
 
 resource "readarr_root_folder" "books" {
-  path                             = "/books"
-  name                             = "Books"
-  default_metadata_profile_id      = 1
-  default_quality_profile_id       = 1
-  default_monitor_option           = "all"
-  default_monitor_new_item_option  = "all"
-  is_calibre_library               = false
-  output_profile                   = "default"
+  path                            = "/books"
+  name                            = "Books"
+  default_metadata_profile_id     = 1
+  default_quality_profile_id      = 1
+  default_monitor_option          = "all"
+  default_monitor_new_item_option = "all"
+  is_calibre_library              = false
+  output_profile                  = "default"
 }

--- a/terraform/readarr/root-folders.tf
+++ b/terraform/readarr/root-folders.tf
@@ -1,0 +1,19 @@
+resource "readarr_root_folder" "audiobooks" {
+  path                        = "/audiobooks"
+  name                        = "Audiobooks"
+  default_metadata_profile_id = 1
+  default_quality_profile_id  = 1
+  default_monitor_option      = "all"
+  is_calibre_library          = false
+  output_profile              = "default"
+}
+
+resource "readarr_root_folder" "books" {
+  path                        = "/books"
+  name                        = "Books"
+  default_metadata_profile_id = 1
+  default_quality_profile_id  = 1
+  default_monitor_option      = "all"
+  is_calibre_library          = false
+  output_profile              = "default"
+}

--- a/terraform/readarr/root-folders.tf
+++ b/terraform/readarr/root-folders.tf
@@ -1,19 +1,21 @@
 resource "readarr_root_folder" "audiobooks" {
-  path                        = "/audiobooks"
-  name                        = "Audiobooks"
-  default_metadata_profile_id = 1
-  default_quality_profile_id  = 1
-  default_monitor_option      = "all"
-  is_calibre_library          = false
-  output_profile              = "default"
+  path                             = "/audiobooks"
+  name                             = "Audiobooks"
+  default_metadata_profile_id      = 1
+  default_quality_profile_id       = 1
+  default_monitor_option           = "all"
+  default_monitor_new_item_option  = "all"
+  is_calibre_library               = false
+  output_profile                   = "default"
 }
 
 resource "readarr_root_folder" "books" {
-  path                        = "/books"
-  name                        = "Books"
-  default_metadata_profile_id = 1
-  default_quality_profile_id  = 1
-  default_monitor_option      = "all"
-  is_calibre_library          = false
-  output_profile              = "default"
+  path                             = "/books"
+  name                             = "Books"
+  default_metadata_profile_id      = 1
+  default_quality_profile_id       = 1
+  default_monitor_option           = "all"
+  default_monitor_new_item_option  = "all"
+  is_calibre_library               = false
+  output_profile                   = "default"
 }

--- a/terraform/readarr/variables.tf
+++ b/terraform/readarr/variables.tf
@@ -1,0 +1,11 @@
+variable "readarr_api_key" {
+  description = "Readarr API key for provider authentication"
+  type        = string
+  sensitive   = true
+}
+
+variable "sabnzbd_api_key" {
+  description = "SABnzbd API key for download client configuration"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/readarr/versions.tf
+++ b/terraform/readarr/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    readarr = {
+      source  = "devopsarr/readarr"
+      version = "~> 2.1"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Deploys Readarr to the `mediastack` namespace alongside Radarr/Sonarr, using the TrueCharts Helm chart (26.1.5) via the existing OCI registry pattern
- Readarr mounts `pvc-audiobooks` (`/audiobooks`) and `pvc-books` (`/books`) — the same PVCs AudiobookShelf already uses — so completed downloads land directly in AudiobookShelf's library without any extra configuration
- Downloads flow through the existing `pvc-completed-downloads` / SABnzbd pipeline
- Authentik application entry added to Terraform (`forward-auth`, no OAuth2 provider — same pattern as Radarr/Sonarr/Prowlarr)
- Homepage widget added with `HOMEPAGE_VAR_READARR_API_KEY` env injection (key populated via `homepage-env-vars` SealedSecret in Phase 2)

### What's included (Phase 1)

| File | Change |
|------|--------|
| `flux-system/repositories/readarr-ocirepository.yaml` | New OCIRepository |
| `mediastack/readarr/app/` | HelmRelease, ConfigMap, Ingress (8787), 5Gi config PVC |
| `mediastack/kustomization.yaml` | Added `./readarr/app` |
| `flux-system/repositories/kustomization.yaml` | Added `readarr-ocirepository.yaml` |
| `terraform/authentik/applications.tf` | Added `authentik_application.readarr` |
| `homepage/homepage/app/configmap.yaml` | Added Readarr widget + env var |
| `terraform/readarr/` | Full Terraform module (download client, root folders) — not yet wired |
| `tofu/readarr-config/app/` | Tofu workspace CR — not yet wired into `tofu/kustomization.yaml` |

### Phase 2 (separate PR, after Readarr is running)

1. Retrieve Readarr API key from Settings → General
2. Seal `readarr-tf-credentials` (readarr + sabnzbd API keys) and commit it to `tofu/readarr-config/app/`
3. Wire `readarr-config/app` into `tofu/kustomization.yaml`
4. Add `prowlarr_application_readarr` to `terraform/prowlarr/` + update prowlarr-config CR `varsFrom`
5. Re-seal `homepage-env-vars` with `READARR_API_KEY` added

🤖 Generated with [Claude Code](https://claude.com/claude-code)