### PR TITLE
fix(vmware-exporter): enable Service so ServiceMonitor can scrape metrics

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/vmware-exporter/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/vmware-exporter/app/configmap.yaml
@@ -29,6 +29,7 @@ data:
         memory: 256Mi
 
     service:
+      enabled: true
       type: ClusterIP
       port: 9272
       targetPort: 9272


### PR DESCRIPTION
## Summary

- Adds `service.enabled: true` to the vmware-exporter Helm values
- The kremers/vmware-exporter chart defaults `service.enabled: false`, so no Service was created when PR #700 deployed the stack
- Without a Service, the ServiceMonitor had nothing to select and Prometheus never scraped VMware metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)