### PR TITLE
fix(filebrowser): use Recreate update strategy for RWO PVC compatibility

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/filebrowser/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/filebrowser/app/deployment.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/name: filebrowser
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: filebrowser


### PR DESCRIPTION
## Summary

- Set `strategy: type: Recreate` on the FileBrowser deployment

The default `RollingUpdate` strategy starts the new pod before terminating the old one. FileBrowser's SMB PVCs (`pvc-misc-incoming`, `pvc-audiobooks-incoming`) are `ReadWriteOnce`, so the new pod blocks in `ContainerCreating` indefinitely waiting for the volume to detach from the node running the old pod — which never happens automatically.

Observed after merging #665: new pod stuck in `ContainerCreating` for 35+ minutes with `Multi-Attach error for volume`.

`Recreate` terminates the old pod first, then starts the new one, avoiding the attach conflict. The brief downtime during deploys is acceptable for a single-user upload tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)