### PR TITLE
chore(authentik): set TrueNAS icon

### DIFF
--- a/terraform/authentik/applications.tf
+++ b/terraform/authentik/applications.tf
@@ -198,6 +198,7 @@ resource "authentik_application" "truenas" {
   name            = "TrueNAS"
   slug            = "truenas"
   meta_launch_url = "https://truenas.vollminlab.com"
+  meta_icon       = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/truenas-scale.svg"
   open_in_new_tab = false
 }
 


### PR DESCRIPTION
## Summary

- Adds `meta_icon` to the TrueNAS Authentik application pointing to the TrueNAS SCALE SVG from the homarr-labs dashboard-icons CDN (same source used by Homepage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)