### PR TITLE
fix(qbittorrent): add app.kubernetes.io/name label for homepage badge

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       labels:
         app: qbittorrent
+        app.kubernetes.io/name: qbittorrent
         env: production
         category: media
     spec:


### PR DESCRIPTION
## Summary

Homepage's k8s status service queries `app.kubernetes.io/name` to find pods. The qBittorrent deployment only had `app=qbittorrent`, causing the widget to show "Not found".

🤖 Generated with [Claude Code](https://claude.com/claude-code)