### PR TITLE
fix(vmware-exporter): add release label so PrometheusRule is loaded by Prometheus

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/vmware-exporter/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/vmware-exporter/app/configmap.yaml
@@ -29,6 +29,7 @@ data:
         memory: 256Mi
 
     service:
+      enabled: true
       type: ClusterIP
       port: 9272
       targetPort: 9272

--- a/clusters/vollminlab-cluster/monitoring/vmware-exporter/app/prometheusrule.yaml
+++ b/clusters/vollminlab-cluster/monitoring/vmware-exporter/app/prometheusrule.yaml
@@ -7,6 +7,7 @@ metadata:
     app: vmware-exporter
     env: production
     category: observability
+    release: kube-prometheus-stack
 spec:
   groups:
     - name: vmware.hosts


### PR DESCRIPTION
## Summary

- Prometheus operator uses `ruleSelector: matchLabels: release: kube-prometheus-stack`
- The vmware-exporter PrometheusRule was missing this label, so Prometheus silently ignored all 5 alert rules
- Caught during post-merge verification: `up{job="vmware-exporter"}` = 1 (scraping works) but rules weren't loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)