### PR TITLE
fix(trivy): add tolerations for control-plane and DMZ nodes

### DIFF
--- a/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
@@ -28,5 +28,24 @@ data:
           cpu: 500m
           memory: 512Mi
 
+    scanJobTolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: dmz
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+
+    nodeCollector:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: dmz
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
+
     serviceMonitor:
       enabled: true


### PR DESCRIPTION
## Summary

- `node-collector` pods were stuck Pending on control-plane nodes (`k8scp01/02/03`) due to missing `node-role.kubernetes.io/control-plane:NoSchedule` toleration
- Adds the same toleration to `scanJobTolerations` so vulnerability scan jobs can also reach control-plane-hosted workloads
- Adds `dmz=true:NoSchedule` toleration to both for completeness (DMZ workers `k8sworker05/06`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)