### PR TITLE
fix(prowlarr): add ignore_changes on fields for 1337x Cardigann indexer

### DIFF
--- a/terraform/prowlarr/indexers.tf
+++ b/terraform/prowlarr/indexers.tf
@@ -1,8 +1,9 @@
 # Prowlarr indexers: Newznab usenet (NZBgeek, NzbPlanet) imported 2026-05-15;
 # Cardigann torrent (1337x, EZTV, YTS) created 2026-05-19.
-# Newznab indexers use ignore_changes on fields to tolerate Prowlarr masking sensitive API keys.
-# Cardigann indexers specify only non-null field values — the provider omits null-value fields
-# from state, so including them in the plan causes a hash mismatch on post-CREATE read.
+# Newznab indexers use ignore_changes on fields: Prowlarr masks sensitive API keys on read-back.
+# Cardigann indexers: specify only non-null, non-info-type field values (provider omits these).
+# 1337x additionally uses ignore_changes: provider bug causes hash mismatch on definition-specific
+# Cardigann fields (downloadlink, sort, type, disablesort) in sensitive-containing sets.
 
 resource "prowlarr_indexer" "eztv" {
   name            = "EZTV"
@@ -66,6 +67,13 @@ resource "prowlarr_indexer" "the1337x" {
   config_contract = "CardigannSettings"
   app_profile_id  = 1
   tags            = [prowlarr_tag.flaresolverr.id]
+
+  # ignore_changes on fields: the devopsarr/prowlarr provider has a bug where
+  # definition-specific Cardigann fields (downloadlink, sort, type, etc.) cause
+  # a post-apply hash mismatch on sensitive-containing sets. The indexer is
+  # correctly configured in Prowlarr; we suppress drift detection to avoid
+  # the destroy-recreate loop.
+  lifecycle { ignore_changes = [fields] }
 
   fields = [
     { name = "definitionFile", text_value = "1337x" },


### PR DESCRIPTION
## Summary

- Adds `lifecycle { ignore_changes = [fields] }` to `prowlarr_indexer.the1337x`
- Updates the file header comment to accurately describe the workaround for each indexer type

## Root cause

The `devopsarr/prowlarr` provider computes a hash over the `fields` set (which is sensitive-containing) during plan, then re-reads the resource after apply and computes a new hash. For the 1337x Cardigann definition, the 5 definition-specific fields (`downloadlink`, `downloadlink2`, `disablesort`, `sort`, `type`) produce a mismatch between the planned hash and the post-apply read-back hash — a known provider bug.

EZTV and YTS are unaffected because their Cardigann definitions have no definition-specific fields beyond the standard base fields.

## Fix

`ignore_changes = [fields]` tells OpenTofu to never plan updates to the `fields` attribute. Since the resource already exists in Prowlarr with the correct field values (state ID=209), tofu will see no diff and skip the apply entirely — no hash check is triggered, no destroy-recreate loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)