### PR TITLE
feat(monitoring): add Loki ruler alert for homepage widget HTTP 500 errors

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/loki/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/loki/app/configmap.yaml
@@ -45,6 +45,14 @@ data:
         retention_enabled: true
         delete_request_store: s3
 
+      rulerConfig:
+        alertmanager_url: http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093
+        enable_api: true
+        storage:
+          type: local
+          local:
+            directory: /etc/loki/rules
+
     singleBinary:
       replicas: 1
 
@@ -77,6 +85,14 @@ data:
         app: loki
         env: production
         category: observability
+
+      extraVolumes:
+        - name: ruler-rules
+          configMap:
+            name: loki-ruler-rules
+      extraVolumeMounts:
+        - name: ruler-rules
+          mountPath: /etc/loki/rules/fake
 
     gateway:
       enabled: false

--- a/clusters/vollminlab-cluster/monitoring/loki/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/monitoring/loki/app/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - helmrelease.yaml
   - configmap.yaml
   - loki-minio-credentials-sealedsecret.yaml
+  - loki-ruler-rules-configmap.yaml

--- a/clusters/vollminlab-cluster/monitoring/loki/app/loki-ruler-rules-configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/loki/app/loki-ruler-rules-configmap.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-ruler-rules
+  namespace: monitoring
+  labels:
+    app: loki
+    env: production
+    category: observability
+data:
+  homepage-alerts.yaml: |
+    groups:
+      - name: homepage-widget-errors
+        rules:
+          - alert: HomepageWidgetPersistentErrors
+            expr: |
+              sum by (widget) (
+                count_over_time(
+                  {namespace="homepage", container="homepage"}
+                    |= "ProxyHandler"
+                    |= "HTTP 500"
+                    | regexp `<(?P<widget>[a-z]+ProxyHandler)>`
+                    [10m]
+                )
+              ) > 5
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Homepage widget {{ $labels.widget }} returning persistent HTTP 500 errors"
+              description: "{{ $value | humanize }} HTTP 500 errors from {{ $labels.widget }} in the last 10 minutes. A backend service is likely down or unreachable."


### PR DESCRIPTION
## Summary

Closes the alerting gap that caused the qbittorrent widget outage to go undetected for 13 hours.

- **`loki-ruler-rules-configmap.yaml`** — new ConfigMap with a Loki ruler alert rule. Fires when any homepage widget `ProxyHandler` emits `HTTP 500` more than 5 times in 10 minutes, sustained for 5 minutes. The `widget` label is extracted from the log line (e.g. `qbittorrentProxyHandler`) so the alert names the broken backend directly.
- **`configmap.yaml` (loki-values)** — enables the Loki ruler with AlertManager integration (`kube-prometheus-stack-alertmanager:9093`) and switches ruler storage to local (the chart's `ruler.directories` mechanism is distributed-mode only; for SingleBinary we mount rules manually).
- **`kustomization.yaml`** — adds the new rules ConfigMap to the Loki kustomization.

## How it works

```
Loki ruler evaluates LogQL every 1m
  └─ {namespace="homepage", container="homepage"} |= "ProxyHandler" |= "HTTP 500"
       | regexp <widget> extracted
       count_over_time [10m] > 5
         for: 5m
           → AlertManager → Pushover
```

The rules ConfigMap is mounted at `/etc/loki/rules/fake/` (the `fake` tenant used by Loki when `auth_enabled: false`). The ruler's local storage root is `/etc/loki/rules`.