### PR TITLE
fix(readarr): override image to public home-operations/readarr

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
@@ -42,6 +42,9 @@ data:
       app: readarr
       env: production
       category: media
+    image:
+      repository: ghcr.io/home-operations/readarr
+      tag: 0.4.18.2805@sha256:8f7551205fbdccd526db23a38a6fba18b0f40726e63bb89be0fb2333ff4ee4cd
     env:
       READARR__AUTH__METHOD: "External"
     securityContext:


### PR DESCRIPTION
## Summary

- The TrueCharts `readarr` chart at `26.1.5` defaults to `ghcr.io/elfhosted/readarr-develop` which returns 401 Unauthorized — the image is gated
- Override `image.repository` to `ghcr.io/home-operations/readarr` (same version `0.4.18.2805`, public registry, same image used by the radarr/sonarr stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)