### PR TITLE
fix(storage): trim harbor-registry PVC and exclude system namespaces from Velero backups

### DIFF
--- a/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
@@ -57,7 +57,7 @@ data:
         registry:
           storageClass: longhorn
           accessMode: ReadWriteOnce
-          size: 25Gi
+          size: 5Gi
         jobservice:
           jobLog:
             storageClass: longhorn

--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -124,6 +124,8 @@ data:
           storageLocation: minio
           defaultVolumesToFsBackup: true
           excludedNamespaces:
+            - kyverno
+            - longhorn-system
             - minio
             - monitoring
             - velero
@@ -139,6 +141,8 @@ data:
           storageLocation: b2
           defaultVolumesToFsBackup: true
           excludedNamespaces:
+            - kyverno
+            - longhorn-system
             - minio
             - monitoring
             - velero
@@ -154,6 +158,8 @@ data:
           storageLocation: b2
           defaultVolumesToFsBackup: true
           excludedNamespaces:
+            - kyverno
+            - longhorn-system
             - minio
             - monitoring
             - velero


### PR DESCRIPTION
## Summary

- **harbor-registry PVC: 25Gi → 5Gi** — actual usage is 265MB. Frees 60Gi of Longhorn scheduled space across 3 nodes, helping worker02 disk pressure
- **Velero: add `kyverno` and `longhorn-system` to `excludedNamespaces`** on all three schedules — these namespaces have no meaningful PVC data worth backing up, and their pods being rescheduled during node drains was the root cause of consistent `PartiallyFailed` B2 backups

## Post-merge manual steps required

The harbor-registry PVC cannot be resized downward by Helm (`resourcePolicy: keep`). After merging:

1. Scale down harbor-registry to release the PVC:
   ```bash
   kubectl scale deployment harbor-registry -n harbor --replicas=0
   ```
2. Delete the old PVC:
   ```bash
   kubectl delete pvc harbor-registry -n harbor
   ```
3. Force Flux to reconcile (recreates PVC at 5Gi):
   ```bash
   flux reconcile helmrelease harbor -n harbor
   ```
4. Re-push the shlink-ingress-controller image to Harbor:
   ```bash
   # On devsbx01 or any node with docker/crane access
   docker pull harbor.vollminlab.com/vollminlab/shlink-ingress-controller:0.3.6
   docker push harbor.vollminlab.com/vollminlab/shlink-ingress-controller:0.3.6
   ```
   (The image is already in the cluster — Flux will re-pull it once Harbor is healthy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)