### PR TITLE
feat(volsync): deploy operator and provision B2 bucket with scoped key

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml
@@ -37,3 +37,4 @@ resources:
   - tofu-kustomization.yaml
   - goldilocks-kustomization.yaml
   - trivy-system-kustomization.yaml
+  - volsync-kustomization.yaml

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/volsync-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/volsync-kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: volsync-system
+  namespace: flux-system
+  labels:
+    app: volsync
+    env: production
+    category: storage
+spec:
+  interval: 10m
+  path: ./clusters/vollminlab-cluster/volsync-system
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: volsync-system
+  timeout: 10m
+  dependsOn:
+    - name: sealed-secrets

--- a/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
@@ -48,5 +48,6 @@ resources:
   - trivy-operator-helmrepository.yaml
   - velero-helmrepository.yaml
   - vmware-exporter-helmrepository.yaml
+  - volsync-helmrepository.yaml
   - harbor-vollminlab-pull-sealedsecret.yaml
   - vollminlab-ocirepository.yaml

--- a/clusters/vollminlab-cluster/flux-system/repositories/volsync-helmrepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/volsync-helmrepository.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: volsync-repo
+  namespace: flux-system
+  labels:
+    app: volsync
+    env: production
+    category: storage
+spec:
+  interval: 12h
+  url: https://backube.github.io/helm-charts/

--- a/clusters/vollminlab-cluster/volsync-system/kustomization.yaml
+++ b/clusters/vollminlab-cluster/volsync-system/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: volsync-system
+  namespace: flux-system
+  labels:
+    app: volsync
+    env: production
+    category: storage
+resources:
+  - namespace.yaml
+  - volsync/app

--- a/clusters/vollminlab-cluster/volsync-system/namespace.yaml
+++ b/clusters/vollminlab-cluster/volsync-system/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: volsync-system
+  labels:
+    app: volsync
+    env: production
+    category: storage

--- a/clusters/vollminlab-cluster/volsync-system/volsync/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/volsync-system/volsync/app/configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: volsync-values
+  namespace: volsync-system
+  labels:
+    app: volsync
+    env: production
+    category: storage
+data:
+  values.yaml: |
+    podLabels:
+      app: volsync
+      env: production
+      category: storage
+
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi

--- a/clusters/vollminlab-cluster/volsync-system/volsync/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/volsync-system/volsync/app/helmrelease.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: volsync
+  namespace: volsync-system
+  labels:
+    app: volsync
+    env: production
+    category: storage
+spec:
+  interval: 5m
+  releaseName: volsync
+  chart:
+    spec:
+      chart: volsync
+      version: 0.15.0
+      sourceRef:
+        kind: HelmRepository
+        name: volsync-repo
+        namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: volsync-values
+      valuesKey: values.yaml

--- a/clusters/vollminlab-cluster/volsync-system/volsync/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/volsync-system/volsync/app/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: volsync-deployment
+  namespace: flux-system
+  labels:
+    app: volsync
+    env: production
+    category: storage
+resources:
+  - helmrelease.yaml
+  - configmap.yaml

--- a/terraform/b2/main.tf
+++ b/terraform/b2/main.tf
@@ -3,3 +3,14 @@ resource "b2_bucket" "velero" {
   bucket_type = "allPrivate"
 }
 
+resource "b2_bucket" "volsync" {
+  bucket_name = "vollminlab-k8s-volsync"
+  bucket_type = "allPrivate"
+}
+
+resource "b2_application_key" "volsync" {
+  key_name     = "vollminlab-k8s-volsync"
+  capabilities = ["listBuckets", "listFiles", "readFiles", "writeFiles", "deleteFiles"]
+  bucket_id    = b2_bucket.volsync.id
+}
+


### PR DESCRIPTION
## Summary

- **Terraform B2**: Adds `vollminlab-k8s-volsync` bucket and a scoped application key restricted to that bucket (`listBuckets`, `listFiles`, `readFiles`, `writeFiles`, `deleteFiles`). tofu-controller will apply on next reconcile and expose the generated key credentials in tfstate.
- **Volsync operator**: Deploys `backube/volsync v0.15.0` in `volsync-system` namespace via Flux HelmRelease. Installs the `ReplicationSource`/`ReplicationDestination` CRDs that PR2 will use.

## What's next (PR2)
After this merges and the B2 key is generated by tofu, PR2 will add:
- One SealedSecret per PVC containing `RESTIC_PASSWORD`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and the B2-specific env vars
- `ReplicationSource` CRs for: `harbor-registry`, arr stack configs (radarr, sonarr, prowlarr, bazarr, sabnzbd, readarr, qbittorrent, seerr), `jellyfin-config`, `audiobookshelf-config`, `audiobookshelf-metadata`
- `copyMethod: Clone` (Longhorn CSI clone — no CSI snapshot controller needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)