### PR TITLE
fix(minio): disable honorTimestamps on bucket metrics scrape

### DIFF
--- a/clusters/vollminlab-cluster/minio/minio/app/servicemonitor.yaml
+++ b/clusters/vollminlab-cluster/minio/minio/app/servicemonitor.yaml
@@ -25,3 +25,4 @@ spec:
       path: /minio/v2/metrics/bucket
       interval: 30s
       scheme: http
+      honorTimestamps: false


### PR DESCRIPTION
## Summary

- Adds `honorTimestamps: false` to the `/minio/v2/metrics/bucket` endpoint in the MinIO ServiceMonitor
- MinIO's bucket metrics endpoint embeds its own cached timestamps which fall behind Prometheus's head block, causing `PrometheusOutOfOrderTimestamps` alerts
- `honorTimestamps: false` instructs Prometheus to use the scrape time instead of the timestamps reported by the target, resolving the OOO conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)