### PR TITLE
fix(volsync): disable metrics auth to resolve TargetDown alert

### DIFF
--- a/clusters/vollminlab-cluster/volsync-system/volsync/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/volsync-system/volsync/app/configmap.yaml
@@ -14,6 +14,9 @@ data:
       env: production
       category: storage
 
+    metrics:
+      disableAuth: true
+
     resources:
       requests:
         cpu: 10m


### PR DESCRIPTION
## Summary

- `TargetDown` alert firing for `volsync-system` — Prometheus gets `401 Unauthorized` scraping the Volsync metrics endpoint
- Volsync's metrics are protected by kube-rbac-proxy; the auto-installed ServiceMonitor has no bearer token configured
- Sets `metrics.disableAuth: true` so the kube-rbac-proxy sidecar allows unauthenticated scraping

🤖 Generated with [Claude Code](https://claude.com/claude-code)