### PR TITLE
feat(qbittorrent): wire download clients + homepage widget (Phase 2)

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -105,6 +105,17 @@ data:
                   type: sabnzbd
                   url: http://sabnzbd.mediastack.svc.cluster.local:10097
                   key: "{{HOMEPAGE_VAR_SABNZBD_API_KEY}}"
+            - qBittorrent:
+                description: Torrent client (VPN)
+                href: https://qbittorrent.vollminlab.com
+                icon: qbittorrent.png
+                namespace: mediastack
+                app: qbittorrent
+                widget:
+                  type: qbittorrent
+                  url: http://qbittorrent.mediastack.svc.cluster.local:8080
+                  username: admin
+                  password: ""
             - Bazarr:
                 description: Subtitle manager
                 href: https://bazarr.vollminlab.com

--- a/terraform/radarr/download-clients.tf
+++ b/terraform/radarr/download-clients.tf
@@ -1,3 +1,15 @@
+resource "radarr_download_client_qbittorrent" "qbittorrent" {
+  name                       = "qBittorrent"
+  enable                     = true
+  priority                   = 25
+  host                       = "qbittorrent"
+  port                       = 8080
+  use_ssl                    = false
+  movie_category             = "movies"
+  remove_completed_downloads = true
+  remove_failed_downloads    = true
+}
+
 resource "radarr_download_client_sabnzbd" "sabnzbd" {
   name                       = "SABnzbd"
   enable                     = true

--- a/terraform/readarr/download-clients.tf
+++ b/terraform/readarr/download-clients.tf
@@ -1,3 +1,15 @@
+resource "readarr_download_client_qbittorrent" "qbittorrent" {
+  name                       = "qBittorrent"
+  enable                     = true
+  priority                   = 25
+  host                       = "qbittorrent"
+  port                       = 8080
+  use_ssl                    = false
+  book_category              = "books"
+  remove_completed_downloads = true
+  remove_failed_downloads    = true
+}
+
 resource "readarr_download_client_sabnzbd" "sabnzbd" {
   name                       = "SABnzbd"
   enable                     = true

--- a/terraform/sonarr/download-clients.tf
+++ b/terraform/sonarr/download-clients.tf
@@ -1,3 +1,15 @@
+resource "sonarr_download_client_qbittorrent" "qbittorrent" {
+  name                       = "qBittorrent"
+  enable                     = true
+  priority                   = 25
+  host                       = "qbittorrent"
+  port                       = 8080
+  use_ssl                    = false
+  tv_category                = "tv"
+  remove_completed_downloads = true
+  remove_failed_downloads    = true
+}
+
 resource "sonarr_download_client_sabnzbd" "sabnzbd" {
   name                       = "SABnzbd"
   enable                     = true


### PR DESCRIPTION
## Summary

- Add qBittorrent as priority-25 fallback download client in Radarr, Sonarr, and Readarr
- SABnzbd stays at priority-1 (primary usenet); qBittorrent handles torrent-only results
- No credentials — WebUI auth is bypassed for all cluster IPs
- Add qBittorrent widget to homepage between SABnzbd and Bazarr

## AudioBookBay (follow-up)

Not included — needs to be added via Prowlarr UI first (Indexers → Add → search "AudioBookBay"), then imported into Terraform state. Will handle in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)