### PR TITLE
feat(shlink): bump chart to v0.3.6 with native imagePullSecrets support

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/vollminlab-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/vollminlab-ocirepository.yaml
@@ -11,6 +11,6 @@ spec:
   interval: 1h
   url: oci://harbor.vollminlab.com/vollminlab/charts/shlink-ingress-controller
   ref:
-    tag: "0.3.5"
+    tag: "0.3.6"
   secretRef:
     name: harbor-vollminlab-pull

--- a/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink-ingress-controller/app/helmrelease.yaml
@@ -17,19 +17,3 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: shlink-ingress-controller-values
-  postRenderers:
-    - kustomize:
-        patches:
-          - patch: |-
-              apiVersion: apps/v1
-              kind: Deployment
-              metadata:
-                name: shlink-ingress-controller
-              spec:
-                template:
-                  spec:
-                    imagePullSecrets:
-                      - name: harbor-vollminlab-pull
-            target:
-              kind: Deployment
-              name: shlink-ingress-controller


### PR DESCRIPTION
## Summary

- Bumps `vollminlab-ocirepository.yaml` tag `0.3.5` → `0.3.6`
- Removes `postRenderers` workaround from HelmRelease — chart v0.3.6 now renders `imagePullSecrets` natively from values
- `imagePullSecrets` value already present in the ConfigMap from #712; no change needed there

Supersedes the postRenderers workaround added in #712.

🤖 Generated with [Claude Code](https://claude.com/claude-code)