### PR TITLE
fix(shlink): add Harbor pull secret to shlink-ingress-controller

### DIFF
--- a/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/configmap.yaml
@@ -14,6 +14,9 @@ data:
       env: production
       category: apps
 
+    imagePullSecrets:
+      - name: harbor-vollminlab-pull
+
     resources:
       requests:
         cpu: 50m

--- a/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/harbor-vollminlab-pull-sealedsecret.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/harbor-vollminlab-pull-sealedsecret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: harbor-vollminlab-pull
+  namespace: shlink
+spec:
+  encryptedData:
+    .dockerconfigjson: AgB5ZMtLw6xGlhiMbXH8CfiN8D9hzN7w/kOP479VmmgnuIKoSkynL5hJ/6lD84f6zAFSDYd8KoNLjNmmXsx2Hy69CR6vuVC1zIgNTJ9GkxdKBgalMC+m8lBks3eCali5as6eb6nTbV6yWALkUjWwSSbqLLxxe5+pEmWFFDu5Pwfzn99LZ6xpwH6jEUbqmCgd1dKzqmf06fdf/e88Z71KLecB6ksP5Q5MaBq0m39+Ml9VfKtPSHPmwycyFwtwVPTM6TslPFylWCbJQRLCCU5tmkzaSFBg5DxLDVhldNBNXfr314XZ0PCyyOUi3/4sqmFfpPeOiJ0TJY3VjzrUnmOjtIkdvavbeTzRG4csJBRKQTEp2hXyW0s5CrCRp0dme56OHviYPsnf/Y7zpVG13Fi6hhlZPwHkDdzTxYCMj6ZwqqPmFuxN8+fxzbGeCvzhZhPnlo+Q/NxgCgzFwQ3bXitI+kBL6yIGQm/LzHgDsg1iXSEf+iZAmhNkW1dIF6ziYJj6wfpxOv3X9CM36jfQ+c2K2/mQJMvnThKpcglPXPZsgHIKXLOSDTC/5svw+9dD/AkllnW6gT3CUh/f7ctn6sheZarPPXWkTIcI8hJifLOB5zwAsGpRxGOHXSdXBWFn/m8+6bpQLZeKlY3KcESsflqs/VWI+aalPJuLRDgTg6BGqG5wqQL1uUMhyGFEfVIelPpqoeaBr09DARPdfvvr9XsR2JtiKsECw/GStD2KAfWMLl15mWbcmaIbE0JUhdIwpwqCci39F/cxtBNIzJXJIkNT6gY62czgHOv6/ZZ9VFgG6nXWx224xZ87svrXznxABORBLdcKeSBco40OsfsP79jOUoXAUMTDG2l4WYvFvhgA24XWfnvDKwV7K2nhlAiHGjk/xezPegeIFJLIGSCx60tQrC4BNHpbYoBGZ2PDUhb6YcrSK0ekLNDpqAmwJwB3vJ0BWA0rCoVLXkoLmGCH0suiprwYWOKnSQ2MU0vHqBT2IgmhC8rN1MArYiIPH6qqTEZ8VS1Uc1OjwUi9
+  template:
+    metadata:
+      name: harbor-vollminlab-pull
+      namespace: shlink
+      labels:
+        app: harbor-vollminlab-pull
+        env: production
+        category: apps
+    type: kubernetes.io/dockerconfigjson

--- a/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - helmrelease.yaml
   - configmap.yaml
+  - harbor-vollminlab-pull-sealedsecret.yaml


### PR DESCRIPTION
## Summary

- Adds `harbor-vollminlab-pull` SealedSecret (namespace: shlink) using the `robot$vollminlab+cluster-pull` robot account
- Wires `imagePullSecrets` into the shlink-ingress-controller Helm values via configmap
- Lists the SealedSecret in kustomization.yaml

**Root cause:** The pod was working because the image was cached on the node it ran on. After k8s upgrade restarted kubelet on worker01, the credential cache was cleared and the pod rescheduled there with no way to authenticate to Harbor.

This same issue would recur on any fresh node. All namespaces pulling custom images from Harbor need this pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)