### PR TITLE
fix(readarr): migrate to bookshelf (hardcover fork) + exclude k8sworker03

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
@@ -43,11 +43,20 @@ data:
       env: production
       category: media
     image:
-      repository: ghcr.io/home-operations/readarr
-      tag: 0.4.18.2805@sha256:8f7551205fbdccd526db23a38a6fba18b0f40726e63bb89be0fb2333ff4ee4cd
+      repository: ghcr.io/pennydreadful/bookshelf
+      tag: hardcover-v0.4.20.129@sha256:388eecc94362580eae31ee0a454be6af516f8a311f8432a521c202fb475f4359
     securityContext:
       runAsUser: 568
       runAsGroup: 568
     podSecurityContext:
       fsGroup: 568
       fsGroupChangePolicy: "OnRootMismatch"
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/hostname
+                  operator: NotIn
+                  values:
+                    - k8sworker03


### PR DESCRIPTION
## Summary

- Swaps the Readarr image to `ghcr.io/pennydreadful/bookshelf:hardcover-v0.4.20.129` — the community-maintained fork of the now-retired Readarr project
- Adds `nodeAffinity` to exclude `k8sworker03` (running k8s v1.32.3, which has `UserNamespacesSupport` feature gate disabled)

## Background

`bookinfo.club` has permanently expired and the Readarr project is officially retired by the Servarr team. The `pennydreadful/bookshelf` fork is the community-adopted continuation:
- Same UI/UX and download client integration as Readarr
- Uses `hardcover.bookinfo.pro` (rreading-glasses Hardcover proxy) as metadata source
- `hardcover` image variant achieves ~87-93% match rate vs ~68% for original Readarr

The `metadataSource` is already set to `https://hardcover.bookinfo.pro` in the Readarr SQLite config on the PVC (set via API before this PR). Bookshelf will pick it up on first start.

The `k8sworker03` exclusion fixes a pod sandbox creation failure: that node runs k8s v1.32.3 with `UserNamespacesSupport` disabled, causing any pod with `spec.hostUsers` to fail with `Failed to create pod sandbox`. All other workers run v1.33.12 where the feature gate is enabled by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)