### PR TITLE
feat(homepage): add ESXi host cards with ping and EHC links

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -153,17 +153,17 @@ data:
                 icon: vmware-esxi.png
                 ping: https://vcenter.vollminlab.com
             - ESXi 01:
-                description: ESXi host 1 — k8scp01/k8sworker01
+                description: VMware ESXi hypervisor 1
                 href: https://esxi01.vollminlab.com/ui/
                 icon: vmware-esxi.png
                 ping: https://esxi01.vollminlab.com
             - ESXi 02:
-                description: ESXi host 2 — k8scp02/k8sworker02
+                description: VMware ESXi hypervisor 2
                 href: https://esxi02.vollminlab.com/ui/
                 icon: vmware-esxi.png
                 ping: https://esxi02.vollminlab.com
             - ESXi 03:
-                description: ESXi host 3 — k8scp03/k8sworker03/k8sworker04/k8sworker05/k8sworker06
+                description: VMware ESXi hypervisor 3
                 href: https://esxi03.vollminlab.com/ui/
                 icon: vmware-esxi.png
                 ping: https://esxi03.vollminlab.com

--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -152,6 +152,21 @@ data:
                 href: https://vcenter.vollminlab.com
                 icon: vmware-esxi.png
                 ping: https://vcenter.vollminlab.com
+            - ESXi 01:
+                description: ESXi host 1 — k8scp01/k8sworker01
+                href: https://esxi01.vollminlab.com/ui/
+                icon: vmware-esxi.png
+                ping: https://esxi01.vollminlab.com
+            - ESXi 02:
+                description: ESXi host 2 — k8scp02/k8sworker02
+                href: https://esxi02.vollminlab.com/ui/
+                icon: vmware-esxi.png
+                ping: https://esxi02.vollminlab.com
+            - ESXi 03:
+                description: ESXi host 3 — k8scp03/k8sworker03/k8sworker04/k8sworker05/k8sworker06
+                href: https://esxi03.vollminlab.com/ui/
+                icon: vmware-esxi.png
+                ping: https://esxi03.vollminlab.com
             - Portainer:
                 description: Container management
                 href: https://portainer.vollminlab.com


### PR DESCRIPTION
## Summary

- Adds three ESXi host cards (`esxi01`, `esxi02`, `esxi03`) to the Infrastructure group on the homepage
- Each card links directly to the ESXi Host Client (`https://esxi0X.vollminlab.com/ui/`)
- Each card has a `ping` status dot showing host availability at a glance
- Cards sit immediately below the existing vCenter card, keeping all VMware infrastructure visually grouped

🤖 Generated with [Claude Code](https://claude.com/claude-code)