### PR TITLE
fix(qbittorrent): allow inbound port 8080 through gluetun firewall

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
@@ -78,6 +78,8 @@ spec:
               value: "CA Montreal"
             - name: VPN_PORT_FORWARDING
               value: "on"
+            - name: FIREWALL_INPUT_PORTS
+              value: "8080"
           envFrom:
             - secretRef:
                 name: qbittorrent-pia-credentials


### PR DESCRIPTION
## Summary

- Gluetun's kill switch drops all new inbound connections on eth0 (INPUT policy DROP)
- nginx proxy_pass to port 8080 was timing out (504) because gluetun had no rule accepting traffic from the cluster network on that port
- `FIREWALL_INPUT_PORTS=8080` tells gluetun to add an ACCEPT rule for port 8080 on eth0, allowing the WebUI to be reachable from inside the cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)