### PR TITLE
fix(tailscale): allow Terraform to take ownership of existing ACL

### DIFF
--- a/terraform/tailscale/acl.tf
+++ b/terraform/tailscale/acl.tf
@@ -1,4 +1,5 @@
 resource "tailscale_acl" "main" {
+  overwrite_existing_content = true
   acl = jsonencode({
     grants = [
       {


### PR DESCRIPTION
## Summary

- Tailscale provider refused to apply `tailscale_acl.main` because a non-default ACL already exists in the console
- ACL content in `acl.tf` matches what's already configured (grants, tagOwners, autoApprovers)
- Setting `overwrite_existing_content = true` lets Terraform take ownership without changing the effective policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)