### PR TITLE
fix(homepage): remove qBittorrent widget credentials to fix DOWN state

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -114,8 +114,6 @@ data:
                 widget:
                   type: qbittorrent
                   url: http://qbittorrent.mediastack.svc.cluster.local:8080
-                  username: admin
-                  password: ""
             - Bazarr:
                 description: Subtitle manager
                 href: https://bazarr.vollminlab.com

--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -253,8 +253,8 @@ data:
                   accountid: "9013108406ddceed8abc1a3e2e21907d"
                   tunnelid: "dbf1e417-263b-4ea9-8404-ee6fe2c9771f"
                   key: "{{HOMEPAGE_VAR_CLOUDFLARE_API_TOKEN}}"
-            - Cloudflare (Filebrowser):
-                description: Cloudflare tunnel — Filebrowser (cluster nginx)
+            - Cloudflare (ClusterNginx):
+                description: Cloudflare tunnel — vollminlab-ClusterNginx (nginx ingress)
                 href: https://dash.cloudflare.com
                 icon: cloudflare.png
                 widget:


### PR DESCRIPTION
## Summary

- qBittorrent has auth bypass enabled via subnet whitelist (`0.0.0.0/0`), meaning all cluster IPs can call the API without credentials
- However, qBittorrent v5.x returns HTTP 204 (empty body) on `POST /api/v2/auth/login` when bypass is active — where homepage expects `"Ok."` — causing the widget to show DOWN
- Removing `username`/`password` from the widget config skips the login step; homepage calls the torrent API directly and gets valid data

**Verified:** `GET /api/v2/torrents/info` from homepage pod returns `[]` (empty list, correct — no active torrents) without any auth session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)