### PR TITLE
fix(velero,kyverno): exclude ephemeral arr volumes from backup, bump reports-controller CPU

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
@@ -147,7 +147,7 @@ data:
           cpu: 100m
           memory: 128Mi
         limits:
-          cpu: 200m
+          cpu: 500m
           memory: 256Mi
 
     resources:

--- a/clusters/vollminlab-cluster/mediastack/prowlarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/prowlarr/app/configmap.yaml
@@ -18,6 +18,8 @@ data:
       app: prowlarr
       env: production
       category: media
+    podAnnotations:
+      backup.velero.io/backup-volumes-excludes: "tmp,varlogs,varrun,devshm"
     env:
       PROWLARR__AUTH__METHOD: "External"
     terminationGracePeriodSeconds: 60

--- a/clusters/vollminlab-cluster/mediastack/radarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/radarr/app/configmap.yaml
@@ -38,6 +38,8 @@ data:
       app: radarr
       env: production
       category: media
+    podAnnotations:
+      backup.velero.io/backup-volumes-excludes: "tmp,varlogs,varrun,devshm"
     env:
       RADARR__AUTH__METHOD: "External"
     securityContext:

--- a/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
@@ -42,6 +42,8 @@ data:
       app: readarr
       env: production
       category: media
+    podAnnotations:
+      backup.velero.io/backup-volumes-excludes: "tmp,varlogs,varrun,devshm"
     image:
       repository: ghcr.io/pennydreadful/bookshelf
       tag: hardcover-v0.4.20.129@sha256:388eecc94362580eae31ee0a454be6af516f8a311f8432a521c202fb475f4359

--- a/clusters/vollminlab-cluster/mediastack/sonarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sonarr/app/configmap.yaml
@@ -33,6 +33,8 @@ data:
       app: sonarr
       env: production
       category: media
+    podAnnotations:
+      backup.velero.io/backup-volumes-excludes: "tmp,varlogs,varrun,devshm"
     env:
       SONARR__AUTH__METHOD: "External"
     securityContext:


### PR DESCRIPTION
## Summary

- **Velero partial failures**: Add `backup.velero.io/backup-volumes-excludes: "tmp,varlogs,varrun,devshm"` to Radarr, Sonarr, Prowlarr, and Readarr pod templates. These emptyDir volumes (linuxserver.io image standard ephemeral mounts) contain no durable state and can't be reliably snapshotted when the pod's node is under pressure. Their FSB failures were marking the entire `daily-full` schedule as `PartiallyFailed`. Only the `config` PVC needs backing up on these apps.
- **Kyverno CPUThrottlingHigh**: Raise `reportsController` CPU limit 200m → 500m. The reports controller is bursting through its limit while processing the batch of Trivy VulnerabilityReport CRs created during the initial scan wave.

**Remaining firing alerts (not actionable from K8s):**
- `DatastoreLowFreeSpace` — vmstore2 at 15%, k8s-control-plane at 19% — needs vCenter/storage attention
- `ESXiHostHighMemory` — esxi03 > 90% memory — VMware level
- `etcdHighCommitDurations` — 266ms p99 on k8scp02, driven by the low k8s-control-plane datastore

🤖 Generated with [Claude Code](https://claude.com/claude-code)