### PR TITLE
fix(prowlarr): increase memory limit 256Mi → 512Mi to fix OOMKill

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/prowlarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/prowlarr/app/configmap.yaml
@@ -28,7 +28,7 @@ data:
     resources:
       requests:
         cpu: 100m
-        memory: 128Mi
+        memory: 256Mi
       limits:
         cpu: 500m
-        memory: 256Mi
+        memory: 512Mi


### PR DESCRIPTION
## Summary

- Bumps Prowlarr memory request 128Mi → 256Mi, limit 256Mi → 512Mi

## Root cause

Prowlarr was being OOMKilled (exit code 137) at the 256Mi limit, causing liveness probe timeouts (`/ping` stopped responding) and a restart loop — which is what broke the homepage widget with `ECONNREFUSED`.

Adding the Cardigann torrent indexers (1337x, EZTV, YTS) in recent PRs increased Prowlarr's memory footprint; the existing 256Mi limit is no longer sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)