### PR TITLE
fix(prowlarr): specify all Cardigann indexer fields to fix provider hash mismatch

### DIFF
--- a/terraform/prowlarr/imports.tf
+++ b/terraform/prowlarr/imports.tf
@@ -21,7 +21,3 @@ import {
   id = "2"
 }
 
-import {
-  to = prowlarr_indexer.yts
-  id = "16"
-}

--- a/terraform/prowlarr/indexers.tf
+++ b/terraform/prowlarr/indexers.tf
@@ -1,6 +1,8 @@
 # Prowlarr indexers: Newznab usenet (NZBgeek, NzbPlanet) imported 2026-05-15;
 # Cardigann torrent (1337x, EZTV, YTS) created 2026-05-19.
-# Sensitive fields use ignore_changes to prevent drift from Prowlarr's masked API responses.
+# Newznab indexers use ignore_changes on fields to tolerate Prowlarr masking sensitive API keys.
+# Cardigann indexers specify all fields returned by Prowlarr to avoid the provider's
+# "inconsistent values for sensitive attribute" hash mismatch on post-CREATE read.
 
 resource "prowlarr_indexer" "eztv" {
   name            = "EZTV"
@@ -12,10 +14,17 @@ resource "prowlarr_indexer" "eztv" {
   app_profile_id  = 1
   tags            = [prowlarr_tag.flaresolverr.id]
 
-  lifecycle { ignore_changes = [fields] }
-
   fields = [
     { name = "definitionFile", text_value = "eztv" },
+    { name = "baseUrl" },
+    { name = "baseSettings.queryLimit" },
+    { name = "baseSettings.grabLimit" },
+    { name = "baseSettings.limitsUnit", number_value = 0 },
+    { name = "torrentBaseSettings.appMinimumSeeders" },
+    { name = "torrentBaseSettings.seedRatio" },
+    { name = "torrentBaseSettings.seedTime" },
+    { name = "torrentBaseSettings.packSeedTime" },
+    { name = "torrentBaseSettings.preferMagnetUrl", bool_value = false },
   ]
 }
 
@@ -65,10 +74,26 @@ resource "prowlarr_indexer" "the1337x" {
   app_profile_id  = 1
   tags            = [prowlarr_tag.flaresolverr.id]
 
-  lifecycle { ignore_changes = [fields] }
-
   fields = [
     { name = "definitionFile", text_value = "1337x" },
+    { name = "baseUrl" },
+    { name = "baseSettings.queryLimit" },
+    { name = "baseSettings.grabLimit" },
+    { name = "baseSettings.limitsUnit", number_value = 0 },
+    { name = "torrentBaseSettings.appMinimumSeeders" },
+    { name = "torrentBaseSettings.seedRatio" },
+    { name = "torrentBaseSettings.seedTime" },
+    { name = "torrentBaseSettings.packSeedTime" },
+    { name = "torrentBaseSettings.preferMagnetUrl", bool_value = false },
+    { name = "uploader" },
+    { name = "info_uploader", text_value = "You can filter by Uploader by entering a Case Sensitive username, or leave empty to get all results.<br>Note: this is the username of the Uploader and not the Groupname that often show up at the end of 1337x titles, eg -GalaxyRG." },
+    { name = "info_flaresolverr", text_value = "This site may use Cloudflare DDoS Protection, therefore Prowlarr requires <a href=\"https://wiki.servarr.com/prowlarr/faq#can-i-use-flaresolverr-indexers\" target=\"_blank\" rel=\"noreferrer\">FlareSolverr</a> to access it." },
+    { name = "downloadlink", number_value = 0 },
+    { name = "downloadlink2", number_value = 1 },
+    { name = "info_download", text_value = "As the iTorrents .torrent download link on this site is known to fail from time to time, we suggest using the magnet link as a fallback. The BTCache and Torrage services are not supported because they require additional user interaction (a captcha for BTCache and a download button on Torrage.)" },
+    { name = "disablesort", bool_value = false },
+    { name = "sort", number_value = 2 },
+    { name = "type", number_value = 1 },
   ]
 }
 
@@ -81,9 +106,17 @@ resource "prowlarr_indexer" "yts" {
   config_contract = "CardigannSettings"
   app_profile_id  = 1
 
-  lifecycle { ignore_changes = [fields] }
-
   fields = [
     { name = "definitionFile", text_value = "yts" },
+    { name = "apiurl", text_value = "movies-api.accel.li" },
+    { name = "baseUrl" },
+    { name = "baseSettings.queryLimit" },
+    { name = "baseSettings.grabLimit" },
+    { name = "baseSettings.limitsUnit", number_value = 0 },
+    { name = "torrentBaseSettings.appMinimumSeeders" },
+    { name = "torrentBaseSettings.seedRatio" },
+    { name = "torrentBaseSettings.seedTime" },
+    { name = "torrentBaseSettings.packSeedTime" },
+    { name = "torrentBaseSettings.preferMagnetUrl", bool_value = false },
   ]
 }


### PR DESCRIPTION
## Summary

- Specifies all fields returned by Prowlarr for each Cardigann indexer (EZTV: 10, YTS: 11, 1337x: 19) so the planned field-set hash matches the post-CREATE read-back hash
- This resolves the \"inconsistent values for sensitive attribute\" provider error that has been keeping \`prowlarr-config\` tofu in a failed apply loop
- Removes the stale YTS import block (the indexer has been cycled through many IDs by the churn loop); tofu will create it fresh
- Root cause: the devopsarr/prowlarr provider computes a hash of the \`fields\` set (which is sensitive-containing due to \`sensitive_value\`), and any element count or value mismatch between plan and read-back triggers the inconsistency error

🤖 Generated with [Claude Code](https://claude.com/claude-code)