### PR TITLE
fix(flaresolverr): increase request timeout to 120s and memory to 2Gi

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/flaresolverr/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/flaresolverr/app/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
+              memory: 512Mi
             limits:
               cpu: 1000m
-              memory: 1Gi
+              memory: 2Gi

--- a/terraform/prowlarr/proxy.tf
+++ b/terraform/prowlarr/proxy.tf
@@ -5,6 +5,6 @@ resource "prowlarr_tag" "flaresolverr" {
 resource "prowlarr_indexer_proxy_flaresolverr" "main" {
   name            = "FlareSolverr"
   host            = "http://flaresolverr.mediastack.svc.cluster.local:8191"
-  request_timeout = 60
+  request_timeout = 120
   tags            = [prowlarr_tag.flaresolverr.id]
 }


### PR DESCRIPTION
## Summary

- Prowlarr validates EZTV and 1337x by making live HTTP requests through FlareSolverr during indexer CREATE — Cloudflare challenges on these sites take >60s to solve, especially when 3+ Chromium sessions run concurrently (one per 1337x search path + EZTV)
- \`request_timeout = 60\` in the proxy config sets the \`maxTimeout\` Prowlarr sends to FlareSolverr — raising to 120s gives Chromium enough runway before Prowlarr abandons with "Http request timed out"
- Memory limit raised 1Gi → 2Gi to accommodate concurrent Chromium sessions without swapping/OOM pressure

🤖 Generated with [Claude Code](https://claude.com/claude-code)