### PR TITLE
feat(homepage): add Cloudflare tunnel widget for Filebrowser

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -255,6 +255,15 @@ data:
                   accountid: "9013108406ddceed8abc1a3e2e21907d"
                   tunnelid: "01ca47d0-b545-4ee4-9fb0-2ae1f74c0e9c"
                   key: "{{HOMEPAGE_VAR_CLOUDFLARE_API_TOKEN}}"
+            - Cloudflare (Filebrowser):
+                description: Cloudflare tunnel — Filebrowser (cluster nginx)
+                href: https://dash.cloudflare.com
+                icon: cloudflare.png
+                widget:
+                  type: cloudflared
+                  accountid: "9013108406ddceed8abc1a3e2e21907d"
+                  tunnelid: "dfdb8c7e-990b-44f2-8afa-fc11d191c4ff"
+                  key: "{{HOMEPAGE_VAR_CLOUDFLARE_API_TOKEN}}"
         - Monitoring & Observability:
             - Policy Reporter:
                 description: Kubernetes policy reporting


### PR DESCRIPTION
## Summary

- Adds a fourth `cloudflared` homepage widget for the `vollminlab-ClusterNginx` tunnel (`dfdb8c7e-990b-44f2-8afa-fc11d191c4ff`), which proxies `filebrowser.vollminlab.com` through nginx ingress
- Matches the existing pattern for the Authentik, Jellyfin, and Audiobookshelf tunnel widgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)