### PR TITLE
fix(goldilocks): raise controller CPU limit to 250m

### DIFF
--- a/clusters/vollminlab-cluster/goldilocks/goldilocks/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/goldilocks/goldilocks/app/configmap.yaml
@@ -32,7 +32,7 @@ data:
           cpu: 25m
           memory: 64Mi
         limits:
-          cpu: 100m
+          cpu: 250m
           memory: 256Mi
 
     dashboard:


### PR DESCRIPTION
## Summary

- `CPUThrottlingHigh` alert firing for `goldilocks-controller` in the `goldilocks` namespace
- Controller averages ~14m CPU but bursts past the 100m limit during VPA recommendation scans
- Raises CPU limit from 100m → 250m to eliminate throttling

🤖 Generated with [Claude Code](https://claude.com/claude-code)