### PR TITLE
fix(tailscale): set imagePullPolicy to IfNotPresent

### DIFF
--- a/clusters/vollminlab-cluster/tailscale/tailscale-operator/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/tailscale/tailscale-operator/app/configmap.yaml
@@ -13,6 +13,8 @@ data:
       hostname: vollminlab-cluster-operator
       defaultTags:
         - tag:k8s
+      image:
+        pullPolicy: IfNotPresent
 
     resources:
       requests:


### PR DESCRIPTION
## Summary

- Chart default `imagePullPolicy: Always` caused Docker Hub 429 rate limit errors on pod restarts
- Image is already cached on the node; `IfNotPresent` avoids unnecessary pulls

🤖 Generated with [Claude Code](https://claude.com/claude-code)