### PR TITLE
fix(dmz): add Harbor pull secret for masters-league

### DIFF
--- a/clusters/vollminlab-cluster/dmz/masters-league/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/dmz/masters-league/app/deployment.yaml
@@ -26,6 +26,8 @@ spec:
         fsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
+      imagePullSecrets:
+        - name: harbor-vollminlab-pull
       containers:
         - name: masters-league
           image: harbor.vollminlab.com/vollminlab/masters-league:v1.1.1

--- a/clusters/vollminlab-cluster/dmz/masters-league/app/harbor-vollminlab-pull-sealedsecret.yaml
+++ b/clusters/vollminlab-cluster/dmz/masters-league/app/harbor-vollminlab-pull-sealedsecret.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: harbor-vollminlab-pull
+  namespace: dmz
+spec:
+  encryptedData:
+    .dockerconfigjson: AgAKw8kv9Ps27hOOefp1CmWxHXHKo6QcOdbvqL3yFI7qHzOBJNV4xDflSryQD6krwM0tDfBH9lJFcA6OMwHc2N9ecIwuM6/QbccR7Jr4YVuItfsDa8KuTXkAdMdd3gur8P5zqr7sn5OZN3G3GB528Crl41jGa3d9b8QmAUNugndvE80JnmScHynTS4GwbSZRoLAUz4DgjQbafFWUKlbsIRkGxJoN6H2OWBdEzJ3J2VET+UHPSt1XWVfNe5mTgNqfSxzRfGu00JTaogVQuSbNb/C7ba3RNJVdg9UfvMF7o+h7WnoYpIf5HvQuNhj7epiSq/Qv6eayXVDMGj6PDm9YlzEe0Hsc2GIcXRAboBO7w20u7hBcaDoW04AzTKyhtbiO7rImVJDRVhbLdDx4YKrAb/GEzdnDBS2YN7xp4MKeIX/n5j/g1OTGJvG8aYDIXu6hi++KiusNFQzOYwOTiG1HkJmZRdN3CPIK6JYkNSQ/rYVzr0Aq8q/mzsVZJCnOVF+cc36RT76ZMjAa9yhFgYO/Tp+pSiTzOCaFnDX+F14Px6QV14g0Oj0D0ipIXtPVl4a9LttvFwjO8YIUaK3rdOSiIBWd9u1HPrTaNgw/9GD/JjlVX7dF85m3sDkBuDPWINWr/m/gsoZRMBnGtZWO1NPul9K90mA1y/V48Wb0hksH00czUpNG560CVD9UzV7b3wdRgtXHXgwKDZGenVB1kfs/WJao49/ed1Nxm+k9l5iNW7LS1OCGJv8fb1BkY5UHQX2Ys+x7f0xD4ywwec9+BSk9DaevYpLdl0tNfih0x/viDCqeucrS4R0+ondXyDWKwRputt+pq801tcTwtTnTZLpYOZ3atca1X4I7AXPEAEDOa8xeeoArB84ctMz+GKybNgyXGNc2Mtyjj1FLIEukoaKMN0VjI7fSfOzuuzCZm2IqVh9OdfRmHvoTiRiwf3UeA8OTc5p4Nux1uSMS/cWFj2KMgUdyonTFBtt8tiPSO6M+hlaVQ7rapOChUOeGoOANsuKR2g8g3h+73pUB
+  template:
+    metadata:
+      name: harbor-vollminlab-pull
+      namespace: dmz
+    type: kubernetes.io/dockerconfigjson

--- a/clusters/vollminlab-cluster/dmz/masters-league/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/dmz/masters-league/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - service.yaml
   - service-redis.yaml
   - networkpolicy.yaml
+  - harbor-vollminlab-pull-sealedsecret.yaml


### PR DESCRIPTION
## Summary

- `masters-league` pods were stuck in `ImagePullBackOff` — the `dmz` namespace had no credentials to authenticate against `harbor.vollminlab.com`
- Seals the Harbor pull secret into the `dmz` namespace and adds `imagePullSecrets` to the deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)