### PR TITLE
fix(tailscale): add vollm.in to split DNS so short links work on tailnet

### DIFF
--- a/terraform/tailscale/dns.tf
+++ b/terraform/tailscale/dns.tf
@@ -2,3 +2,8 @@ resource "tailscale_dns_split_nameservers" "vollminlab" {
   domain      = "vollminlab.com"
   nameservers = ["192.168.100.4"]
 }
+
+resource "tailscale_dns_split_nameservers" "vollm_in" {
+  domain      = "vollm.in"
+  nameservers = ["192.168.100.4"]
+}


### PR DESCRIPTION
## Summary

- Adds `vollm.in` to Tailscale split DNS, pointing at the Pi-hole VRRP VIP (192.168.100.4)

## Why

`vollm.in` has no public DNS records — it only exists in Pi-hole local DNS resolving to `192.168.152.244` (ingress-nginx MetalLB VIP). Without a split DNS entry, Tailscale clients query public DNS for `vollm.in`, get NXDOMAIN, and cannot reach shlink short URLs at all. Adding it here sends those queries to Pi-hole, which returns the correct internal IP, and the Connector's `192.168.152.0/24` subnet route handles the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)