### PR TITLE
fix(tailscale): separate Connector into its own Kustomization

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - kube-system-kustomization.yaml
   - sealed-secrets-kustomization.yaml
   - tailscale-kustomization.yaml
+  - tailscale-connector-kustomization.yaml
   - arc-controller-kustomization.yaml
   - actions-runner-system-kustomization.yaml
   - actions-runner-system-runners-kustomization.yaml

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/tailscale-connector-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/tailscale-connector-kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: tailscale-connector
+  namespace: flux-system
+  labels:
+    app: tailscale-operator
+    env: production
+    category: networking
+spec:
+  interval: 10m
+  path: ./clusters/vollminlab-cluster/tailscale-connector
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: tailscale
+  timeout: 5m
+  dependsOn:
+    - name: tailscale

--- a/clusters/vollminlab-cluster/tailscale-connector/app/connector.yaml
+++ b/clusters/vollminlab-cluster/tailscale-connector/app/connector.yaml
@@ -1,0 +1,15 @@
+apiVersion: tailscale.com/v1alpha1
+kind: Connector
+metadata:
+  name: vollminlab-cluster
+  namespace: tailscale
+  labels:
+    app: tailscale-operator
+    env: production
+    category: networking
+spec:
+  hostname: vollminlab-cluster
+  subnetRouter:
+    advertiseRoutes:
+      - "192.168.152.0/24"
+      - "192.168.100.0/24"

--- a/clusters/vollminlab-cluster/tailscale-connector/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/tailscale-connector/app/kustomization.yaml
@@ -1,13 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 metadata:
-  name: tailscale-operator-deployment
+  name: tailscale-connector-deployment
   namespace: flux-system
   labels:
     app: tailscale-operator
     env: production
     category: networking
 resources:
-  - helmrelease.yaml
-  - configmap.yaml
-  - operator-oauth-sealedsecret.yaml
+  - connector.yaml


### PR DESCRIPTION
## Summary

- The `Connector` CR requires the `tailscale.com/v1alpha1` CRD, which is installed by the operator Helm chart
- Having both in the same Flux Kustomization caused Flux's dry-run validation to fail before the HelmRelease could deploy
- Moves `connector.yaml` to `tailscale-connector/` with its own Flux Kustomization that `dependsOn: tailscale`
- Flux now waits for the operator (and its CRDs) to be ready before applying the Connector CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)