### PR TITLE
fix(shlink): inject imagePullSecrets via HelmRelease postRenderers

### DIFF
--- a/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/helmrelease.yaml
@@ -17,3 +17,19 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: shlink-ingress-controller-values
+  postRenderers:
+    - kustomize:
+        patches:
+          - patch: |-
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: shlink-ingress-controller
+              spec:
+                template:
+                  spec:
+                    imagePullSecrets:
+                      - name: harbor-vollminlab-pull
+            target:
+              kind: Deployment
+              name: shlink-ingress-controller


### PR DESCRIPTION
## Summary

- The shlink-ingress-controller chart template does not support `imagePullSecrets` — passing it via `values` has no effect on the rendered Deployment
- Without credentials, pods on nodes that don't have the image cached fail to pull from `harbor.vollminlab.com` (discovered during k8s upgrade when pods reschedule to freshly upgraded nodes)
- Fix: use Flux `postRenderers.kustomize` to patch the Deployment spec directly after Helm rendering, injecting `imagePullSecrets: [{name: harbor-vollminlab-pull}]`
- The `imagePullSecrets` key in the configmap values can be removed in a follow-up cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)