### PR TITLE
fix(filebrowser): bypass Authentik auth on /api/tus to fix upload failures

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/filebrowser/app/ingress-tus.yaml
+++ b/clusters/vollminlab-cluster/mediastack/filebrowser/app/ingress-tus.yaml
@@ -1,0 +1,37 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: filebrowser-tus-ingress
+  namespace: mediastack
+  annotations:
+    # No Authentik auth_request — filebrowser's own JWT validates TUS uploads.
+    # Authentik sessions expire independently of filebrowser sessions; auth_request
+    # on the TUS path causes every chunk to fail with a 302 redirect loop once the
+    # Authentik session expires, even though the filebrowser JWT is still valid.
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      client_body_timeout 600s;
+  labels:
+    app: filebrowser
+    env: production
+    category: apps
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: filebrowser.vollminlab.com
+      http:
+        paths:
+          - path: /api/tus
+            pathType: Prefix
+            backend:
+              service:
+                name: filebrowser
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - filebrowser.vollminlab.com
+      secretName: wildcard-tls

--- a/clusters/vollminlab-cluster/mediastack/filebrowser/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/filebrowser/app/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+  - ingress-tus.yaml


### PR DESCRIPTION
## Summary

- **Root cause**: Every TUS `POST`/`PATCH` to `/api/tus/` hits nginx `auth_request` → Authentik. When the Authentik session expires (24h default), the upload gets a 302 redirect instead of reaching filebrowser — even though filebrowser's own JWT is still valid and the UI still works
- **Evidence**: nginx logs show 100% of TUS `POST` requests returning `302` with no upstream contact; Authentik outpost logs confirm 401 for unauthenticated requests on the same pattern seen with Radarr/Readarr SignalR
- **Fix**: Path-split ingress for `/api/tus` without Authentik annotations. Filebrowser's own JWT validates TUS requests. The JWT is only obtainable via Authentik-authenticated `/api/login`, so there is no effective auth bypass

The main ingress at `/` still enforces Authentik forward-auth for all UI and API access. Only the TUS upload path is split out.