### PR TITLE
chore(resources): right-size memory limits based on Goldilocks VPA data

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/bazarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr/app/configmap.yaml
@@ -50,4 +50,4 @@ data:
         memory: 256Mi
       limits:
         cpu: 500m
-        memory: 512Mi
+        memory: 768Mi

--- a/clusters/vollminlab-cluster/mediastack/prowlarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/prowlarr/app/configmap.yaml
@@ -33,4 +33,4 @@ data:
         memory: 256Mi
       limits:
         cpu: 500m
-        memory: 512Mi
+        memory: 1Gi

--- a/clusters/vollminlab-cluster/mediastack/radarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/radarr/app/configmap.yaml
@@ -33,7 +33,7 @@ data:
         memory: 256Mi
       limits:
         cpu: 500m
-        memory: 512Mi
+        memory: 768Mi
     podLabels:
       app: radarr
       env: production

--- a/clusters/vollminlab-cluster/mediastack/sonarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sonarr/app/configmap.yaml
@@ -28,7 +28,7 @@ data:
         memory: 256Mi
       limits:
         cpu: 500m
-        memory: 512Mi
+        memory: 1Gi
     podLabels:
       app: sonarr
       env: production

--- a/clusters/vollminlab-cluster/minio/minio/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/minio/minio/app/configmap.yaml
@@ -21,7 +21,7 @@ data:
     resources:
       requests:
         cpu: 150m
-        memory: 512Mi
+        memory: 2Gi
       limits:
         cpu: 1000m
         memory: 2Gi

--- a/clusters/vollminlab-cluster/monitoring/loki/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/loki/app/configmap.yaml
@@ -76,7 +76,7 @@ data:
       resources:
         requests:
           cpu: 50m
-          memory: 256Mi
+          memory: 512Mi
         limits:
           cpu: 1000m
           memory: 1Gi

--- a/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
@@ -14,10 +14,10 @@ data:
       resources:
         requests:
           cpu: 100m
-          memory: 128Mi
+          memory: 384Mi
         limits:
           cpu: 500m
-          memory: 512Mi
+          memory: 768Mi
 
     trivy:
       ignoreUnfixed: true

--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -17,7 +17,7 @@ data:
     resources:
       requests:
         cpu: 500m
-        memory: 128Mi
+        memory: 512Mi
       limits:
         cpu: 1000m
         memory: 512Mi


### PR DESCRIPTION
## Summary

Goldilocks VPA recommendations after first 24h of cluster-wide coverage. CPU unchanged — not the constraint on this cluster. Memory-only changes.

**P1 — memory limits below observed burst (pods likely degrading during scans/syncs):**
| App | Before | After | VPA upper |
|-----|--------|-------|-----------|
| sonarr | 512Mi | 1Gi | 1084Mi |
| prowlarr | 512Mi | 1Gi | 926Mi |
| bazarr | 512Mi | 768Mi | 797Mi |
| radarr | 512Mi | 768Mi | 733Mi |

**P2 — memory requests misaligned with actual usage (scheduler accuracy):**
| App | Request before | Request after | VPA target |
|-----|---------------|---------------|------------|
| minio | 512Mi | 2Gi | 2421Mi |
| velero | 128Mi | 512Mi | 729Mi |
| loki | 256Mi | 512Mi | 640Mi |
| trivy-operator | 128Mi | 384Mi (+limit 512Mi→768Mi) | 640Mi |

🤖 Generated with [Claude Code](https://claude.com/claude-code)