### PR TITLE
fix(tailscale): auto-approve management VLAN route for k8s connector

### DIFF
--- a/terraform/tailscale/acl.tf
+++ b/terraform/tailscale/acl.tf
@@ -25,6 +25,7 @@ resource "tailscale_acl" "main" {
     autoApprovers = {
       routes = {
         "192.168.152.0/24" = ["tag:k8s"]
+        "192.168.151.0/24" = ["tag:k8s"]
         "192.168.100.0/24" = ["tag:k8s"]
       }
     }


### PR DESCRIPTION
## Summary

- Adds `192.168.151.0/24` to `autoApprovers.routes` in the Tailscale ACL

## Why

The Connector now advertises `192.168.151.0/24` (VMWMgmt — vCenter + ESXi hosts) but without an `autoApprovers` entry the route requires manual approval in the admin console before Tailscale clients will use it. This matches the existing pattern for the other two advertised subnets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)