### PR TITLE
fix(trivy,minio): limit concurrent scan jobs and fix out-of-order timestamps

### DIFF
--- a/clusters/vollminlab-cluster/minio/minio/app/servicemonitor.yaml
+++ b/clusters/vollminlab-cluster/minio/minio/app/servicemonitor.yaml
@@ -17,10 +17,12 @@ spec:
       path: /minio/v2/metrics/cluster
       interval: 30s
       scheme: http
+      honorTimestamps: false
     - port: http
       path: /minio/v2/metrics/node
       interval: 30s
       scheme: http
+      honorTimestamps: false
     - port: http
       path: /minio/v2/metrics/bucket
       interval: 30s

--- a/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
@@ -10,6 +10,7 @@ metadata:
 data:
   values.yaml: |
     operator:
+      scanJobsConcurrentLimit: 3
       resources:
         requests:
           cpu: 100m
@@ -23,10 +24,10 @@ data:
       resources:
         requests:
           cpu: 100m
-          memory: 128Mi
+          memory: 256Mi
         limits:
           cpu: 500m
-          memory: 512Mi
+          memory: 1Gi
 
     scanJobTolerations:
       - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
## Summary

- **Trivy**: Set `operator.scanJobsConcurrentLimit=3` (default 10 was scheduling 10+ concurrent scan jobs on k8sworker04, saturating its CPU/memory and causing kubelet to stop posting node status — node went NotReady). Also increased scan job memory limits (128Mi→256Mi request, 512Mi→1Gi limit) to give the Trivy DB download/decompression sufficient headroom.
- **MinIO ServiceMonitor**: Added `honorTimestamps: false` to the cluster and node metric endpoints. The bucket endpoint already had it, but the missing flag on the other two was the root cause of the `PrometheusOutOfOrderTimestamps` alert — MinIO serves metrics with its own internal timestamps, which can arrive out of order relative to the previous Prometheus scrape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)