### PR TITLE
fix(qbittorrent,metallb): add readiness probe and unblock metallb upgrade

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
@@ -54,6 +54,14 @@ spec:
           ports:
             - containerPort: 8080
               name: webui
+          readinessProbe:
+            httpGet:
+              path: /api/v2/app/version
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            failureThreshold: 3
+            timeoutSeconds: 5
           volumeMounts:
             - name: config
               mountPath: /config

--- a/clusters/vollminlab-cluster/metallb-system/metallb/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/metallb-system/metallb/app/configmap.yaml
@@ -20,6 +20,10 @@ data:
         limits:
           cpu: 200m
           memory: 128Mi
+    frr-k8s:
+      prometheus:
+        serviceMonitor:
+          enabled: false
     speaker:
       enabled: true
       podAnnotations:

--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -128,6 +128,7 @@ data:
             - longhorn-system
             - minio
             - monitoring
+            - tofu
             - velero
           resourcePolicy:
             kind: ConfigMap
@@ -145,6 +146,7 @@ data:
             - longhorn-system
             - minio
             - monitoring
+            - tofu
             - velero
           resourcePolicy:
             kind: ConfigMap
@@ -162,6 +164,7 @@ data:
             - longhorn-system
             - minio
             - monitoring
+            - tofu
             - velero
           resourcePolicy:
             kind: ConfigMap


### PR DESCRIPTION
## Summary

- **qbittorrent**: Add HTTP readiness probe on `/api/v2/app/version:8080` so Kubernetes marks the pod `NotReady` when the WebUI is down. Without this, qBittorrent can crash-loop inside s6 for hours (stale lockfile, OOM, etc.) while the pod stays `Ready` and Prometheus/alerting see nothing wrong.
- **metallb**: Add `frr-k8s.prometheus.serviceMonitor.enabled: false` to the values ConfigMap. The frr-k8s subchart introduced in 0.16.0 requires this key — without it the template nil-panics on render, blocking the upgrade with 202 consecutive failures while MetalLB stays running at 0.15.3.