### PR TITLE
fix(cloudflare): bypass bot challenges for authentik.vollminlab.com

### DIFF
--- a/terraform/cloudflare/security.tf
+++ b/terraform/cloudflare/security.tf
@@ -1,0 +1,31 @@
+# ---------------------------------------------------------------------------
+# Cloudflare WAF Custom Rules — Security overrides
+#
+# Authentik handles all authentication itself, so Cloudflare's bot challenges
+# must be bypassed for authentik.vollminlab.com. Without this, a fresh browser
+# session (incognito, first visit) gets a managed challenge on the
+# /api/v3/flows/executor/ fetch, which returns HTML instead of JSON and
+# breaks the login flow with "Request failed and the interceptors did not
+# return an alternative response".
+# ---------------------------------------------------------------------------
+
+resource "cloudflare_ruleset" "authentik_skip_challenges" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "Authentik — skip bot challenges"
+  description = "Bypass Cloudflare bot/security challenges for authentik.vollminlab.com so the login flow API calls are not intercepted"
+  kind        = "zone"
+  phase       = "http_request_firewall_custom"
+
+  rules = [
+    {
+      action = "skip"
+      action_parameters = {
+        phases   = ["http_ratelimit", "http_request_firewall_managed"]
+        products = ["bic", "hot", "rateLimit", "securityLevel", "uaBlock", "waf", "zoneLockdown"]
+      }
+      expression  = "(http.host eq \"authentik.vollminlab.com\")"
+      description = "Skip bot challenges for Authentik — IAM handles its own authentication"
+      enabled     = true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Cloudflare was intercepting `fetch()` API calls (e.g. `/api/v3/flows/executor/`) with a 403 Managed Challenge for fresh browser sessions (incognito, new device, any client without a `cf_clearance` cookie)
- The Authentik flow SPA's JavaScript `fetch()` cannot execute JS to solve the challenge, so it receives an HTML challenge page instead of JSON
- This causes "The request failed and the interceptors did not return an alternative response" on the Authentik login page — visible in fresh incognito windows and on first-ever visits
- Regular sessions were unaffected because they already held a `cf_clearance` cookie from a prior visit

**Root cause confirmed** via `curl --resolve authentik.vollminlab.com:443:104.21.84.3` — returned HTTP 403 with Cloudflare challenge HTML, not the expected JSON.

**Fix:** WAF Custom Rule in `terraform/cloudflare/security.tf` that skips all bot challenges and managed rules for `authentik.vollminlab.com`. Authentik handles its own authentication, so Cloudflare bot protection is redundant and actively harmful here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)