### PR TITLE
fix(tailscale): explicitly approve connector subnet routes via Terraform

### DIFF
--- a/terraform/tailscale/routes.tf
+++ b/terraform/tailscale/routes.tf
@@ -1,0 +1,12 @@
+data "tailscale_device" "connector" {
+  hostname = "vollminlab-cluster.tail8b1511.ts.net"
+}
+
+resource "tailscale_device_subnet_routes" "connector" {
+  device_id = data.tailscale_device.connector.id
+  routes = [
+    "192.168.152.0/24",
+    "192.168.151.0/24",
+    "192.168.100.0/24",
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `tailscale_device_subnet_routes` resource to explicitly approve all three advertised subnets for `vollminlab-cluster`

## Why

`autoApprovers` in the ACL only auto-approves a route at the moment it's first advertised. If the route was already being advertised before the ACL rule existed (as with `192.168.151.0/24`), it never gets retroactively approved and sits pending in the admin console indefinitely. The `tailscale_device_subnet_routes` resource is declarative and idempotent — tofu-controller will ensure the approved routes always match what's listed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)