### PR TITLE
fix(volsync,prometheus): fix restic mover failures and raise Prometheus memory limit

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/volsync/filebrowser-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/filebrowser-config-replicationsource.yaml
@@ -17,3 +17,7 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000

--- a/clusters/vollminlab-cluster/mediastack/volsync/prowlarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/prowlarr-config-replicationsource.yaml
@@ -17,3 +17,5 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
+    exclude:
+      - asp/

--- a/clusters/vollminlab-cluster/mediastack/volsync/radarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/radarr-config-replicationsource.yaml
@@ -17,3 +17,5 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
+    exclude:
+      - asp/

--- a/clusters/vollminlab-cluster/mediastack/volsync/readarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/readarr-config-replicationsource.yaml
@@ -17,3 +17,5 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
+    exclude:
+      - asp/

--- a/clusters/vollminlab-cluster/mediastack/volsync/sonarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/sonarr-config-replicationsource.yaml
@@ -17,3 +17,5 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
+    exclude:
+      - asp/

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -32,7 +32,7 @@ data:
             memory: 1Gi
           limits:
             cpu: 2000m
-            memory: 3Gi
+            memory: 4Gi
         storageSpec:
           volumeClaimTemplate:
             spec:


### PR DESCRIPTION
## Summary

- **VolSync arr apps (radarr/sonarr/prowlarr/readarr)**: Restic exits code 3 when `asp/key-*.xml` files are permission-denied. These ASP.NET Data Protection keys are runtime-generated and not worth backing up. Adding `exclude: asp/` stops the retry storm (30+ pods looping on k8sworker04 since ~03:00 today).

- **VolSync filebrowser**: `database.db` is unreadable due to UID mismatch between the filebrowser process (fsGroup 1000) and the default mover UID. Adding `moverSecurityContext: runAsUser/Group/fsGroup: 1000` fixes the permission error.

- **Prometheus memory**: Currently at 2895Mi/3Gi (96.5%) — close enough to the limit that an OOMKill would take down monitoring. Raising limit 3Gi → 4Gi. Also a contributor to the `NodeMemoryMajorPagesFaults` alert on k8sworker04 alongside the VolSync retry storm.