### PR TITLE
fix(kyverno): enable PolicyExceptions feature

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/app/configmap.yaml
@@ -22,6 +22,11 @@ data:
       env: production
       category: security
 
+    features:
+      policyExceptions:
+        enabled: true
+        namespace: kyverno
+
     admissionController:
       labels:
         app: kyverno-admission-controller


### PR DESCRIPTION
## Summary

- `PolicyException` resources exist in the cluster but the feature flag was disabled (`--enablePolicyException=false`)
- Enables `features.policyExceptions.enabled: true` scoped to the `kyverno` namespace
- Unblocks the Tailscale connector exception (PR #744) and any future exceptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)