### PR TITLE
fix(ingress-nginx): stop ssl-redirect loop for external Cloudflare traffic

### DIFF
--- a/clusters/vollminlab-cluster/ingress-nginx/ingress-nginx/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/ingress-nginx/ingress-nginx/app/configmap.yaml
@@ -13,5 +13,6 @@ data:
       config:
         allow-snippet-annotations: "true"
         annotations-risk-level: Critical
+        use-forwarded-headers: "true"
       extraArgs:
         default-ssl-certificate: cert-manager/wildcard-tls


### PR DESCRIPTION
## Summary

- Adds `use-forwarded-headers: "true"` to the ingress-nginx ConfigMap
- Without this, nginx sees all Cloudflare tunnel traffic as HTTP (cloudflared terminates TLS and forwards plain HTTP to nginx)
- Services with `ssl-redirect: true` (almost all of them) were redirecting HTTP → HTTPS on every request
- Cloudflare then forwarded that HTTPS request as HTTP again → infinite 308 loop → external users see "too many redirects"
- Internal users (via Pi-hole → nginx port 443) were unaffected because they hit nginx on the SSL port directly
- With `use-forwarded-headers: true`, nginx respects `X-Forwarded-Proto: https` from Cloudflare and skips the ssl-redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)