### PR TITLE
fix(flux): add Harbor pull credentials to vollminlab OCIRepository

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -401,21 +401,24 @@ jobs:
 
       - name: Create test namespace
         if: needs.validate-changes.outputs.changed == 'true'
+        env:
+          HARBOR_USERNAME: ${{ secrets.HARBOR_USERNAME }}
+          HARBOR_PASSWORD: ${{ secrets.HARBOR_PASSWORD }}
         run: |
           set -euo pipefail
           TEST_NAMESPACE="ci-test-${{ env.RUN_SUFFIX }}"
           echo "TEST_NAMESPACE=$TEST_NAMESPACE" >> $GITHUB_ENV
-          
+
           kubectl create namespace "$TEST_NAMESPACE" || true
           echo "✅ Created test namespace: $TEST_NAMESPACE"
 
-          # Pre-create Harbor pull secret so OCIRepositories with secretRef can authenticate
+          # Pre-create Harbor pull secret so OCIRepositories with secretRef can authenticate.
+          # Secrets passed via env: to avoid shell expanding $ in the robot username.
           kubectl create secret docker-registry harbor-vollminlab-pull \
             -n "$TEST_NAMESPACE" \
             --docker-server=harbor.vollminlab.com \
-            --docker-username="${{ secrets.HARBOR_USERNAME }}" \
-            --docker-password="${{ secrets.HARBOR_PASSWORD }}" \
-            --dry-run=client -o yaml | kubectl apply -f -
+            --docker-username="$HARBOR_USERNAME" \
+            --docker-password="$HARBOR_PASSWORD"
           echo "✅ Created harbor-vollminlab-pull secret in $TEST_NAMESPACE"
 
       - name: Check Flux CRDs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -409,6 +409,15 @@ jobs:
           kubectl create namespace "$TEST_NAMESPACE" || true
           echo "✅ Created test namespace: $TEST_NAMESPACE"
 
+          # Pre-create Harbor pull secret so OCIRepositories with secretRef can authenticate
+          kubectl create secret docker-registry harbor-vollminlab-pull \
+            -n "$TEST_NAMESPACE" \
+            --docker-server=harbor.vollminlab.com \
+            --docker-username="${{ secrets.HARBOR_USERNAME }}" \
+            --docker-password="${{ secrets.HARBOR_PASSWORD }}" \
+            --dry-run=client -o yaml | kubectl apply -f -
+          echo "✅ Created harbor-vollminlab-pull secret in $TEST_NAMESPACE"
+
       - name: Check Flux CRDs
         if: needs.validate-changes.outputs.changed == 'true'
         run: |

--- a/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/rbac.yaml
+++ b/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/rbac.yaml
@@ -18,6 +18,10 @@ rules:
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "watch", "create", "delete"]
+  # Secrets - create/delete for CI test namespace pre-seeding (e.g. Harbor pull credentials)
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "delete"]
   # Service accounts - read only
   - apiGroups: [""]
     resources: ["serviceaccounts"]

--- a/clusters/vollminlab-cluster/flux-system/repositories/harbor-vollminlab-pull-sealedsecret.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/harbor-vollminlab-pull-sealedsecret.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: harbor-vollminlab-pull
+  namespace: flux-system
+spec:
+  encryptedData:
+    .dockerconfigjson: AgDKEkAAr99WofglQ8JAF1HBh4VEIwUOgbt8loQMWFxwakVtkyeSmz2XhvqHs+8e/9nSZWep6yAU7mP6uTT/FM55ABOjbRFHrR3dqDyfv/w+bC8J9MbRoxXh8M34ZAQFr0nHMM+o/teaSOQvsNkdHVYrJIsvBuckP06+dGaS8e4BSUF7j6KzjJc109BsHhTSzb3KE/g1IxvPLlYNer2FcssjbN6cjAU5jh5QjMy9pXkVk+isx9adZcCSDYO0PqXZyUP+NEA1jz3/wQ1lMNl82ut7199+cUkQ+DzDdxLPB0XwqduzrcHv6IXJZeTYkBR6b9yvl3mAkwx8ZzKwc7vAxbm48wAuYK/OuqFeTWyo8N4O7hl9AM2s7YSwlRq0EFNhc6Xi6YOtUksKow1duhyXSyXxp+UgOyFDa6kOzl3fCsWHyrXQjD3vzHXgyk1W2bxixNdYdqe29o/5BTIGI6sty9lgKQBN5CeVbGhdbdf7IysyMiKEXB8xTnO6OjQI8TuBQdP9xgpnlCDW4GXGiXt1a6tJQ1v4lIgpfBwxtGs1s5p3DXS4ojY0d0OR9Nlx9OVCg2MarvfUW+lvcqxHxR0pqUGFllr4w1LXMN91xfdWqor2sHAu18naAJPc9MwhEhwpvklzRSA61JqWu8ozv2FpWKchskT+1j6Lddfg0Y5l3cPESlRLz5VCWi3gzjXRFiD/+yNNCdDFeWpk6hYCz3r2fqm67CiGCixpVRhfrgJYwkrilWfkaE+LtqYPxqLuYDI6JPuaH6ZsLNYHmWwOrxe6A97YWqOA6kar1lDTz4ygTUVCCGjuOBfZ20B0slGoyHELPFgng6rjYhPoqCoCQlDto0BkTfC1WQSDe/UgKrJ56ZKBVthk6lAJ5g0swm8YkkTyHxQeUYiSd+4Y+kAR7DtzrfzlhWSGliJGPmyPaPW/H93G8DDQy2REnIjnwxRa6Y+PFwznx53wAE2MK37QXpS8tNrHW5xf8No/C40pSBZHEjL+JdFG8LiVjmcMMyW/mYYlZhM5rY1cXP+W
+  template:
+    metadata:
+      name: harbor-vollminlab-pull
+      namespace: flux-system
+    type: kubernetes.io/dockerconfigjson

--- a/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
@@ -45,4 +45,5 @@ resources:
   - sonarr-ocirepository.yaml
   - tofu-controller-helmrepository.yaml
   - velero-helmrepository.yaml
+  - harbor-vollminlab-pull-sealedsecret.yaml
   - vollminlab-ocirepository.yaml

--- a/clusters/vollminlab-cluster/flux-system/repositories/vollminlab-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/vollminlab-ocirepository.yaml
@@ -12,3 +12,5 @@ spec:
   url: oci://harbor.vollminlab.com/vollminlab/charts/shlink-ingress-controller
   ref:
     tag: "0.3.5"
+  secretRef:
+    name: harbor-vollminlab-pull


### PR DESCRIPTION
## Summary

- `vollminlab/charts` Harbor project is `public = false` (set in harbor-config IaC)
- `vollminlab-repo` OCIRepository had no `secretRef`, so Flux was attempting anonymous pulls → UNAUTHORIZED
- This blocked `shlink-ingress-controller` from deploying

Fix: seals the existing `cluster-pull` robot account credentials into `flux-system` and adds `secretRef` to the OCIRepository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)