### PR TITLE
fix(authentik): extend session duration to 30 days

### DIFF
--- a/terraform/authentik/imports.tf
+++ b/terraform/authentik/imports.tf
@@ -250,6 +250,12 @@ import {
   id = "8e340cfd-475d-4f20-b3c6-67b395a900eb"
 }
 
+# Login stage
+import {
+  to = authentik_stage_user_login.default_authentication_login
+  id = "06d0ce3a-ec88-4295-882d-af84d84aa892"
+}
+
 # Portainer settings
 import {
   to = portainer_settings.main

--- a/terraform/authentik/stages.tf
+++ b/terraform/authentik/stages.tf
@@ -1,0 +1,7 @@
+resource "authentik_stage_user_login" "default_authentication_login" {
+  name               = "default-authentication-login"
+  session_duration   = "days=30"
+  remember_me_offset = "days=0"
+  network_binding    = "no_binding"
+  geoip_binding      = "no_binding"
+}


### PR DESCRIPTION
## Summary

- Adds `terraform/authentik/stages.tf` managing `authentik_stage_user_login.default_authentication_login` via the Authentik Terraform provider
- Changes `session_duration` from `seconds=0` (browser session cookie — dies on browser close) to `days=30` (persistent cookie stored to disk)
- Adds the import block to `imports.tf` so tofu adopts the existing `default-authentication-login` stage (UUID `06d0ce3a-ec88-4295-882d-af84d84aa892`) rather than trying to create a new one

**Effect:** Users who authenticate will stay logged in for 30 days across browser restarts instead of being prompted on every new session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)