### PR TITLE
docs(secrets): add 1Password save-before-you-seal rule

### DIFF
--- a/.claude/rules/secrets.md
+++ b/.claude/rules/secrets.md
@@ -15,6 +15,42 @@ The CI runs gitleaks on every PR as a required check ("Secret Scanning"). If it 
 
 Credentials belong in **1Password** (Homelab vault). Kubernetes secrets belong in **SealedSecrets**.
 
+## 1Password — save before you seal
+
+Every API key, password, or token generated when setting up a new service **must be saved to 1Password before it is sealed or used anywhere else**. This is the source of truth for credential recovery.
+
+**When adding a new service**, save to 1Password at the point the credential is generated (not after):
+
+- App-generated API keys (Readarr, Radarr, SABnzbd, Prowlarr, etc.) → save immediately after first login
+- Terraform-managed credentials (robot accounts, OAuth clients, access keys) → save the input values before running `tofu apply`
+- Homepage widget API keys → save alongside the app's own entry
+
+**Naming convention for 1Password items** (Homelab vault):
+
+| What | Item name pattern |
+|------|------------------|
+| App API key | `<AppName> API Key` (e.g. `Readarr API Key`) |
+| Service account / robot | `<Service> <Purpose>` (e.g. `Harbor Registry Robot`) |
+| OAuth client | `<AppName> OAuth Client` |
+| Database password | `<AppName> DB Password` |
+
+Apply the **"Homelab"** tag to every item.
+
+**Retrieving credentials in Claude sessions** — always use `op` CLI, never ask the user to paste values into chat:
+
+```bash
+# Sign in first if needed
+op signin
+
+# List items to find the right one
+op item list --vault Homelab --format json | python3 -c \
+  "import json,sys; [print(i['title']) for i in json.load(sys.stdin) if 'readarr' in i['title'].lower()]"
+
+# Get a specific field (use --format json for concealed fields)
+op item get "Readarr API Key" --vault Homelab --format json | python3 -c \
+  "import json,sys; d=json.load(sys.stdin); print(next(f['value'] for f in d['fields'] if f['label']=='api_key'))"
+```
+
 ## Creating a sealed secret
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds an explicit rule that every API key/credential must be saved to 1Password **at the point it is generated**, before it is sealed or used anywhere else
- Documents a naming convention for Homelab vault items (app API keys, robot accounts, OAuth clients, DB passwords) with the "Homelab" tag
- Documents the `op` CLI retrieval pattern so future Claude sessions always pull from the vault rather than asking the user to paste credentials into chat

Motivated by Readarr/Bookshelf setup where the API key was saved to 1Password but there was no documented expectation that this always happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)