### PR TITLE
fix(arc-runners): bump runner image 2.332.0 → 2.334.0

### DIFF
--- a/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/configmap.yaml
@@ -42,7 +42,7 @@ data:
                   topologyKey: kubernetes.io/hostname
         containers:
           - name: runner
-            image: ghcr.io/actions/actions-runner:2.332.0
+            image: ghcr.io/actions/actions-runner:2.334.0
             command: ["/home/runner/run.sh"]
             env:
               - name: DOCKER_HOST


### PR DESCRIPTION
## Summary

- GitHub deprecated runner v2.332.0, which now returns `403 Forbidden` when polling for jobs
- All CI is blocked — runners start, register, then immediately exit with: `Runner version v2.332.0 is deprecated and cannot receive messages`
- Bumps to v2.334.0 (current latest, released 2026-04-21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)