### PR TITLE
chore(arc-runners): bump gha-runner-scale-set chart 0.14.0 → 0.14.1

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/arc-runners-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/arc-runners-ocirepository.yaml
@@ -11,7 +11,7 @@ spec:
   interval: 1h
   url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
   ref:
-    tag: "0.14.0"
+    tag: "0.14.1"
   layerSelector:
     mediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip"
     operation: copy


### PR DESCRIPTION
## Summary

- Bumps ARC `gha-runner-scale-set` chart `0.14.0` → `0.14.1` (released 2026-04-15)
- Runner image already at `v2.334.0` from #701

Chart 0.14.1 changelog: runner updates to v2.333.1, null field fixes for resource metadata, scaleset library bump to v0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)