### PR TITLE
feat(observability,security): deploy Goldilocks VPA recommender and Trivy Operator

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/goldilocks-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/goldilocks-kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: goldilocks
+  namespace: flux-system
+  labels:
+    app: goldilocks
+    env: production
+    category: observability
+spec:
+  interval: 10m
+  path: ./clusters/vollminlab-cluster/goldilocks
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: goldilocks
+  timeout: 5m
+  dependsOn:
+    - name: sealed-secrets

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml
@@ -35,3 +35,5 @@ resources:
   - harbor-kustomization.yaml
   - authentik-kustomization.yaml
   - tofu-kustomization.yaml
+  - goldilocks-kustomization.yaml
+  - trivy-system-kustomization.yaml

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/trivy-system-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/trivy-system-kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: trivy-system
+  namespace: flux-system
+  labels:
+    app: trivy-operator
+    env: production
+    category: security
+spec:
+  interval: 10m
+  path: ./clusters/vollminlab-cluster/trivy-system
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: trivy-system
+  timeout: 5m
+  dependsOn:
+    - name: sealed-secrets

--- a/clusters/vollminlab-cluster/flux-system/repositories/goldilocks-helmrepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/goldilocks-helmrepository.yaml
@@ -1,0 +1,13 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: goldilocks-repo
+  namespace: flux-system
+  labels:
+    app: goldilocks
+    env: production
+    category: observability
+spec:
+  interval: 5m
+  url: https://charts.fairwinds.com/stable
+  timeout: 3m

--- a/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - cnpg-helmrepository.yaml
   - descheduler-helmrepository.yaml
   - external-dns-helmrepository.yaml
+  - goldilocks-helmrepository.yaml
   - grafana-helmrepository.yaml
   - harbor-helmrepository.yaml
   - headlamp-helmrepository.yaml
@@ -44,6 +45,7 @@ resources:
   - smb-csi-driver-helmrepository.yaml
   - sonarr-ocirepository.yaml
   - tofu-controller-helmrepository.yaml
+  - trivy-operator-helmrepository.yaml
   - velero-helmrepository.yaml
   - vmware-exporter-helmrepository.yaml
   - harbor-vollminlab-pull-sealedsecret.yaml

--- a/clusters/vollminlab-cluster/flux-system/repositories/trivy-operator-helmrepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/trivy-operator-helmrepository.yaml
@@ -1,0 +1,13 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: trivy-operator-repo
+  namespace: flux-system
+  labels:
+    app: trivy-operator
+    env: production
+    category: security
+spec:
+  interval: 5m
+  url: https://aquasecurity.github.io/helm-charts/
+  timeout: 3m

--- a/clusters/vollminlab-cluster/goldilocks/goldilocks/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/goldilocks/goldilocks/app/configmap.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: goldilocks-values
+  namespace: goldilocks
+  labels:
+    app: goldilocks
+    env: production
+    category: observability
+data:
+  values.yaml: |
+    vpa:
+      enabled: true
+      recommender:
+        enabled: true
+        resources:
+          requests:
+            cpu: 50m
+            memory: 256Mi
+          limits:
+            cpu: 200m
+            memory: 512Mi
+      updater:
+        enabled: false
+      admissionController:
+        enabled: false
+
+    controller:
+      enabled: true
+      resources:
+        requests:
+          cpu: 25m
+          memory: 64Mi
+        limits:
+          cpu: 100m
+          memory: 256Mi
+
+    dashboard:
+      enabled: true
+      resources:
+        requests:
+          cpu: 25m
+          memory: 32Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
+      ingress:
+        enabled: false

--- a/clusters/vollminlab-cluster/goldilocks/goldilocks/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/goldilocks/goldilocks/app/helmrelease.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: goldilocks
+  namespace: goldilocks
+  labels:
+    app: goldilocks
+    env: production
+    category: observability
+spec:
+  interval: 5m
+  releaseName: goldilocks
+  chart:
+    spec:
+      chart: goldilocks
+      version: 10.3.0
+      sourceRef:
+        kind: HelmRepository
+        name: goldilocks-repo
+        namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: goldilocks-values
+      valuesKey: values.yaml

--- a/clusters/vollminlab-cluster/goldilocks/goldilocks/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/goldilocks/goldilocks/app/ingress.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: goldilocks-ingress
+  namespace: goldilocks
+  labels:
+    app: goldilocks
+    env: production
+    category: observability
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=https://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/auth-snippet: |
+      proxy_set_header X-Forwarded-Host $http_host;
+    shlink.vollminlab.com/slug: goldilocks
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: goldilocks.vollminlab.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: goldilocks-dashboard
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - goldilocks.vollminlab.com
+      secretName: wildcard-tls

--- a/clusters/vollminlab-cluster/goldilocks/goldilocks/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/goldilocks/goldilocks/app/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: goldilocks-deployment
+  namespace: flux-system
+  labels:
+    app: goldilocks
+    env: production
+    category: observability
+resources:
+  - helmrelease.yaml
+  - configmap.yaml
+  - ingress.yaml

--- a/clusters/vollminlab-cluster/goldilocks/kustomization.yaml
+++ b/clusters/vollminlab-cluster/goldilocks/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: goldilocks
+  labels:
+    app: goldilocks
+    env: production
+    category: observability
+resources:
+  - namespace.yaml
+  - goldilocks/app

--- a/clusters/vollminlab-cluster/goldilocks/namespace.yaml
+++ b/clusters/vollminlab-cluster/goldilocks/namespace.yaml
@@ -1,10 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: monitoring
+  name: goldilocks
   labels:
-    app: monitoring
+    app: goldilocks
     env: production
     category: observability
-  annotations:
-    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/mediastack/namespace.yaml
+++ b/clusters/vollminlab-cluster/mediastack/namespace.yaml
@@ -6,3 +6,5 @@ metadata:
     app: mediastack
     env: production
     category: media
+  annotations:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/trivy-system/kustomization.yaml
+++ b/clusters/vollminlab-cluster/trivy-system/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: trivy-system
+  labels:
+    app: trivy-operator
+    env: production
+    category: security
+resources:
+  - namespace.yaml
+  - trivy-operator/app

--- a/clusters/vollminlab-cluster/trivy-system/namespace.yaml
+++ b/clusters/vollminlab-cluster/trivy-system/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: trivy-system
+  labels:
+    app: trivy-operator
+    env: production
+    category: security

--- a/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trivy-operator-values
+  namespace: trivy-system
+  labels:
+    app: trivy-operator
+    env: production
+    category: security
+data:
+  values.yaml: |
+    operator:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+
+    trivy:
+      ignoreUnfixed: true
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+
+    serviceMonitor:
+      enabled: true

--- a/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/helmrelease.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: trivy-operator
+  namespace: trivy-system
+  labels:
+    app: trivy-operator
+    env: production
+    category: security
+spec:
+  interval: 5m
+  releaseName: trivy-operator
+  chart:
+    spec:
+      chart: trivy-operator
+      version: 0.32.1
+      sourceRef:
+        kind: HelmRepository
+        name: trivy-operator-repo
+        namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: trivy-operator-values
+      valuesKey: values.yaml

--- a/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: trivy-operator-deployment
+  namespace: flux-system
+  labels:
+    app: trivy-operator
+    env: production
+    category: security
+resources:
+  - helmrelease.yaml
+  - configmap.yaml


### PR DESCRIPTION
## Summary

- **Goldilocks** (fairwinds/goldilocks v10.3.0) — VPA recommender in recommendation-only mode (updater + admissionController disabled). Dashboard at `goldilocks.vollminlab.com` behind Authentik forward-auth. Goldilocks annotation enabled on `mediastack` and `monitoring` namespaces to immediately surface right-sizing data for the arr stack and observability workloads.
- **Trivy Operator** (aquasecurity/trivy-operator v0.32.1) — cluster-wide runtime vulnerability scanner, generates `VulnerabilityReport` and `ConfigAuditReport` CRs for all running workloads. ServiceMonitor enabled for Prometheus. `ignoreUnfixed: true` to reduce noise.
- Authentik Application entry created for `goldilocks` (forward-auth, `provider_id=None`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)