### PR TITLE
fix(cnpg): fix hourly backup schedules on all 4 CNPG clusters + expand authentik-db PVC

### DIFF
--- a/clusters/vollminlab-cluster/authentik/cnpg/app/cluster.yaml
+++ b/clusters/vollminlab-cluster/authentik/cnpg/app/cluster.yaml
@@ -15,7 +15,7 @@ spec:
       env: production
       category: security
   storage:
-    size: 5Gi
+    size: 10Gi
     storageClass: longhorn
   bootstrap:
     initdb:

--- a/clusters/vollminlab-cluster/authentik/cnpg/app/scheduled-backup.yaml
+++ b/clusters/vollminlab-cluster/authentik/cnpg/app/scheduled-backup.yaml
@@ -8,7 +8,7 @@ metadata:
     env: production
     category: security
 spec:
-  schedule: "0 1 * * *"
+  schedule: "0 0 1 * * *"
   backupOwnerReference: self
   cluster:
     name: authentik-db

--- a/clusters/vollminlab-cluster/harbor/harbor-db/app/scheduled-backup.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor-db/app/scheduled-backup.yaml
@@ -8,7 +8,7 @@ metadata:
     env: production
     category: storage
 spec:
-  schedule: "15 1 * * *"
+  schedule: "0 15 1 * * *"
   backupOwnerReference: self
   cluster:
     name: harbor-db

--- a/clusters/vollminlab-cluster/mediastack/jellystat-db/app/scheduled-backup.yaml
+++ b/clusters/vollminlab-cluster/mediastack/jellystat-db/app/scheduled-backup.yaml
@@ -8,7 +8,7 @@ metadata:
     env: production
     category: media
 spec:
-  schedule: "0 3 * * *"
+  schedule: "0 0 3 * * *"
   backupOwnerReference: self
   cluster:
     name: jellystat-db

--- a/clusters/vollminlab-cluster/shlink/shlink-db/app/scheduled-backup.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink-db/app/scheduled-backup.yaml
@@ -8,7 +8,7 @@ metadata:
     env: production
     category: apps
 spec:
-  schedule: "30 1 * * *"
+  schedule: "0 30 1 * * *"
   backupOwnerReference: self
   cluster:
     name: shlink-db


### PR DESCRIPTION
## Summary

- All 4 CNPG `ScheduledBackup` objects used 5-field cron syntax (`0 1 * * *`), which CNPG's scheduler interprets as 6-field (first field = seconds), running backups every hour instead of once daily
- 148 hourly base backups accumulated in 7 days (vs 7 expected), filling the 100 Gi MinIO PVC → WAL archiving failures → `authentik-db` CrashLoopBackOff
- Fixed all schedules to explicit 6-field daily cron; expanded `authentik-db` CNPG PVC 5 Gi → 10 Gi (already patched live)

| Cluster | Old (hourly) | New (daily) |
|---------|--------------|-------------|
| `authentik-db` | `0 1 * * *` | `0 0 1 * * *` (01:00) |
| `shlink-db` | `30 1 * * *` | `0 30 1 * * *` (01:30) |
| `harbor-db` | `15 1 * * *` | `0 15 1 * * *` (01:15) |
| `jellystat-db` | `0 3 * * *` | `0 0 3 * * *` (03:00) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)