### PR TITLE
fix(scheduling): prevent Prometheus+ARC co-scheduling, bump metrics-server memory

### DIFF
--- a/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/configmap.yaml
@@ -29,6 +29,17 @@ data:
           category: ci
       spec:
         serviceAccountName: github-actions-runner
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: prometheus
+                  namespaces:
+                    - monitoring
+                  topologyKey: kubernetes.io/hostname
         containers:
           - name: runner
             image: ghcr.io/actions/actions-runner:2.332.0

--- a/clusters/vollminlab-cluster/kube-system/metrics-server/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kube-system/metrics-server/app/configmap.yaml
@@ -26,10 +26,10 @@ data:
     resources:
       requests:
         cpu: 50m
-        memory: 64Mi
+        memory: 128Mi
       limits:
         cpu: 200m
-        memory: 128Mi
+        memory: 256Mi
     service:
       annotations:
         prometheus.io/scrape: "true"


### PR DESCRIPTION
## Summary

- Add soft `PodAntiAffinity` to ARC runner pods to prefer nodes not running Prometheus
- Double metrics-server memory limit: 128Mi → 256Mi (request 64Mi → 128Mi)

## Root cause

k8sworker04 accumulated Prometheus + 2+ ARC runners by random scheduler luck. With Prometheus at 2 CPU / 3Gi limits and each runner at 2 CPU / 2Gi, the node hit 85% CPU and 85% memory under load. This starved metrics-server (capped at 128Mi), causing:

1. metrics-server liveness probe timeouts → 23 container restarts in 30h
2. `metrics.k8s.io` returning "unable to handle request"
3. Longhorn manager goroutine buildup from failed metric scrapes every 30s
4. longhorn-manager healthz probe timeouts → node marked "down" → alerts fired

## Changes

**ARC runners** (`arc-runners/app/configmap.yaml`): soft `preferredDuringSchedulingIgnoredDuringExecution` anti-affinity (weight 100) avoiding nodes with `app.kubernetes.io/name: prometheus` in the `monitoring` namespace. This is a scheduling hint only — no node gets special treatment, any worker can still run either workload.

**metrics-server** (`metrics-server/app/configmap.yaml`): memory request 64Mi → 128Mi, limit 128Mi → 256Mi. The original limits were undersized for a 7-node cluster under normal load.