### PR TITLE
fix(qbittorrent): switch gluetun OpenVPN to TCP

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
@@ -78,6 +78,8 @@ spec:
               value: "CA Montreal"
             - name: VPN_PORT_FORWARDING
               value: "on"
+            - name: OPENVPN_PROTOCOL
+              value: "tcp"
           envFrom:
             - secretRef:
                 name: qbittorrent-pia-credentials


### PR DESCRIPTION
## Summary

- UDP 1197 is blocked outbound on cluster nodes — gluetun stalled at UDP handshake with no progression after 5+ minutes
- Switch to TCP so OpenVPN connects via port 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)