### PR TITLE
fix(tailscale): add Kyverno exception for connector StatefulSet

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-tailscale.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-tailscale.yaml
@@ -1,0 +1,30 @@
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: ignore-tailscale-connector
+  namespace: kyverno
+  labels:
+    app: kyverno
+    env: production
+    category: security
+spec:
+  # The Tailscale operator creates a StatefulSet for the subnet router connector.
+  # The connector pod requires privileged mode to create TUN devices and manage
+  # kernel routing tables for subnet advertisement. The operator controls this
+  # pod's spec directly — resource limits and security context are not configurable
+  # via our Helm values (use ProxyClass CR if fine-grained control is needed later).
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+            - StatefulSet
+          namespaces:
+            - tailscale
+  exceptions:
+    - policyName: restrict-privileged
+      ruleNames:
+        - block-privileged
+    - policyName: require-resources
+      ruleNames:
+        - require-limits

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/kustomization.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - dmz-restrict-external-access.yaml
   - exceptions-calico.yaml
   - exceptions-ci-test-namespaces.yaml
+  - exceptions-tailscale.yaml
   - exceptions-kyverno-hooks.yaml
   - exceptions-kubeadm-cert-renew.yaml
   - exceptions-longhorn-dynamic.yaml


### PR DESCRIPTION
## Summary

- Kyverno's `restrict-privileged` policy was blocking the Tailscale subnet router StatefulSet
- The connector pod needs `privileged: true` to create TUN devices and manage kernel routing tables — this is not configurable via Helm values
- Also exempts from `require-resources` since the operator manages the connector pod spec directly
- Matches pattern used by `exceptions-calico.yaml` for operator-managed privileged workloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)