### PR TITLE
docs(tailscale): add subnet router spec and implementation plan

### DIFF
--- a/docs/superpowers/plans/tailscale.md
+++ b/docs/superpowers/plans/tailscale.md
@@ -1,0 +1,732 @@
+# Tailscale Subnet Router Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy Tailscale as a subnet router so all cluster services and nodes are reachable over Tailscale as a failsafe when Cloudflare or ingress-nginx is unavailable.
+
+**Architecture:** Tailscale operator runs in the `tailscale` namespace and manages a `Connector` CR that advertises `192.168.152.0/24` (nodes + MetalLB VIPs) and `192.168.100.0/24` (Pi-hole). A `terraform/tailscale/` module manages ACL autoApprovers (so routes are approved without manual console steps) and split DNS for `vollminlab.com` → Pi-hole. Two separate least-privilege OAuth clients: one for the operator (`auth_keys:write`), one for Terraform (`acls:write` + `dns:write`).
+
+**Tech Stack:** Tailscale operator chart v1.98.3, `tailscale.com/v1alpha1 Connector` CR, Tailscale Terraform provider v0.29.1, tofu-controller, SealedSecrets, Flux CD.
+
+---
+
+## File Map
+
+**Create — cluster:**
+- `clusters/vollminlab-cluster/tailscale/namespace.yaml`
+- `clusters/vollminlab-cluster/tailscale/kustomization.yaml`
+- `clusters/vollminlab-cluster/tailscale/tailscale-operator/app/helmrelease.yaml`
+- `clusters/vollminlab-cluster/tailscale/tailscale-operator/app/configmap.yaml`
+- `clusters/vollminlab-cluster/tailscale/tailscale-operator/app/connector.yaml`
+- `clusters/vollminlab-cluster/tailscale/tailscale-operator/app/operator-oauth-sealedsecret.yaml`
+- `clusters/vollminlab-cluster/tailscale/tailscale-operator/app/kustomization.yaml`
+- `clusters/vollminlab-cluster/flux-system/repositories/tailscale-operator-helmrepository.yaml`
+- `clusters/vollminlab-cluster/flux-system/flux-kustomizations/tailscale-kustomization.yaml`
+
+**Modify — Flux indexes:**
+- `clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml`
+- `clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml`
+
+**Create — Terraform:**
+- `terraform/tailscale/versions.tf`
+- `terraform/tailscale/providers.tf`
+- `terraform/tailscale/variables.tf`
+- `terraform/tailscale/acl.tf`
+- `terraform/tailscale/dns.tf`
+
+**Create — tofu workspace:**
+- `clusters/vollminlab-cluster/tofu/tailscale-config/app/terraform-cr.yaml`
+- `clusters/vollminlab-cluster/tofu/tailscale-config/app/tailscale-tf-credentials-sealedsecret.yaml`
+- `clusters/vollminlab-cluster/tofu/tailscale-config/app/kustomization.yaml`
+
+**Modify — tofu namespace index:**
+- `clusters/vollminlab-cluster/tofu/kustomization.yaml`
+
+---
+
+## ⚠️ USER ACTION REQUIRED — Task 1 (do this before implementation begins)
+
+> This task cannot be automated. It requires the Tailscale admin console.
+
+- [ ] **Step 1: Create Operator OAuth client**
+
+  Go to `https://login.tailscale.com/admin/settings/oauth` → New OAuth client.
+  - Name: `vollminlab-cluster-operator`
+  - Scope: **Devices** → Write (this grants `auth_keys:write`)
+  - Click Create, copy the **Client ID** and **Client Secret**
+
+- [ ] **Step 2: Save operator credentials to 1Password**
+
+  In 1Password Homelab vault, create item **"Tailscale Operator OAuth Client"**:
+  - Field `client_id`: paste Client ID
+  - Field `client_secret`: paste Client Secret
+  - Tag: `Homelab`
+
+- [ ] **Step 3: Create Terraform OAuth client**
+
+  Back in `https://login.tailscale.com/admin/settings/oauth` → New OAuth client.
+  - Name: `vollminlab-terraform`
+  - Scopes: **Policy File** → Write, **DNS** → Write
+  - Click Create, copy the **Client ID** and **Client Secret**
+
+- [ ] **Step 4: Save Terraform credentials to 1Password**
+
+  In 1Password Homelab vault, create item **"Tailscale Terraform API Key"**:
+  - Field `client_id`: paste Client ID
+  - Field `client_secret`: paste Client Secret
+  - Tag: `Homelab`
+
+---
+
+### Task 2: Create feature branch
+
+- [ ] **Step 1: Checkout main and pull latest**
+
+```bash
+git -C /home/vollmin/repos/vollminlab/k8s-vollminlab-cluster checkout main && git -C /home/vollmin/repos/vollminlab/k8s-vollminlab-cluster pull
+```
+
+- [ ] **Step 2: Create branch**
+
+```bash
+git -C /home/vollmin/repos/vollminlab/k8s-vollminlab-cluster checkout -b feat/tailscale
+```
+
+---
+
+### Task 3: Seal operator OAuth credentials
+
+**Files:**
+- Create: `clusters/vollminlab-cluster/tailscale/tailscale-operator/app/operator-oauth-sealedsecret.yaml`
+
+> Requires a live `op` session. Run `op account list` to verify; if not signed in run `op signin` first.
+
+- [ ] **Step 1: Fetch the sealing certificate**
+
+```bash
+cd /home/vollmin/repos/vollminlab/k8s-vollminlab-cluster
+kubeseal --fetch-cert \
+  --controller-namespace sealed-secrets \
+  --controller-name sealed-secrets-controller > /tmp/pub-cert.pem
+```
+
+Expected: `/tmp/pub-cert.pem` created, starts with `-----BEGIN CERTIFICATE-----`
+
+- [ ] **Step 2: Pull credentials from 1Password**
+
+```bash
+CLIENT_ID=$(op item get "Tailscale Operator OAuth Client" --vault Homelab --format json | \
+  python3 -c "import json,sys; d=json.load(sys.stdin); print(next(f['value'] for f in d['fields'] if f['label']=='client_id'))")
+
+CLIENT_SECRET=$(op item get "Tailscale Operator OAuth Client" --vault Homelab --format json | \
+  python3 -c "import json,sys; d=json.load(sys.stdin); print(next(f['value'] for f in d['fields'] if f['label']=='client_secret'))")
+
+echo "Got client_id: ${CLIENT_ID:0:8}... (truncated)"
+```
+
+- [ ] **Step 3: Create the directory and seal**
+
+```bash
+mkdir -p clusters/vollminlab-cluster/tailscale/tailscale-operator/app
+
+kubectl create secret generic operator-oauth \
+  -n tailscale \
+  --from-literal=client_id="$CLIENT_ID" \
+  --from-literal=client_secret="$CLIENT_SECRET" \
+  --dry-run=client -o yaml | \
+  kubeseal --cert /tmp/pub-cert.pem --format yaml \
+  > clusters/vollminlab-cluster/tailscale/tailscale-operator/app/operator-oauth-sealedsecret.yaml
+
+rm /tmp/pub-cert.pem
+unset CLIENT_ID CLIENT_SECRET
+```
+
+- [ ] **Step 4: Verify the sealed secret file**
+
+```bash
+head -5 clusters/vollminlab-cluster/tailscale/tailscale-operator/app/operator-oauth-sealedsecret.yaml
+```
+
+Expected: starts with `apiVersion: bitnami.com/v1alpha1` and `kind: SealedSecret`
+
+- [ ] **Step 5: Add required labels to the SealedSecret template**
+
+The sealed file needs labels in the `.spec.template.metadata` block. Edit the file to add after the `encryptedData` section:
+
+```yaml
+  template:
+    metadata:
+      name: operator-oauth
+      namespace: tailscale
+      labels:
+        app: tailscale-operator
+        env: production
+        category: networking
+```
+
+---
+
+### Task 4: Create namespace and namespace-level kustomization
+
+**Files:**
+- Create: `clusters/vollminlab-cluster/tailscale/namespace.yaml`
+- Create: `clusters/vollminlab-cluster/tailscale/kustomization.yaml`
+
+- [ ] **Step 1: Create namespace.yaml**
+
+```yaml
+# clusters/vollminlab-cluster/tailscale/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailscale
+  labels:
+    app: tailscale-operator
+    env: production
+    category: networking
+```
+
+- [ ] **Step 2: Create kustomization.yaml**
+
+```yaml
+# clusters/vollminlab-cluster/tailscale/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: tailscale
+  labels:
+    app: tailscale-operator
+    env: production
+    category: networking
+resources:
+  - namespace.yaml
+  - tailscale-operator/app
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+kubectl apply --dry-run=client -f clusters/vollminlab-cluster/tailscale/namespace.yaml
+```
+
+Expected: `namespace/tailscale created (dry run)`
+
+---
+
+### Task 5: Create operator app manifests
+
+**Files:**
+- Create: `clusters/vollminlab-cluster/tailscale/tailscale-operator/app/helmrelease.yaml`
+- Create: `clusters/vollminlab-cluster/tailscale/tailscale-operator/app/configmap.yaml`
+- Create: `clusters/vollminlab-cluster/tailscale/tailscale-operator/app/connector.yaml`
+- Create: `clusters/vollminlab-cluster/tailscale/tailscale-operator/app/kustomization.yaml`
+
+- [ ] **Step 1: Create helmrelease.yaml**
+
+```yaml
+# clusters/vollminlab-cluster/tailscale/tailscale-operator/app/helmrelease.yaml
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tailscale-operator
+  namespace: tailscale
+  labels:
+    app: tailscale-operator
+    env: production
+    category: networking
+spec:
+  interval: 10m
+  releaseName: tailscale-operator
+  chart:
+    spec:
+      chart: tailscale-operator
+      version: 1.98.3
+      sourceRef:
+        kind: HelmRepository
+        name: tailscale-operator-repo
+        namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: tailscale-operator-values
+      valuesKey: values.yaml
+```
+
+- [ ] **Step 2: Create configmap.yaml**
+
+```yaml
+# clusters/vollminlab-cluster/tailscale/tailscale-operator/app/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tailscale-operator-values
+  namespace: tailscale
+  labels:
+    app: tailscale-operator
+    env: production
+    category: networking
+data:
+  values.yaml: |
+    operatorConfig:
+      hostname: vollminlab-cluster-operator
+      defaultTags:
+        - tag:k8s
+
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 256Mi
+```
+
+- [ ] **Step 3: Create connector.yaml**
+
+```yaml
+# clusters/vollminlab-cluster/tailscale/tailscale-operator/app/connector.yaml
+apiVersion: tailscale.com/v1alpha1
+kind: Connector
+metadata:
+  name: vollminlab-cluster
+  namespace: tailscale
+  labels:
+    app: tailscale-operator
+    env: production
+    category: networking
+spec:
+  hostname: vollminlab-cluster
+  subnetRouter:
+    advertiseRoutes:
+      - "192.168.152.0/24"
+      - "192.168.100.0/24"
+```
+
+- [ ] **Step 4: Create app kustomization.yaml**
+
+```yaml
+# clusters/vollminlab-cluster/tailscale/tailscale-operator/app/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: tailscale-operator-deployment
+  namespace: flux-system
+  labels:
+    app: tailscale-operator
+    env: production
+    category: networking
+resources:
+  - helmrelease.yaml
+  - configmap.yaml
+  - connector.yaml
+  - operator-oauth-sealedsecret.yaml
+```
+
+- [ ] **Step 5: Verify manifests**
+
+```bash
+kubectl apply --dry-run=client -f clusters/vollminlab-cluster/tailscale/tailscale-operator/app/helmrelease.yaml
+kubectl apply --dry-run=client -f clusters/vollminlab-cluster/tailscale/tailscale-operator/app/configmap.yaml
+```
+
+Expected: both return `(dry run)` with no errors.
+
+> **Kyverno note:** The operator creates a pod for the connector (`vollminlab-cluster` Connector CR). If Kyverno blocks that pod for missing resource limits, create a `ProxyClass` resource in `tailscale` namespace with resource limits and reference it in the Connector CR via `spec.proxyClass`. This is an operator-managed pod; the resource limits in `configmap.yaml` only apply to the operator itself.
+
+---
+
+### Task 6: Create HelmRepository + Flux Kustomization CR + wire indexes
+
+**Files:**
+- Create: `clusters/vollminlab-cluster/flux-system/repositories/tailscale-operator-helmrepository.yaml`
+- Create: `clusters/vollminlab-cluster/flux-system/flux-kustomizations/tailscale-kustomization.yaml`
+- Modify: `clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml`
+- Modify: `clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml`
+
+- [ ] **Step 1: Create tailscale-operator-helmrepository.yaml**
+
+```yaml
+# clusters/vollminlab-cluster/flux-system/repositories/tailscale-operator-helmrepository.yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: tailscale-operator-repo
+  namespace: flux-system
+  labels:
+    app: tailscale-operator
+    env: production
+    category: networking
+spec:
+  interval: 5m
+  url: https://pkgs.tailscale.com/helmcharts
+  timeout: 3m
+```
+
+- [ ] **Step 2: Create tailscale-kustomization.yaml**
+
+```yaml
+# clusters/vollminlab-cluster/flux-system/flux-kustomizations/tailscale-kustomization.yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: tailscale
+  namespace: flux-system
+  labels:
+    app: tailscale-operator
+    env: production
+    category: networking
+spec:
+  interval: 10m
+  path: ./clusters/vollminlab-cluster/tailscale
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: tailscale
+  timeout: 5m
+  dependsOn:
+    - name: sealed-secrets
+```
+
+- [ ] **Step 3: Add to flux-kustomizations index**
+
+Open `clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml` and add `- tailscale-kustomization.yaml` in alphabetical order (between `sealed-secrets-kustomization.yaml` and `tofu-kustomization.yaml`).
+
+- [ ] **Step 4: Add to repositories index**
+
+Open `clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml` and add `- tailscale-operator-helmrepository.yaml` in alphabetical order (between `sonarr-ocirepository.yaml` and `tofu-controller-helmrepository.yaml`).
+
+- [ ] **Step 5: Verify all four files**
+
+```bash
+kubectl apply --dry-run=client -f clusters/vollminlab-cluster/flux-system/repositories/tailscale-operator-helmrepository.yaml
+kubectl apply --dry-run=client -f clusters/vollminlab-cluster/flux-system/flux-kustomizations/tailscale-kustomization.yaml
+kubectl apply --dry-run=client -f clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
+kubectl apply --dry-run=client -f clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml
+```
+
+Expected: all four return `(dry run)` with no errors.
+
+---
+
+### Task 7: Create Terraform module
+
+**Files:**
+- Create: `terraform/tailscale/versions.tf`
+- Create: `terraform/tailscale/providers.tf`
+- Create: `terraform/tailscale/variables.tf`
+- Create: `terraform/tailscale/acl.tf`
+- Create: `terraform/tailscale/dns.tf`
+
+- [ ] **Step 1: Create versions.tf**
+
+```hcl
+# terraform/tailscale/versions.tf
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    tailscale = {
+      source  = "tailscale/tailscale"
+      version = "~> 0.29"
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Create providers.tf**
+
+```hcl
+# terraform/tailscale/providers.tf
+provider "tailscale" {
+  oauth_client_id     = var.tailscale_oauth_client_id
+  oauth_client_secret = var.tailscale_oauth_client_secret
+}
+```
+
+- [ ] **Step 3: Create variables.tf**
+
+```hcl
+# terraform/tailscale/variables.tf
+variable "tailscale_oauth_client_id" {
+  type      = string
+  sensitive = true
+}
+
+variable "tailscale_oauth_client_secret" {
+  type      = string
+  sensitive = true
+}
+```
+
+- [ ] **Step 4: Create acl.tf**
+
+> Before writing this file, check the current ACL in the Tailscale admin console at `https://login.tailscale.com/admin/acls`. If there are any customizations beyond the default allow-all rule, include them verbatim in the `acls` block below.
+
+```hcl
+# terraform/tailscale/acl.tf
+resource "tailscale_acl" "main" {
+  acl = jsonencode({
+    tagOwners = {
+      "tag:k8s" = []
+    }
+
+    autoApprovers = {
+      routes = {
+        "192.168.152.0/24" = ["tag:k8s"]
+        "192.168.100.0/24" = ["tag:k8s"]
+      }
+    }
+
+    acls = [
+      {
+        action = "accept"
+        src    = ["*"]
+        dst    = ["*:*"]
+      }
+    ]
+  })
+}
+```
+
+- [ ] **Step 5: Create dns.tf**
+
+```hcl
+# terraform/tailscale/dns.tf
+resource "tailscale_dns_split_nameservers" "vollminlab" {
+  domain      = "vollminlab.com"
+  nameservers = ["192.168.100.2"]
+}
+```
+
+> If `vollminlab.com` split DNS already exists in the Tailscale admin console, import it before applying:
+> ```bash
+> tofu -chdir=terraform/tailscale import tailscale_dns_split_nameservers.vollminlab vollminlab.com
+> ```
+
+- [ ] **Step 6: Validate the module**
+
+```bash
+cd /home/vollmin/repos/vollminlab/k8s-vollminlab-cluster
+terraform -chdir=terraform/tailscale fmt --check
+tofu -chdir=terraform/tailscale validate 2>/dev/null || terraform -chdir=terraform/tailscale validate
+```
+
+Expected: `fmt --check` exits 0 (no formatting issues); `validate` prints `Success!`
+
+---
+
+### Task 8: Seal Terraform credentials + create tofu workspace
+
+**Files:**
+- Create: `clusters/vollminlab-cluster/tofu/tailscale-config/app/tailscale-tf-credentials-sealedsecret.yaml`
+- Create: `clusters/vollminlab-cluster/tofu/tailscale-config/app/terraform-cr.yaml`
+- Create: `clusters/vollminlab-cluster/tofu/tailscale-config/app/kustomization.yaml`
+- Modify: `clusters/vollminlab-cluster/tofu/kustomization.yaml`
+
+- [ ] **Step 1: Fetch sealing cert**
+
+```bash
+cd /home/vollmin/repos/vollminlab/k8s-vollminlab-cluster
+kubeseal --fetch-cert \
+  --controller-namespace sealed-secrets \
+  --controller-name sealed-secrets-controller > /tmp/pub-cert.pem
+```
+
+- [ ] **Step 2: Pull Terraform credentials from 1Password**
+
+```bash
+TF_CLIENT_ID=$(op item get "Tailscale Terraform API Key" --vault Homelab --format json | \
+  python3 -c "import json,sys; d=json.load(sys.stdin); print(next(f['value'] for f in d['fields'] if f['label']=='client_id'))")
+
+TF_CLIENT_SECRET=$(op item get "Tailscale Terraform API Key" --vault Homelab --format json | \
+  python3 -c "import json,sys; d=json.load(sys.stdin); print(next(f['value'] for f in d['fields'] if f['label']=='client_secret'))")
+
+echo "Got client_id: ${TF_CLIENT_ID:0:8}... (truncated)"
+```
+
+- [ ] **Step 3: Seal and create directory**
+
+```bash
+mkdir -p clusters/vollminlab-cluster/tofu/tailscale-config/app
+
+kubectl create secret generic tailscale-tf-credentials \
+  -n tofu \
+  --from-literal=tailscale_oauth_client_id="$TF_CLIENT_ID" \
+  --from-literal=tailscale_oauth_client_secret="$TF_CLIENT_SECRET" \
+  --dry-run=client -o yaml | \
+  kubeseal --cert /tmp/pub-cert.pem --format yaml \
+  > clusters/vollminlab-cluster/tofu/tailscale-config/app/tailscale-tf-credentials-sealedsecret.yaml
+
+rm /tmp/pub-cert.pem
+unset TF_CLIENT_ID TF_CLIENT_SECRET
+```
+
+- [ ] **Step 4: Add labels to SealedSecret template**
+
+Edit `clusters/vollminlab-cluster/tofu/tailscale-config/app/tailscale-tf-credentials-sealedsecret.yaml` and add after the `encryptedData` section:
+
+```yaml
+  template:
+    metadata:
+      name: tailscale-tf-credentials
+      namespace: tofu
+      labels:
+        app: tofu-controller
+        env: production
+        category: core
+```
+
+- [ ] **Step 5: Create terraform-cr.yaml**
+
+```yaml
+# clusters/vollminlab-cluster/tofu/tailscale-config/app/terraform-cr.yaml
+---
+apiVersion: infra.contrib.fluxcd.io/v1alpha2
+kind: Terraform
+metadata:
+  name: tailscale-config
+  namespace: tofu
+  labels:
+    app: tofu-controller
+    env: production
+    category: core
+spec:
+  interval: 10m
+  approvePlan: auto
+  path: ./terraform/tailscale
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  backendConfig:
+    customConfiguration: |
+      backend "s3" {
+        bucket                      = "terraform-state"
+        key                         = "tailscale/terraform.tfstate"
+        region                      = "us-east-1"
+        endpoint                    = "http://minio.minio.svc.cluster.local:9000"
+        force_path_style            = true
+        skip_credentials_validation = true
+        skip_metadata_api_check     = true
+        skip_region_validation      = true
+      }
+  backendConfigsFrom:
+    - kind: Secret
+      name: tofu-minio-credentials
+  varsFrom:
+    - kind: Secret
+      name: tailscale-tf-credentials
+```
+
+- [ ] **Step 6: Create workspace kustomization.yaml**
+
+```yaml
+# clusters/vollminlab-cluster/tofu/tailscale-config/app/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: tailscale-config
+  labels:
+    app: tofu-controller
+    env: production
+    category: core
+resources:
+  - tailscale-tf-credentials-sealedsecret.yaml
+  - terraform-cr.yaml
+```
+
+- [ ] **Step 7: Add tailscale-config to tofu namespace kustomization**
+
+Open `clusters/vollminlab-cluster/tofu/kustomization.yaml` and add `- tailscale-config/app` in alphabetical order (between `sonarr-config/app` and `tofu-controller/app`).
+
+---
+
+### Task 9: Commit and open PR
+
+- [ ] **Step 1: Stage all files explicitly**
+
+```bash
+git add \
+  clusters/vollminlab-cluster/tailscale/namespace.yaml \
+  clusters/vollminlab-cluster/tailscale/kustomization.yaml \
+  clusters/vollminlab-cluster/tailscale/tailscale-operator/app/helmrelease.yaml \
+  clusters/vollminlab-cluster/tailscale/tailscale-operator/app/configmap.yaml \
+  clusters/vollminlab-cluster/tailscale/tailscale-operator/app/connector.yaml \
+  clusters/vollminlab-cluster/tailscale/tailscale-operator/app/operator-oauth-sealedsecret.yaml \
+  clusters/vollminlab-cluster/tailscale/tailscale-operator/app/kustomization.yaml \
+  clusters/vollminlab-cluster/flux-system/repositories/tailscale-operator-helmrepository.yaml \
+  clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml \
+  clusters/vollminlab-cluster/flux-system/flux-kustomizations/tailscale-kustomization.yaml \
+  clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml \
+  clusters/vollminlab-cluster/tofu/tailscale-config/app/terraform-cr.yaml \
+  clusters/vollminlab-cluster/tofu/tailscale-config/app/tailscale-tf-credentials-sealedsecret.yaml \
+  clusters/vollminlab-cluster/tofu/tailscale-config/app/kustomization.yaml \
+  clusters/vollminlab-cluster/tofu/kustomization.yaml \
+  terraform/tailscale/versions.tf \
+  terraform/tailscale/providers.tf \
+  terraform/tailscale/variables.tf \
+  terraform/tailscale/acl.tf \
+  terraform/tailscale/dns.tf \
+  docs/superpowers/plans/tailscale.md
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(tailscale): deploy subnet router operator and Terraform IaC
+
+Deploys Tailscale operator v1.98.3 in `tailscale` namespace with a
+Connector CR advertising 192.168.152.0/24 (nodes + VIPs) and
+192.168.100.0/24 (Pi-hole). Terraform module manages ACL autoApprovers
+and split DNS for vollminlab.com, eliminating manual console steps.
+
+Two separate least-privilege OAuth clients: operator (auth_keys:write)
+and Terraform provider (acls:write + dns:write).
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 3: Push and open PR**
+
+```bash
+git push -u origin feat/tailscale
+gh pr create \
+  --title "feat(tailscale): deploy subnet router as cluster failsafe" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Deploys Tailscale operator v1.98.3 in dedicated `tailscale` namespace
+- `Connector` CR advertises `192.168.152.0/24` (nodes + MetalLB VIPs) and `192.168.100.0/24` (Pi-hole)
+- `terraform/tailscale/` module manages ACL `autoApprovers` and split DNS for `vollminlab.com` → Pi-hole
+- Two separate least-privilege OAuth clients (operator + Terraform provider)
+- No manual Tailscale admin console steps required after merge
+
+When connected to Tailscale: `*.vollminlab.com` resolves via Pi-hole → routes through ingress-nginx exactly as if on the home LAN. SSH to any node IP works directly.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Post-merge verification**
+
+After the PR merges and Flux reconciles (~10 min):
+
+```bash
+# Operator running
+kubectl get pods -n tailscale
+
+# Connector device registered (look for vollminlab-cluster)
+kubectl get connector -n tailscale
+
+# Tofu workspace reconciling
+kubectl get terraform tailscale-config -n tofu
+
+# From a Tailscale-connected device (not on home LAN):
+# nslookup grafana.vollminlab.com    → should return 192.168.152.244
+# curl -sk https://grafana.vollminlab.com  → should respond
+# ssh 192.168.152.8                  → should reach k8scp01
+```

--- a/docs/superpowers/specs/tailscale-design.md
+++ b/docs/superpowers/specs/tailscale-design.md
@@ -1,0 +1,150 @@
+# Tailscale Subnet Router Design
+
+**Date:** 2026-05-24
+**Goal:** Deploy Tailscale as a cluster-wide failsafe — when Cloudflare or ingress-nginx is unavailable, connecting to Tailscale restores full access to all services and nodes via the existing ingress stack.
+
+---
+
+## Architecture
+
+A Tailscale subnet router runs as a pod in the `tailscale` namespace, managed by the Tailscale Kubernetes Operator. It advertises two subnets to the tailnet:
+
+- `192.168.152.0/24` — covers all 9 cluster nodes (`.8`–`.16`) and all MetalLB VIPs (`.244`–`.254`)
+- `192.168.100.0/24` — covers Pi-hole at `192.168.100.2`
+
+Tailscale split DNS is configured to forward `vollminlab.com` queries to Pi-hole. When connected to Tailscale from anywhere, `*.vollminlab.com` names resolve via Pi-hole to the nginx-ingress VIP (`192.168.152.244`) and route through the subnet — identical to being on the home LAN. SSH to any node IP works directly.
+
+Route auto-approval is managed via the Tailscale ACL (`autoApprovers`), eliminating the manual admin console approval step. Split DNS is also managed via Terraform.
+
+---
+
+## Scope
+
+**What this delivers:**
+- All services accessible over Tailscale via existing `*.vollminlab.com` hostnames
+- SSH to any cluster node by IP
+- No changes to existing services, ingress, or MetalLB config
+
+**Out of scope:**
+- Individual per-service Tailscale proxies (`loadBalancerClass: tailscale`)
+- Tailscale exit node (routes all internet traffic through the cluster)
+- Exposing services to other tailnet members (can be added later via per-service annotations)
+
+---
+
+## Components
+
+### 1. Tailscale Operator (cluster)
+
+Namespace: `tailscale`, category: `networking`
+
+Standard Flux app under `clusters/vollminlab-cluster/tailscale/tailscale-operator/app/`:
+- `helmrelease.yaml` — Tailscale operator from `https://pkgs.tailscale.com/helmcharts`
+- `configmap.yaml` — Helm values (resource limits; operator does not expose a UI or need an ingress)
+- `connector.yaml` — `Connector` CR (see below)
+- `operator-oauth-sealedsecret.yaml` — SealedSecret with `client_id` and `client_secret`
+- `kustomization.yaml` — lists all four files
+
+HelmRepository and Flux Kustomization CR live in `flux-system/` per standard convention.
+
+### 2. Connector CR
+
+A `tailscale.com/v1alpha1 Connector` CR in the `tailscale` namespace tells the operator to create a subnet router pod:
+
+```yaml
+apiVersion: tailscale.com/v1alpha1
+kind: Connector
+metadata:
+  name: vollminlab-cluster
+  namespace: tailscale
+spec:
+  hostname: vollminlab-cluster
+  subnetRouter:
+    advertiseRoutes:
+      - 192.168.152.0/24
+      - 192.168.100.0/24
+```
+
+The operator creates a Deployment for the connector, authenticates it to Tailscale using the OAuth credentials, and registers it as a tailnet device named `vollminlab-cluster`.
+
+### 3. Operator OAuth SealedSecret
+
+The operator authenticates to Tailscale's control plane via an OAuth client created in the Tailscale admin console (`login.tailscale.com/admin/settings/oauth`). Required scopes: `auth_keys` write (allows the operator to generate device auth keys).
+
+Secret fields: `client_id`, `client_secret`
+Secret name: `operator-oauth` (the name the Tailscale operator chart expects by default)
+Sealed and committed as `operator-oauth-sealedsecret.yaml`.
+
+Credentials saved to 1Password as **"Tailscale Operator OAuth Client"** (Homelab vault) before sealing.
+
+### 4. Terraform Module (`terraform/tailscale/`)
+
+Manages tailnet configuration via the `tailscale/tailscale` Terraform provider. Uses a dedicated API key (OAuth client with `acls:write` and `dns:write` scopes — separate from the operator's OAuth client for least privilege).
+
+Files:
+- `versions.tf` — provider `tailscale/tailscale` pinned version
+- `providers.tf` — `tailscale { api_key = var.tailscale_api_key }`
+- `acl.tf` — `tailscale_acl` resource: adds `autoApprovers` for both subnet routes for devices tagged `tag:k8s` (the default tag applied by the Tailscale operator to managed devices — verify against chart values during implementation). Also defines `tagOwners` for that tag.
+- `dns.tf` — `tailscale_dns_split_nameservers` resource: forwards `vollminlab.com` queries to `192.168.100.2`
+- `variables.tf` — `tailscale_api_key`
+
+**Note:** The Tailscale ACL is a single JSON document managed as a whole. The existing ACL (if any) must be imported into state before the first apply to avoid overwriting it.
+
+### 5. Tofu Workspace (`clusters/vollminlab-cluster/tofu/tailscale-config/app/`)
+
+Standard tofu-controller workspace pattern:
+- `terraform-cr.yaml` — `Terraform` CR pointing to `./terraform/tailscale`, MinIO S3 backend at key `tailscale/terraform.tfstate`, `varsFrom` the credentials secret
+- `tailscale-tf-credentials-sealedsecret.yaml` — sealed `tailscale_api_key`
+- `kustomization.yaml` — lists both files
+
+`clusters/vollminlab-cluster/tofu/kustomization.yaml` updated to include `tailscale-config/app`.
+
+Credentials saved to 1Password as **"Tailscale Terraform API Key"** (Homelab vault) before sealing.
+
+---
+
+## Bootstrap Prerequisites (user actions)
+
+Before implementation begins:
+
+1. **Create Operator OAuth client** at `login.tailscale.com/admin/settings/oauth`
+   - Scope: `auth_keys` — write
+   - Save to 1Password as **"Tailscale Operator OAuth Client"**
+
+2. **Create Terraform API key** at `login.tailscale.com/admin/settings/oauth` (or API keys page)
+   - Scopes: `acls` — write, `dns` — write
+   - Save to 1Password as **"Tailscale Terraform API Key"**
+
+3. Provide both credentials so they can be sealed.
+
+---
+
+## Deployment Sequence
+
+1. Create `terraform/tailscale/` module with ACL + DNS resources
+2. Create `clusters/vollminlab-cluster/tailscale/` with operator + connector + sealed secret
+3. Create tofu workspace for `tailscale-config`
+4. Wire into Flux indexes
+5. Merge PR → Flux reconciles operator → connector pod registers → routes advertised → ACL auto-approves → split DNS active
+
+No manual admin console steps required after merge.
+
+---
+
+## Verification
+
+After Flux reconciles:
+```bash
+# Operator pod running
+kubectl get pods -n tailscale
+
+# Connector device appears in tailnet
+# (check Tailscale admin console → Machines, or use tailscale CLI)
+
+# Routes auto-approved (no pending approval in admin console)
+
+# From a Tailscale-connected device:
+# nslookup grafana.vollminlab.com     → should return 192.168.152.244
+# curl -s https://grafana.vollminlab.com  → should respond (not timeout)
+# ssh 192.168.152.8                   → should reach k8scp01
+```


### PR DESCRIPTION
## Summary

- Adds `docs/superpowers/specs/tailscale-design.md` — subnet router design: Connector CR advertising `192.168.152.0/24` + `192.168.100.0/24`, Terraform IaC for ACL autoApprovers and split DNS
- Adds `docs/superpowers/plans/tailscale.md` — full implementation plan ready for subagent execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)