### PR TITLE
feat(tailscale): deploy subnet router as cluster failsafe

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - policy-reporter-patch-kustomization.yaml
   - kube-system-kustomization.yaml
   - sealed-secrets-kustomization.yaml
+  - tailscale-kustomization.yaml
   - arc-controller-kustomization.yaml
   - actions-runner-system-kustomization.yaml
   - actions-runner-system-runners-kustomization.yaml

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/tailscale-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/tailscale-kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: tailscale
+  namespace: flux-system
+  labels:
+    app: tailscale-operator
+    env: production
+    category: networking
+spec:
+  interval: 10m
+  path: ./clusters/vollminlab-cluster/tailscale
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: tailscale
+  timeout: 5m
+  dependsOn:
+    - name: sealed-secrets

--- a/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
@@ -45,6 +45,7 @@ resources:
   - shlink-helmrepository.yaml
   - smb-csi-driver-helmrepository.yaml
   - sonarr-ocirepository.yaml
+  - tailscale-operator-helmrepository.yaml
   - tofu-controller-helmrepository.yaml
   - trivy-operator-helmrepository.yaml
   - velero-helmrepository.yaml

--- a/clusters/vollminlab-cluster/flux-system/repositories/tailscale-operator-helmrepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/tailscale-operator-helmrepository.yaml
@@ -1,0 +1,13 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: tailscale-operator-repo
+  namespace: flux-system
+  labels:
+    app: tailscale-operator
+    env: production
+    category: networking
+spec:
+  interval: 5m
+  url: https://pkgs.tailscale.com/helmcharts
+  timeout: 3m

--- a/clusters/vollminlab-cluster/tailscale/kustomization.yaml
+++ b/clusters/vollminlab-cluster/tailscale/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: tailscale
+  labels:
+    app: tailscale-operator
+    env: production
+    category: networking
+resources:
+  - namespace.yaml
+  - tailscale-operator/app

--- a/clusters/vollminlab-cluster/tailscale/namespace.yaml
+++ b/clusters/vollminlab-cluster/tailscale/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailscale
+  labels:
+    app: tailscale-operator
+    env: production
+    category: networking

--- a/clusters/vollminlab-cluster/tailscale/tailscale-operator/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/tailscale/tailscale-operator/app/configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tailscale-operator-values
+  namespace: tailscale
+  labels:
+    app: tailscale-operator
+    env: production
+    category: networking
+data:
+  values.yaml: |
+    operatorConfig:
+      hostname: vollminlab-cluster-operator
+      defaultTags:
+        - tag:k8s
+
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 256Mi

--- a/clusters/vollminlab-cluster/tailscale/tailscale-operator/app/connector.yaml
+++ b/clusters/vollminlab-cluster/tailscale/tailscale-operator/app/connector.yaml
@@ -1,0 +1,15 @@
+apiVersion: tailscale.com/v1alpha1
+kind: Connector
+metadata:
+  name: vollminlab-cluster
+  namespace: tailscale
+  labels:
+    app: tailscale-operator
+    env: production
+    category: networking
+spec:
+  hostname: vollminlab-cluster
+  subnetRouter:
+    advertiseRoutes:
+      - "192.168.152.0/24"
+      - "192.168.100.0/24"

--- a/clusters/vollminlab-cluster/tailscale/tailscale-operator/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/tailscale/tailscale-operator/app/helmrelease.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tailscale-operator
+  namespace: tailscale
+  labels:
+    app: tailscale-operator
+    env: production
+    category: networking
+spec:
+  interval: 10m
+  releaseName: tailscale-operator
+  chart:
+    spec:
+      chart: tailscale-operator
+      version: 1.98.3
+      sourceRef:
+        kind: HelmRepository
+        name: tailscale-operator-repo
+        namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: tailscale-operator-values
+      valuesKey: values.yaml

--- a/clusters/vollminlab-cluster/tailscale/tailscale-operator/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/tailscale/tailscale-operator/app/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: tailscale-operator-deployment
+  namespace: flux-system
+  labels:
+    app: tailscale-operator
+    env: production
+    category: networking
+resources:
+  - helmrelease.yaml
+  - configmap.yaml
+  - connector.yaml
+  - operator-oauth-sealedsecret.yaml

--- a/clusters/vollminlab-cluster/tailscale/tailscale-operator/app/operator-oauth-sealedsecret.yaml
+++ b/clusters/vollminlab-cluster/tailscale/tailscale-operator/app/operator-oauth-sealedsecret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: operator-oauth
+  namespace: tailscale
+spec:
+  encryptedData:
+    client_id: AgBYX6Q4L/f/OS9Hrdp8EShVPtwJrSVXIrmfhcsOiZVMb8RDlH1hNVYhj5UvhZcp/8wTVIQcj0q2vSpnbbqubEuIhQ0oJs3DN0guyJcjME4C+L5JVrxBGiNH8rB/qy06+wI1xTN5jsFYNjCuGyXEQwwJK2tS7e6HlHWEiCB/NmgsDXqnQMzRABOiSEde+YGLQ5GuUYcvtByxBQ/GJwC1TjaYRS3juS3HUJ6A9A1gBEDMygcKPTNpTXfeO8uxRYp/dIiBwko+wpdrh6Uf0jRcEB7qAZlEEtbdTWW0GUwHhTF/4qp+kiH/gcAOHCf/PLfiyseZERlcJMMoZU2cdEOsf6SkiCAZd7GLLiCXgJrf58OnxoXV+GN2E/Rso5++NJCNaR8xEAx6ccaB/7ZesJCQFDBRdAhwOubQD4UKGsN1+V1f+faNPhZc4qNyH/7IgQ2fGiembF3yVDpunVK1XLJA+oKv36x9tycmgkxsbSZ8JbP8TlhHoXDMcky4nIPLq7whTZaMBhAM2R1v+p9h20iItvLJMUASJicnsPy1JobMuoYOlN+RtpThSi+sZL8c3XXNQYoIK2i3HGYZ5+3eUor7dflsN5qWP5GcBK16JRKimlXLQ15gNu+ceJo/1pqOEH/lidBCchRtFa02RS2Fp92sZMcXt5EiNLAEV5p+MyoZykoePIeu2SUwGm5wKo4y6BvsGBVH52bcOntI1TPXmblGrTg63w==
+    client_secret: AgCf3kRTWCGjumYLIF5jTf6bSf+sEoJX9gCgR311WC7JzIjQCVMS4XPZC7DZuftFkPjGpR9x0o/coGQD9BB5kJP3bUOHMysVu8XVraj7rOp8HlmvkuOTY62jWrfD3gATbQR6FpUIJsq6dFMDqSsibBKlzfk3tT93z4YSiG89L5Dh0QSIsgyaCUsoGH75dDARhfWH5sBZfJN5NF5DlqIt3+0sVkZOKynT3UwFRfyygX70PbBqKRw2ZIzQlsSNj6fwYa/6NplzmVdzmgTXC/LLNL/a09oNTYu5wyLycS11HiassyRAIx5hERBwNPY9CVmYYGIA9UnCTapHLM5H7qf/FtNH5v0Xaosf8aqytTMrQ3Ox5hm1bNr9Y9dk98VHCqu7Dn7BECOlsQI0jXUhBcO7QWm9tQw11NmTU0PAfGMUtrShSP6vcDvKNUkmieAA4al/co6S+8VdU8NmUzz/R3vYaN2ctRTC0KyD2K/pMYK6Bc6ZeKXKBDtRTrJQsLo2oBwA2g4MNRP4tjUT+vRkgyWsoQYixldCl78Io6ykRekd+GYVoutGzXax2y3bQbcLJDgesI8+dS8XJrPwlg5xaY1kcBnTnUe8PgGkU/gehEIdn91Vcmdcp0r7w9AHbne7LsbbLY1NDFTddTnE/XY6+JTxatnpDrCCLVm3FZ8awphbWUefrzR72F94n+8333zO+lYSSw9Ar9IFotSttx3QTv53Z0O+2c7JPeFksxvfK/ywK2sj5hIzemLrPfB7oVlORwNozlVHaLopFaGjka7/22ZNAJnz
+  template:
+    metadata:
+      name: operator-oauth
+      namespace: tailscale
+      labels:
+        app: tailscale-operator
+        env: production
+        category: networking

--- a/clusters/vollminlab-cluster/tofu/kustomization.yaml
+++ b/clusters/vollminlab-cluster/tofu/kustomization.yaml
@@ -18,4 +18,5 @@ resources:
   - radarr-config/app
   - readarr-config/app
   - sonarr-config/app
+  - tailscale-config/app
   - tofu-controller/app

--- a/clusters/vollminlab-cluster/tofu/tailscale-config/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/tofu/tailscale-config/app/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: tailscale-config
+  labels:
+    app: tofu-controller
+    env: production
+    category: core
+resources:
+  - tailscale-tf-credentials-sealedsecret.yaml
+  - terraform-cr.yaml

--- a/clusters/vollminlab-cluster/tofu/tailscale-config/app/tailscale-tf-credentials-sealedsecret.yaml
+++ b/clusters/vollminlab-cluster/tofu/tailscale-config/app/tailscale-tf-credentials-sealedsecret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: tailscale-tf-credentials
+  namespace: tofu
+spec:
+  encryptedData:
+    tailscale_oauth_client_id: AgAJNHGX5BFEAl+TP3lBgdOETsn6VDU/jhzX1kjJ4p9SQdCfqW6t+3biOCKu5otBrd9kL5/D2patm2OwoxpL5UxgHUzlv/jDlNV89aXxihqjlaEQCvpwRqIIaaoYdbxqdroCtW3F7N9uXiwcjcgdM056fAsFwOs+laRVFPIBnFIiFmJEfjEHyav5l5l2BLtetJXJcURVbUD2Wr6qDgM3iw0rGAe/EfEo6iwOpRkwa1EvPbpi89HF7LpTChqnN7UJTvZGdM0fr997qi6ZtWp78nMvcMS1GamUPlhOHTpTEh621o3h8++InXN8HV1OvjyugLaQsaZ5ANbts/95WqW40vdANsHKlyA3p4ohngEkAKrzlLvOgQeqkgTyXH81uoRa9eKsUnRqGYeoQ9+/Pf+1SqXiUWCAZwXGLgvZYaZqCajyZIDZG8vocoUK99e3WUQlKWDkGHwcE6YX1o3kRq7hpx3oEQwe/oXtPllsisITNj2rIZLB30XPynOFnsrk7FEG1f1RK98Woe/OKoeBCgVdifDsCYfuJ1xzsQjwt+NqBBHwa1hpwgLaYXRSxTN17qpUY8rkNLK3hQIqck+aMEEA3+7v+81zCfxSjYhqTxvnBgoKxbm3I84URo6f2cJfuCOSUoe/8B3N3OuvldzS0Od45vM6OlvdVcjFZEVSBfufYEmMrnWpJi/+lf5xJkPUePd+8XWbb6we43yuGVIYBi+fqs3u0g==
+    tailscale_oauth_client_secret: AgB5XKYCQZ/yGx9dPOaEKXILohAxbheN47plKj5QL/kCFIFoUYHZ0sNQyN6cqO5rCuVTyuJAdtrv4l6ngjNLlmMeVNNMLGs0yvqqFbqKS3adByQYKnBLmxATHC5oJlIlX9xTzhjg+P6iheDrLUf/+yoz0ptOLZA9H6mYKJ3PaGlTz5uW1wwoMtItFz3zo2eK5ZeegKbLNmRALAt4Gr4nFtGYWmnmNJlpa1cj1KoNoFj1+47X4q5autSgkYCLsFlxuG3ujGQWQOgQMONM1nJd1+lO3SuGE+y8H/6J7LwPCD4QEO+jFJiPGIM2qj7Nailhby39HAwK7E0BbzlF4EyzD5h6g2DOBMwpKX1wYtITnnuCa0KZBb6U291yXv+tA8j8gfFDNYw4T1zxDTIYYRKOngfsNWdfunKgfcZKrWl6DsP9j/WJRKAmlx5lJfZNlqk9W/eGvm6VYkaHbAGQ6H5QEyfRbme2C689y4PZV8u5Q/HnfOJfeZqjRjYlTR16Z8CHqWyRXNrqo0aEElNwMG01TqmKLL6wiPrSbGLYoPKGza4mq51xEfR1xFI3mAKYuK9JcINRP5E8pmP1lB8MAYwL+woGnWxwNBtgpFHrO74NR3R8yf8rYpcowoCEl9nVeNvaXGKEo5Qv/H2q8ez/s9uRx+H5rUltq/rxDjrEyVldOKiTEifqhVbDsIF+cjN2S6L2sMB0l8tSUZXgxTXx0Ar7OERUyUWR1EOAHyCERR4j7uEWrBEObht+8Y2xe2bu5oXDL1K6kYYtDE91a74vtYzvNVDo
+  template:
+    metadata:
+      name: tailscale-tf-credentials
+      namespace: tofu
+      labels:
+        app: tofu-controller
+        env: production
+        category: core

--- a/clusters/vollminlab-cluster/tofu/tailscale-config/app/terraform-cr.yaml
+++ b/clusters/vollminlab-cluster/tofu/tailscale-config/app/terraform-cr.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: infra.contrib.fluxcd.io/v1alpha2
+kind: Terraform
+metadata:
+  name: tailscale-config
+  namespace: tofu
+  labels:
+    app: tofu-controller
+    env: production
+    category: core
+spec:
+  interval: 10m
+  approvePlan: auto
+  path: ./terraform/tailscale
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  backendConfig:
+    customConfiguration: |
+      backend "s3" {
+        bucket                      = "terraform-state"
+        key                         = "tailscale/terraform.tfstate"
+        region                      = "us-east-1"
+        endpoint                    = "http://minio.minio.svc.cluster.local:9000"
+        force_path_style            = true
+        skip_credentials_validation = true
+        skip_metadata_api_check     = true
+        skip_region_validation      = true
+      }
+  backendConfigsFrom:
+    - kind: Secret
+      name: tofu-minio-credentials
+  varsFrom:
+    - kind: Secret
+      name: tailscale-tf-credentials

--- a/terraform/tailscale/acl.tf
+++ b/terraform/tailscale/acl.tf
@@ -1,0 +1,31 @@
+resource "tailscale_acl" "main" {
+  acl = jsonencode({
+    grants = [
+      {
+        src = ["*"]
+        dst = ["*"]
+        ip  = ["*"]
+      }
+    ]
+
+    ssh = [
+      {
+        action = "check"
+        src    = ["autogroup:member"]
+        dst    = ["autogroup:self"]
+        users  = ["autogroup:nonroot", "root"]
+      }
+    ]
+
+    tagOwners = {
+      "tag:k8s" = ["autogroup:admin"]
+    }
+
+    autoApprovers = {
+      routes = {
+        "192.168.152.0/24" = ["tag:k8s"]
+        "192.168.100.0/24" = ["tag:k8s"]
+      }
+    }
+  })
+}

--- a/terraform/tailscale/dns.tf
+++ b/terraform/tailscale/dns.tf
@@ -1,0 +1,4 @@
+resource "tailscale_dns_split_nameservers" "vollminlab" {
+  domain      = "vollminlab.com"
+  nameservers = ["192.168.100.2"]
+}

--- a/terraform/tailscale/providers.tf
+++ b/terraform/tailscale/providers.tf
@@ -1,0 +1,4 @@
+provider "tailscale" {
+  oauth_client_id     = var.tailscale_oauth_client_id
+  oauth_client_secret = var.tailscale_oauth_client_secret
+}

--- a/terraform/tailscale/variables.tf
+++ b/terraform/tailscale/variables.tf
@@ -1,0 +1,9 @@
+variable "tailscale_oauth_client_id" {
+  type      = string
+  sensitive = true
+}
+
+variable "tailscale_oauth_client_secret" {
+  type      = string
+  sensitive = true
+}

--- a/terraform/tailscale/versions.tf
+++ b/terraform/tailscale/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    tailscale = {
+      source  = "tailscale/tailscale"
+      version = "~> 0.29"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Deploys Tailscale operator v1.98.3 in dedicated \`tailscale\` namespace
- \`Connector\` CR advertises \`192.168.152.0/24\` (nodes + MetalLB VIPs) and \`192.168.100.0/24\` (Pi-hole)
- \`terraform/tailscale/\` module manages ACL \`autoApprovers\` and split DNS for \`vollminlab.com\` → Pi-hole at \`192.168.100.2\`
- Two separate least-privilege OAuth clients (operator \`auth_keys:write\`, Terraform \`acls:write + dns:write\`)
- No manual Tailscale admin console steps required after merge

When connected to Tailscale from anywhere: \`*.vollminlab.com\` resolves via Pi-hole → routes through ingress-nginx exactly as on the home LAN. SSH to any node IP works directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)