### PR TITLE
fix(authentik-tf): add import block for jkvedaras (manually created user)

### DIFF
--- a/terraform/authentik/imports.tf
+++ b/terraform/authentik/imports.tf
@@ -19,6 +19,11 @@ import {
   id = "12"
 }
 
+import {
+  to = authentik_user.jkvedaras
+  id = "13"
+}
+
 # Groups
 import {
   to = authentik_group.audiobookshelf_admins


### PR DESCRIPTION
## Summary

- Adds `import` block for `authentik_user.jkvedaras` (pk=13)
- jkvedaras was manually created in Authentik before the TF resource landed in #645
- Without this, `tofu apply` would fail trying to create a duplicate user

🤖 Generated with [Claude Code](https://claude.com/claude-code)