### PR TITLE
fix(qbittorrent): add Recreate deployment strategy for RWO PVC

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     category: media
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: qbittorrent


### PR DESCRIPTION
## Summary

- The qBittorrent deployment mounts a `ReadWriteOnce` Longhorn PVC (`pvc-qbittorrent-config`), but had no `strategy` field — defaulting to `RollingUpdate`
- Any pod template change (e.g. adding a label) starts a new pod before terminating the old one; the new pod blocks indefinitely on `Multi-Attach error` because RWO volumes can only be attached to one node at a time
- This was triggered in practice by PR #679 adding the `app.kubernetes.io/name` label — the pod got stuck in `ContainerCreating` for 20+ minutes until the old pod was manually deleted

`strategy: type: Recreate` ensures the old pod is terminated before the new one starts, avoiding the PVC conflict entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)