### PR TITLE
fix(bookshelf): inject LSIO_NON_ROOT_USER via correct TrueCharts workload path

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
@@ -45,10 +45,13 @@ data:
     image:
       repository: ghcr.io/pennydreadful/bookshelf
       tag: hardcover-v0.4.20.129@sha256:388eecc94362580eae31ee0a454be6af516f8a311f8432a521c202fb475f4359
-    env:
-      PUID: "568"
-      PGID: "568"
-      LSIO_NON_ROOT_USER: "true"
+    workload:
+      main:
+        podSpec:
+          containers:
+            main:
+              env:
+                LSIO_NON_ROOT_USER: "true"
     podSecurityContext:
       fsGroup: 568
       fsGroupChangePolicy: "OnRootMismatch"


### PR DESCRIPTION
## Summary

- Fixes bookshelf startup failure: `s6-applyuidgid: fatal: unable to set supplementary group list: Operation not permitted`
- The root-level `env:` block in TrueCharts values is intercepted by the chart — `READARR__*` vars pass through, but `PUID`/`PGID` are converted to `securityContext` and unknown vars like `LSIO_NON_ROOT_USER` are silently dropped
- `workload.main.podSpec.containers.main.env` merges directly with the chart's own container env block, so `LSIO_NON_ROOT_USER` actually reaches the container

**Why this fixes it**: the bookshelf service run script explicitly checks for `LSIO_NON_ROOT_USER`:
```bash
if [[ -z ${LSIO_NON_ROOT_USER} ]]; then
    exec s6-notifyoncheck ... s6-setuidgid abc /app/readarr/bin/Readarr ...
else
    exec s6-notifyoncheck ... /app/readarr/bin/Readarr ...  # no user switching
fi
```
Without it → `s6-setuidgid abc` calls `setgroups()` which requires `CAP_SETGID` (dropped by TrueCharts chart) → crash loop. With it → Readarr runs directly as uid=568 (set by Kubernetes `runAsUser`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)