### PR TITLE
fix(sealed-secrets): increase memory limit to fix OOMKill cycling

### DIFF
--- a/clusters/vollminlab-cluster/sealed-secrets/sealed-secrets/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/sealed-secrets/sealed-secrets/app/configmap.yaml
@@ -17,10 +17,10 @@ data:
     resources:
       requests:
         cpu: 50m
-        memory: 32Mi
+        memory: 64Mi
       limits:
         cpu: 100m
-        memory: 64Mi
+        memory: 128Mi
     podLabels:
       app: sealed-secrets
       env: production


### PR DESCRIPTION
## Summary

- Controller was OOMKilled at the 64Mi limit after loading 11 sealing keys into memory on startup
- Bumped memory limit 64Mi → 128Mi and request 32Mi → 64Mi
- Last exit code was 137 (SIGKILL from OOM), running for only ~3 seconds before being killed

🤖 Generated with [Claude Code](https://claude.com/claude-code)