### PR TITLE
fix(bookshelf): switch to PUID/PGID env vars for s6-overlay startup

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
@@ -45,9 +45,9 @@ data:
     image:
       repository: ghcr.io/pennydreadful/bookshelf
       tag: hardcover-v0.4.20.129@sha256:388eecc94362580eae31ee0a454be6af516f8a311f8432a521c202fb475f4359
-    securityContext:
-      runAsUser: 568
-      runAsGroup: 568
+    env:
+      PUID: "568"
+      PGID: "568"
     podSecurityContext:
       fsGroup: 568
       fsGroupChangePolicy: "OnRootMismatch"


### PR DESCRIPTION
## Summary

- Replaces `securityContext.runAsUser/runAsGroup: 568` with `env.PUID/PGID: "568"`

## Problem

bookshelf uses s6-overlay (LinuxServer-style init), which starts as root and drops to the configured user via `s6-applyuidgid`. With `securityContext.runAsUser: 568` set, the container starts as uid 568 directly, so `s6-applyuidgid` can't call `setgroups()` → repeated `unable to set supplementary group list: Operation not permitted` → readiness probe never passes.

## Fix

Remove `securityContext` (runAsUser/runAsGroup) so the container starts as root per its design, and pass `PUID=568`/`PGID=568` env vars which s6 uses for the privilege-drop sequence. `podSecurityContext.fsGroup: 568` is kept for PVC mount ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)