### PR TITLE
feat(tailscale): expose ingress-nginx as native Tailscale LoadBalancer service

### DIFF
--- a/clusters/vollminlab-cluster/ingress-nginx/kustomization.yaml
+++ b/clusters/vollminlab-cluster/ingress-nginx/kustomization.yaml
@@ -4,5 +4,6 @@ metadata:
   name: ingress-nginx
 resources:
   - namespace.yaml
-  - ./ingress-nginx/app
   - ./cloudflared-nginx/app
+  - ./ingress-nginx/app
+  - ./tailscale-svc

--- a/clusters/vollminlab-cluster/ingress-nginx/tailscale-svc/kustomization.yaml
+++ b/clusters/vollminlab-cluster/ingress-nginx/tailscale-svc/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: ingress-nginx-tailscale-svc
+resources:
+  - service.yaml

--- a/clusters/vollminlab-cluster/ingress-nginx/tailscale-svc/service.yaml
+++ b/clusters/vollminlab-cluster/ingress-nginx/tailscale-svc/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx-tailscale
+  namespace: ingress-nginx
+  labels:
+    app: ingress-nginx
+    env: production
+    category: networking
+  annotations:
+    tailscale.com/hostname: vollminlab-ingress
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 80
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 443

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-tailscale.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-tailscale.yaml
@@ -8,11 +8,12 @@ metadata:
     env: production
     category: security
 spec:
-  # The Tailscale operator creates a StatefulSet for the subnet router connector.
-  # The connector pod requires privileged mode to create TUN devices and manage
-  # kernel routing tables for subnet advertisement. The operator controls this
-  # pod's spec directly — resource limits and security context are not configurable
-  # via our Helm values (use ProxyClass CR if fine-grained control is needed later).
+  # The Tailscale operator creates privileged StatefulSets for:
+  # 1. The subnet router Connector (tailscale namespace)
+  # 2. LoadBalancer service proxies (in the service's namespace, e.g. ingress-nginx)
+  # All require privileged mode to create TUN devices. The operator controls pod
+  # specs directly — limits and security context are not configurable via Helm
+  # values (use ProxyClass CR if fine-grained control is needed later).
   match:
     any:
       - resources:
@@ -21,6 +22,15 @@ spec:
             - StatefulSet
           namespaces:
             - tailscale
+      - resources:
+          kinds:
+            - Pod
+            - StatefulSet
+          namespaces:
+            - ingress-nginx
+          selector:
+            matchLabels:
+              tailscale.com/managed: "true"
   exceptions:
     - policyName: restrict-privileged
       ruleNames:


### PR DESCRIPTION
## Summary

- Creates `ingress-nginx-tailscale` LoadBalancer service (class: `tailscale`) in the `ingress-nginx` namespace
- Tailscale operator creates a proxy StatefulSet that joins the tailnet as `vollminlab-ingress` and forwards TCP 80/443 to the ingress-nginx ClusterIP
- Extends the Kyverno `PolicyException` to cover `tailscale.com/managed=true` pods in `ingress-nginx` (proxy pods need privileged mode for TUN devices, same as the connector)

## Why

MetalLB VIPs with `ipMode: VIP` (default since MetalLB 0.14 + K8s 1.30+) are unreachable from the pod network — kube-proxy skips DNAT entirely. The subnet router connector can't forward traffic to `192.168.152.244`. This approach bypasses the VIP completely: the operator proxy pod routes traffic to the ingress-nginx **ClusterIP** which is fully reachable from the pod network. TLS works end-to-end since the client sends SNI for `*.vollminlab.com` and ingress-nginx terminates with the existing cert.

## After merge

Once the proxy pod is Running, check its tailnet IP:
```bash
kubectl get svc -n ingress-nginx ingress-nginx-tailscale
```

Then update Pi-hole with a custom DNS record: `*.vollminlab.com → <tailnet IP>` so that tailnet clients resolve vollminlab.com services to the Tailscale proxy instead of the MetalLB VIP.