### PR TITLE
fix(goldilocks): raise controller CPU limit to 500m

### DIFF
--- a/clusters/vollminlab-cluster/goldilocks/goldilocks/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/goldilocks/goldilocks/app/configmap.yaml
@@ -32,7 +32,7 @@ data:
           cpu: 25m
           memory: 64Mi
         limits:
-          cpu: 250m
+          cpu: 500m
           memory: 256Mi
 
     dashboard:


### PR DESCRIPTION
## Summary

- Controller still throttling at ~33% despite the 250m limit from PR #731
- Averages 87m CPU but spikes much higher when processing VPA recommendations across `mediastack` and `monitoring`
- Raises limit 250m → 500m to give burst headroom

🤖 Generated with [Claude Code](https://claude.com/claude-code)