### PR TITLE
fix(velero): exclude tofu namespace from all backup schedules

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -128,6 +128,7 @@ data:
             - longhorn-system
             - minio
             - monitoring
+            - tofu
             - velero
           resourcePolicy:
             kind: ConfigMap
@@ -145,6 +146,7 @@ data:
             - longhorn-system
             - minio
             - monitoring
+            - tofu
             - velero
           resourcePolicy:
             kind: ConfigMap
@@ -162,6 +164,7 @@ data:
             - longhorn-system
             - minio
             - monitoring
+            - tofu
             - velero
           resourcePolicy:
             kind: ConfigMap


### PR DESCRIPTION
## Summary

- Adds `tofu` to `excludedNamespaces` in all three Velero schedules (daily-full, daily-b2, monthly-b2)

**Root cause:** Tofu runner pods (e.g. `sonarr-config-tf-runner`) are ephemeral — they spin up during a reconcile cycle and are deleted when the plan completes. With `defaultVolumesToFsBackup: true`, Velero snapshots the pod list at backup start, but by the time it actually attempts the fs-backup the runner pod is gone. This produces `PartiallyFailed` backups with `error getting client pod <name>: pods "<name>" not found`.

**Why safe to exclude:** The `tofu` namespace has no PVCs. All tofu-controller state lives in git. Nothing in this namespace is worth backing up.

**Follow-up to:** #716 (which added kyverno + longhorn-system exclusions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)