### PR TITLE
feat(prowlarr): add 1337x, EZTV, YTS torrent indexers

### DIFF
--- a/terraform/prowlarr/indexers.tf
+++ b/terraform/prowlarr/indexers.tf
@@ -1,7 +1,23 @@
-# Indexers imported from Prowlarr API
-# Retrieved 2026-05-15 via kubectl exec prowlarr /api/v1/indexer
-# Both are Newznab usenet indexers; sensitive fields use ignore_changes
-# to prevent perpetual drift from Prowlarr's masked API responses.
+# Prowlarr indexers: Newznab usenet (NZBgeek, NzbPlanet) imported 2026-05-15;
+# Cardigann torrent (1337x, EZTV, YTS) created 2026-05-19.
+# Sensitive fields use ignore_changes to prevent drift from Prowlarr's masked API responses.
+
+resource "prowlarr_indexer" "eztv" {
+  name            = "EZTV"
+  enable          = true
+  priority        = 25
+  protocol        = "torrent"
+  implementation  = "Cardigann"
+  config_contract = "CardigannSettings"
+  app_profile_id  = 1
+
+  lifecycle { ignore_changes = [fields] }
+
+  fields = [
+    { name = "definitionFile", text_value = "eztv" },
+    { name = "minimumSeeders", number_value = 1 },
+  ]
+}
 
 resource "prowlarr_indexer" "nzbgeek" {
   name            = "NZBgeek"
@@ -36,5 +52,39 @@ resource "prowlarr_indexer" "nzbplanet" {
     { name = "baseUrl", text_value = "https://api.nzbplanet.net" },
     { name = "apiPath", text_value = "/api" },
     { name = "apiKey", sensitive_value = var.nzbplanet_api_key },
+  ]
+}
+
+resource "prowlarr_indexer" "the1337x" {
+  name            = "1337x"
+  enable          = true
+  priority        = 25
+  protocol        = "torrent"
+  implementation  = "Cardigann"
+  config_contract = "CardigannSettings"
+  app_profile_id  = 1
+
+  lifecycle { ignore_changes = [fields] }
+
+  fields = [
+    { name = "definitionFile", text_value = "1337x" },
+    { name = "minimumSeeders", number_value = 1 },
+  ]
+}
+
+resource "prowlarr_indexer" "yts" {
+  name            = "YTS"
+  enable          = true
+  priority        = 25
+  protocol        = "torrent"
+  implementation  = "Cardigann"
+  config_contract = "CardigannSettings"
+  app_profile_id  = 1
+
+  lifecycle { ignore_changes = [fields] }
+
+  fields = [
+    { name = "definitionFile", text_value = "yts" },
+    { name = "minimumSeeders", number_value = 1 },
   ]
 }


### PR DESCRIPTION
## Summary

- Adds **1337x** (Cardigann): broad public tracker covering movies, TV, and audiobooks
- Adds **EZTV** (Cardigann): TV-focused public tracker
- Adds **YTS** (Cardigann): high-quality movie rips with small file sizes

All three use `app_profile_id = 1` (All Apps sync profile) so Prowlarr automatically syncs them to Radarr, Sonarr, and Readarr. No new credentials or secrets needed — all are public, no-API-key indexers.

The `lifecycle { ignore_changes = [fields] }` block on each prevents Terraform drift when Prowlarr normalises stored field values on read-back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)