### PR TITLE
fix(goldilocks): raise controller CPU limit to 1000m

### DIFF
--- a/clusters/vollminlab-cluster/goldilocks/goldilocks/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/goldilocks/goldilocks/app/configmap.yaml
@@ -32,7 +32,7 @@ data:
           cpu: 25m
           memory: 64Mi
         limits:
-          cpu: 500m
+          cpu: 1000m
           memory: 256Mi
 
     dashboard:


### PR DESCRIPTION
## Summary

- Controller CPU limit raised 500m → 1000m

The cgroup CPU stats show 68,225 throttled periods out of 241,558 total — a 28% throttle rate. Since #734 enabled VPA recommendations for all app namespaces the reconciliation burst is significantly larger, regularly spiking past the existing 500m ceiling. The controller idles at ~20m so raising the limit doesn't meaningfully affect node scheduling.