### PR TITLE
fix(tailscale): use ghcr.io for proxy (connector) image

### DIFF
--- a/clusters/vollminlab-cluster/tailscale/tailscale-operator/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/tailscale/tailscale-operator/app/configmap.yaml
@@ -17,6 +17,10 @@ data:
         repository: ghcr.io/tailscale/k8s-operator
         pullPolicy: IfNotPresent
 
+    proxyConfig:
+      image:
+        repository: ghcr.io/tailscale/tailscale
+
     resources:
       requests:
         cpu: 10m


### PR DESCRIPTION
## Summary

- The connector (subnet router) pod pulls `tailscale/tailscale` from Docker Hub, hitting the same 429 rate limit as the operator image
- Tailscale mirrors this image to `ghcr.io/tailscale/tailscale` (official, noted in chart docs)
- Sets `proxyConfig.image.repository` to use GHCR for all operator-managed proxy pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)