### PR TITLE
fix(goldilocks): move enabled flag from annotation to label

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/namespace.yaml
+++ b/clusters/vollminlab-cluster/mediastack/namespace.yaml
@@ -6,5 +6,4 @@ metadata:
     app: mediastack
     env: production
     category: media
-  annotations:
     goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/monitoring/namespace.yaml
+++ b/clusters/vollminlab-cluster/monitoring/namespace.yaml
@@ -6,5 +6,4 @@ metadata:
     app: monitoring
     env: production
     category: observability
-  annotations:
     goldilocks.fairwinds.com/enabled: "true"


### PR DESCRIPTION
## Summary

- Goldilocks controller checks namespace **labels** for `goldilocks.fairwinds.com/enabled`, not annotations — the initial deployment put it in `annotations` which the controller silently ignores
- Moves the flag to `labels` on `mediastack` and `monitoring` so the controller recognises them as managed namespaces and starts creating VPA recommendation objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)