### PR TITLE
fix(qbittorrent): switch PIA region to CA Montreal for port forwarding

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
@@ -75,7 +75,7 @@ spec:
             - name: VPN_TYPE
               value: "openvpn"
             - name: SERVER_REGIONS
-              value: "US East"
+              value: "CA Montreal"
             - name: VPN_PORT_FORWARDING
               value: "on"
           envFrom:


### PR DESCRIPTION
## Summary

- PIA does not allow port forwarding on US servers (DMCA restrictions)
- Gluetun with `VPN_PORT_FORWARDING=on` filters to PF-capable servers only, so `US East` returned zero matches and the VPN refused to connect
- CA Montreal is the nearest PIA region that supports port forwarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)