### PR TITLE
fix(bookshelf): set LSIO_NON_ROOT_USER to skip root-requiring s6 init ops

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
@@ -48,6 +48,7 @@ data:
     env:
       PUID: "568"
       PGID: "568"
+      LSIO_NON_ROOT_USER: "true"
     podSecurityContext:
       fsGroup: 568
       fsGroupChangePolicy: "OnRootMismatch"


### PR DESCRIPTION
## Summary

- Adds `LSIO_NON_ROOT_USER: "true"` to the bookshelf env block in the readarr ConfigMap
- TrueCharts chart injects `runAsUser: 568` + `capabilities.drop: [ALL]` as defaults, meaning the container never starts as root
- Bookshelf's s6-overlay `init-adduser` unconditionally calls `usermod`/`groupmod`/`lsiown` which all require root, causing `s6-applyuidgid: fatal: unable to set supplementary group list: Operation not permitted`
- Setting `LSIO_NON_ROOT_USER` tells the linuxserver.io s6 framework that the container is already running as the target uid/gid and to skip all those root-requiring operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)