### PR TITLE
fix(filebrowser): improve large file upload stability

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/filebrowser/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/filebrowser/app/deployment.yaml
@@ -33,6 +33,10 @@ spec:
               value: proxy
             - name: FB_AUTH_HEADER
               value: X-authentik-username
+            - name: FB_TUS_CHUNKSIZE
+              value: "52428800"
+            - name: FB_TUS_RETRYCOUNT
+              value: "2"
           ports:
             - containerPort: 8080
           volumeMounts:

--- a/clusters/vollminlab-cluster/mediastack/filebrowser/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/filebrowser/app/ingress.yaml
@@ -13,6 +13,8 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      client_body_timeout 600s;
     nginx.ingress.kubernetes.io/auth-snippet: |
       proxy_set_header X-Forwarded-Host $http_host;
     shlink.vollminlab.com/slug: filebrowser


### PR DESCRIPTION
## Summary

- **TUS chunk size 10MB → 50MB**: Fewer chunks per file means fewer opportunities for concurrent chunk conflicts. When the client retries a chunk while the original request is still in-flight, FileBrowser returns 403 (TUS conflict lock). With 50MB chunks, most ebooks and audiobook tracks become single-chunk uploads with no retry conflict possible.
- **TUS retry count 5 → 2**: Limits the 403 storm when a conflict does occur (5 rapid retries → 403 × 5 within 1 second → all fail)
- **`client_body_timeout 600s` in nginx**: nginx's default is 60s between successive bytes from the client. On slow upload connections (< 1.5 Mbps), a 10MB chunk takes > 60s and nginx silently closes the client connection mid-upload. This was not addressed by `proxy-read-timeout`/`proxy-send-timeout` (those are nginx→upstream timeouts, not client→nginx).

**Root cause observed**: The friend's batch upload at 00:19 showed 55 "deleting incomplete upload file" entries plus a 403 storm for Sanderson files — same files getting 403 10+ times within 1-2 seconds. This is the TUS concurrent-upload conflict signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)