### PR TITLE
fix(filebrowser): allow large uploads via nginx timeout/body-size annotations

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/filebrowser/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/filebrowser/app/ingress.yaml
@@ -9,6 +9,10 @@ metadata:
     nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=https://$http_host$escaped_request_uri"
     nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     nginx.ingress.kubernetes.io/auth-snippet: |
       proxy_set_header X-Forwarded-Host $http_host;
     shlink.vollminlab.com/slug: filebrowser


### PR DESCRIPTION
## Summary

- `proxy-body-size: "0"` — removes nginx's default 1m upload cap that was silently dropping large files
- `proxy-request-buffering: "off"` — streams directly to FileBrowser instead of buffering the full file in nginx first (prevents memory-related drops on large uploads)
- `proxy-read-timeout: "600"` / `proxy-send-timeout: "600"` — gives slow connections 10 minutes to complete a transfer

Root cause: friend uploading epub/mobi files was hitting nginx's default limits. FileBrowser logs showed "deleting incomplete upload file" — the pod itself was healthy with 0 restarts; nginx was dropping the connection mid-upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)