### PR TITLE
fix(prowlarr): remove minimumSeeders from Cardigann indexers

### DIFF
--- a/terraform/prowlarr/indexers.tf
+++ b/terraform/prowlarr/indexers.tf
@@ -15,7 +15,6 @@ resource "prowlarr_indexer" "eztv" {
 
   fields = [
     { name = "definitionFile", text_value = "eztv" },
-    { name = "minimumSeeders", number_value = 1 },
   ]
 }
 
@@ -68,7 +67,6 @@ resource "prowlarr_indexer" "the1337x" {
 
   fields = [
     { name = "definitionFile", text_value = "1337x" },
-    { name = "minimumSeeders", number_value = 1 },
   ]
 }
 
@@ -85,6 +83,5 @@ resource "prowlarr_indexer" "yts" {
 
   fields = [
     { name = "definitionFile", text_value = "yts" },
-    { name = "minimumSeeders", number_value = 1 },
   ]
 }


### PR DESCRIPTION
## Summary

- Prowlarr 2.3.7 returns `500 Unknown Cardigann setting (Parameter 'minimumSeeders')` when creating EZTV, 1337x, and YTS indexers — their Cardigann definitions don't declare that field
- `prowlarr-config` tofu has been stuck in a failed apply loop since PR #684 merged, cycling a runner pod every ~23s
- Fix: drop the `minimumSeeders` field from all three Cardigann resources; `definitionFile` alone is sufficient