### PR TITLE
chore(authentik): add jvollmin to FileBrowser Users group

### DIFF
--- a/terraform/authentik/groups.tf
+++ b/terraform/authentik/groups.tf
@@ -10,7 +10,7 @@ resource "authentik_group" "audiobookshelf_users" {
 
 resource "authentik_group" "filebrowser_users" {
   name  = "FileBrowser Users"
-  users = toset([authentik_user.vollmin.id, authentik_user.gkroner.id, authentik_user.jkvedaras.id])
+  users = toset([authentik_user.vollmin.id, authentik_user.jvollmin.id, authentik_user.gkroner.id, authentik_user.jkvedaras.id])
 }
 
 resource "authentik_group" "grafana_admins" {


### PR DESCRIPTION
## Summary

- Adds `jvollmin` to the `FileBrowser Users` Authentik group

jvollmin was in `jellyfin_users` and `audiobookshelf_users` but missing from `filebrowser_users`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)