### PR TITLE
fix(tailscale): use ghcr.io mirror to avoid Docker Hub rate limits

### DIFF
--- a/clusters/vollminlab-cluster/tailscale/tailscale-operator/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/tailscale/tailscale-operator/app/configmap.yaml
@@ -14,6 +14,7 @@ data:
       defaultTags:
         - tag:k8s
       image:
+        repository: ghcr.io/tailscale/k8s-operator
         pullPolicy: IfNotPresent
 
     resources:


### PR DESCRIPTION
## Summary

- Docker Hub unauthenticated pull rate limits (429) are blocking the operator pod from starting on nodes that don't have the image cached
- The Tailscale chart documents that images are synced to `ghcr.io/tailscale/k8s-operator`
- Switching to GHCR eliminates the rate limit issue entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)