### PR TITLE
feat(goldilocks): enable VPA recommendations for all app namespaces

### DIFF
--- a/clusters/vollminlab-cluster/actions-runner-system/namespace.yaml
+++ b/clusters/vollminlab-cluster/actions-runner-system/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: actions-runner-controller
     env: production
     category: ci
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/arc-controller/namespace.yaml
+++ b/clusters/vollminlab-cluster/arc-controller/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: arc-controller
     env: production
     category: ci
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/authentik/namespace.yaml
+++ b/clusters/vollminlab-cluster/authentik/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: authentik
     env: production
     category: security
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/cert-manager/namespace.yaml
+++ b/clusters/vollminlab-cluster/cert-manager/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: cert-manager
     env: production
     category: security
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/cnpg-system/namespace.yaml
+++ b/clusters/vollminlab-cluster/cnpg-system/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: cnpg
     env: production
     category: storage
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/dmz/namespace.yaml
+++ b/clusters/vollminlab-cluster/dmz/namespace.yaml
@@ -9,3 +9,4 @@ metadata:
     pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/warn: restricted
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/external-dns/namespace.yaml
+++ b/clusters/vollminlab-cluster/external-dns/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: external-dns
     env: production
     category: networking
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/harbor/namespace.yaml
+++ b/clusters/vollminlab-cluster/harbor/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: harbor
     env: production
     category: storage
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/homepage/namespace.yaml
+++ b/clusters/vollminlab-cluster/homepage/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: homepage
     env: production
     category: apps
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/ingress-nginx/namespace.yaml
+++ b/clusters/vollminlab-cluster/ingress-nginx/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: ingress-nginx
     env: production
     category: networking
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/kyverno/namespace.yaml
+++ b/clusters/vollminlab-cluster/kyverno/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: kyverno
     env: production
     category: security
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/local-path-storage/namespace.yaml
+++ b/clusters/vollminlab-cluster/local-path-storage/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: local-path-provisioner
     env: production
     category: storage
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/longhorn-system/namespace.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: longhorn
     env: production
     category: storage
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/metallb-system/namespace.yaml
+++ b/clusters/vollminlab-cluster/metallb-system/namespace.yaml
@@ -9,3 +9,4 @@ metadata:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/warn: privileged
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/metallb-system/namespace.yaml
+++ b/clusters/vollminlab-cluster/metallb-system/namespace.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: metallb
     env: production
-    category: networking 
+    category: networking
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/warn: privileged

--- a/clusters/vollminlab-cluster/minio/namespace.yaml
+++ b/clusters/vollminlab-cluster/minio/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: minio
     env: production
     category: storage
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/portainer/namespace.yaml
+++ b/clusters/vollminlab-cluster/portainer/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: portainer
     env: production
     category: apps
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/renovate/namespace.yaml
+++ b/clusters/vollminlab-cluster/renovate/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: renovate
     env: production
     category: apps
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/sealed-secrets/namespace.yaml
+++ b/clusters/vollminlab-cluster/sealed-secrets/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: sealed-secrets
     env: production
     category: security
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/shlink/namespace.yaml
+++ b/clusters/vollminlab-cluster/shlink/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: shlink
     env: production
     category: apps
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/tofu/namespace.yaml
+++ b/clusters/vollminlab-cluster/tofu/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: tofu-controller
     env: production
     category: core
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/trivy-system/namespace.yaml
+++ b/clusters/vollminlab-cluster/trivy-system/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: trivy-operator
     env: production
     category: security
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/velero/namespace.yaml
+++ b/clusters/vollminlab-cluster/velero/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: velero
     env: production
     category: storage
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/volsync-system/namespace.yaml
+++ b/clusters/vollminlab-cluster/volsync-system/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     app: volsync
     env: production
     category: storage
+    goldilocks.fairwinds.com/enabled: "true"


### PR DESCRIPTION
## Summary

- Adds `goldilocks.fairwinds.com/enabled: "true"` label to 23 remaining namespace manifests
- Previously only `mediastack` and `monitoring` were enabled
- Skipped `goldilocks` (itself) and `kube-system` (not Helm-managed)
- Also fixes missing trailing newlines on 4 files (actions-runner-system, kyverno, longhorn-system, metallb-system)

Covered namespaces: `actions-runner-system`, `arc-controller`, `authentik`, `cert-manager`, `cnpg-system`, `dmz`, `external-dns`, `harbor`, `homepage`, `ingress-nginx`, `kyverno`, `local-path-storage`, `longhorn-system`, `metallb-system`, `minio`, `portainer`, `renovate`, `sealed-secrets`, `shlink`, `tofu`, `trivy-system`, `velero`, `volsync-system`

🤖 Generated with [Claude Code](https://claude.com/claude-code)