### PR TITLE
fix(mediastack): bypass Authentik forward-auth for Arr SignalR endpoints

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/prowlarr/app/ingress-signalr.yaml
+++ b/clusters/vollminlab-cluster/mediastack/prowlarr/app/ingress-signalr.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prowlarr-signalr-ingress
+  namespace: mediastack
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+  labels:
+    app: prowlarr
+    env: production
+    category: media
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: prowlarr.vollminlab.com
+      http:
+        paths:
+          - path: /signalr
+            pathType: Prefix
+            backend:
+              service:
+                name: prowlarr
+                port:
+                  number: 9696
+  tls:
+    - hosts:
+        - prowlarr.vollminlab.com
+      secretName: wildcard-tls

--- a/clusters/vollminlab-cluster/mediastack/prowlarr/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/prowlarr/app/kustomization.yaml
@@ -5,5 +5,6 @@ metadata:
 resources:
   - configmap.yaml
   - helmrelease.yaml
+  - ingress-signalr.yaml
   - ingress.yaml
   - pvc-prowlarr-config.yaml

--- a/clusters/vollminlab-cluster/mediastack/radarr/app/ingress-signalr.yaml
+++ b/clusters/vollminlab-cluster/mediastack/radarr/app/ingress-signalr.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: radarr-signalr-ingress
+  namespace: mediastack
+  annotations:
+    # No Authentik auth_request — Radarr validates its own bearer token on SignalR
+    # connections (?access_token=<radarr-jwt>). Authentik forward-auth cannot
+    # validate app-level JWTs, causing 1200+ 401/redirect loops per day.
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+  labels:
+    app: radarr
+    env: production
+    category: media
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: radarr.vollminlab.com
+      http:
+        paths:
+          - path: /signalr
+            pathType: Prefix
+            backend:
+              service:
+                name: radarr
+                port:
+                  number: 7878
+  tls:
+    - hosts:
+        - radarr.vollminlab.com
+      secretName: wildcard-tls

--- a/clusters/vollminlab-cluster/mediastack/radarr/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/radarr/app/kustomization.yaml
@@ -5,5 +5,6 @@ metadata:
 resources:
   - configmap.yaml
   - helmrelease.yaml
+  - ingress-signalr.yaml
   - ingress.yaml
   - pvc-radarr-config.yaml

--- a/clusters/vollminlab-cluster/mediastack/readarr/app/ingress-signalr.yaml
+++ b/clusters/vollminlab-cluster/mediastack/readarr/app/ingress-signalr.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: readarr-signalr-ingress
+  namespace: mediastack
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+  labels:
+    app: readarr
+    env: production
+    category: media
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: readarr.vollminlab.com
+      http:
+        paths:
+          - path: /signalr
+            pathType: Prefix
+            backend:
+              service:
+                name: readarr
+                port:
+                  number: 8787
+  tls:
+    - hosts:
+        - readarr.vollminlab.com
+      secretName: wildcard-tls

--- a/clusters/vollminlab-cluster/mediastack/readarr/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/readarr/app/kustomization.yaml
@@ -5,5 +5,6 @@ metadata:
 resources:
   - configmap.yaml
   - helmrelease.yaml
+  - ingress-signalr.yaml
   - ingress.yaml
   - pvc-readarr-config.yaml

--- a/clusters/vollminlab-cluster/mediastack/sonarr/app/ingress-signalr.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sonarr/app/ingress-signalr.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sonarr-signalr-ingress
+  namespace: mediastack
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+  labels:
+    app: sonarr
+    env: production
+    category: media
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: sonarr.vollminlab.com
+      http:
+        paths:
+          - path: /signalr
+            pathType: Prefix
+            backend:
+              service:
+                name: sonarr
+                port:
+                  number: 8989
+  tls:
+    - hosts:
+        - sonarr.vollminlab.com
+      secretName: wildcard-tls

--- a/clusters/vollminlab-cluster/mediastack/sonarr/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sonarr/app/kustomization.yaml
@@ -5,5 +5,6 @@ metadata:
 resources:
   - configmap.yaml
   - helmrelease.yaml
+  - ingress-signalr.yaml
   - ingress.yaml
   - pvc-sonarr-config.yaml


### PR DESCRIPTION
## Summary

- Adds path-split ingresses for `/signalr` on Radarr, Sonarr, Readarr, and Prowlarr that skip Authentik `auth_request`
- Each Arr app embeds an app-level JWT in SignalR WebSocket URLs (`?access_token=<jwt>`); Authentik cannot validate these tokens and returns 401 on every ~30s keepalive — confirmed 1255 Radarr + 1191 Readarr failures in 48h
- The apps handle their own bearer token validation on the SignalR endpoint; Authentik is not needed there
- `proxy-read-timeout` and `proxy-send-timeout` set to 3600s to keep long-lived WebSocket connections alive

🤖 Generated with [Claude Code](https://claude.com/claude-code)