### PR TITLE
fix(velero,b2-exporter): exclude ephemeral namespaces and fix CPU throttling

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/b2-exporter/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/monitoring/b2-exporter/app/deployment.yaml
@@ -48,5 +48,5 @@ spec:
               cpu: 10m
               memory: 64Mi
             limits:
-              cpu: 100m
+              cpu: 250m
               memory: 128Mi

--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -126,9 +126,11 @@ data:
           excludedNamespaces:
             - kyverno
             - longhorn-system
+            - metallb-system
             - minio
             - monitoring
             - tofu
+            - trivy-system
             - velero
           resourcePolicy:
             kind: ConfigMap
@@ -144,9 +146,11 @@ data:
           excludedNamespaces:
             - kyverno
             - longhorn-system
+            - metallb-system
             - minio
             - monitoring
             - tofu
+            - trivy-system
             - velero
           resourcePolicy:
             kind: ConfigMap
@@ -162,9 +166,11 @@ data:
           excludedNamespaces:
             - kyverno
             - longhorn-system
+            - metallb-system
             - minio
             - monitoring
             - tofu
+            - trivy-system
             - velero
           resourcePolicy:
             kind: ConfigMap


### PR DESCRIPTION
## Summary

- Exclude `metallb-system` and `trivy-system` from all three Velero backup schedules (`daily-full`, `daily-b2`, `monthly-b2`)
- Raise b2-exporter CPU limit from 100m → 250m to clear pending `CPUThrottlingHigh` alert

## Root cause

The `velero-daily-full-20260523020001` backup ran for 4 hours (2am–6am) and completed `PartiallyFailed` with 19 errors. All errors share the same message:

```
failed to list node-agent pods: client rate limiter Wait returned an error: context deadline exceeded
```

The backup was hitting Velero's default 4h timeout because it was trying to back up:
- **metallb-system**: 6 MetalLB FRR DaemonSet pods × 7 volumes each = 42 PodVolumeBackup attempts for purely ephemeral networking state (sockets, config files, tmp dirs)
- **trivy-system**: ephemeral vulnerability scan pods that were in Pending state during backup, causing additional rate limiter pressure

Neither namespace contains persistent data that needs backup. Excluding them reduces backup scope significantly and should keep runtime well under the 4h timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)