### PR TITLE
feat(authentik-tf): add jkvedaras user with audiobookshelf, jellyfin, and filebrowser access

### DIFF
--- a/terraform/authentik/groups.tf
+++ b/terraform/authentik/groups.tf
@@ -5,12 +5,12 @@ resource "authentik_group" "audiobookshelf_admins" {
 
 resource "authentik_group" "audiobookshelf_users" {
   name  = "Audiobookshelf Users"
-  users = toset([authentik_user.jvollmin.id, authentik_user.gkroner.id, authentik_user.chavelock.id])
+  users = toset([authentik_user.jvollmin.id, authentik_user.gkroner.id, authentik_user.chavelock.id, authentik_user.jkvedaras.id])
 }
 
 resource "authentik_group" "filebrowser_users" {
   name  = "FileBrowser Users"
-  users = toset([authentik_user.vollmin.id, authentik_user.gkroner.id])
+  users = toset([authentik_user.vollmin.id, authentik_user.gkroner.id, authentik_user.jkvedaras.id])
 }
 
 resource "authentik_group" "grafana_admins" {
@@ -35,7 +35,7 @@ resource "authentik_group" "jellyfin_admins" {
 
 resource "authentik_group" "jellyfin_users" {
   name  = "Jellyfin Users"
-  users = toset([authentik_user.jvollmin.id, authentik_user.vollmin.id, authentik_user.gkroner.id, authentik_user.chavelock.id])
+  users = toset([authentik_user.jvollmin.id, authentik_user.vollmin.id, authentik_user.gkroner.id, authentik_user.chavelock.id, authentik_user.jkvedaras.id])
 }
 
 resource "authentik_group" "minio_admins" {

--- a/terraform/authentik/users.tf
+++ b/terraform/authentik/users.tf
@@ -33,6 +33,17 @@ resource "authentik_user" "gkroner" {
   }
 }
 
+resource "authentik_user" "jkvedaras" {
+  username  = "jkvedaras"
+  name      = "jkvedaras"
+  email     = "jokvedaras@gmail.com"
+  is_active = true
+
+  lifecycle {
+    ignore_changes = [password, groups]
+  }
+}
+
 resource "authentik_user" "chavelock" {
   username  = "chavelock"
   name      = "chavelock"


### PR DESCRIPTION
## Summary

- Adds `jkvedaras` Authentik user (email: jokvedaras@gmail.com)
- Adds to `Audiobookshelf Users`, `Jellyfin Users`, and `FileBrowser Users` groups
- FileBrowser user already bootstrapped (create/download/share permissions, no rename/modify/delete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)