### PR TITLE
fix(tailscale): use short hostname in device data source

### DIFF
--- a/terraform/tailscale/routes.tf
+++ b/terraform/tailscale/routes.tf
@@ -1,5 +1,5 @@
 data "tailscale_device" "connector" {
-  hostname = "vollminlab-cluster.tail8b1511.ts.net"
+  hostname = "vollminlab-cluster"
 }
 
 resource "tailscale_device_subnet_routes" "connector" {


### PR DESCRIPTION
## Summary

- Fixes `tailscale_device` data source hostname from `vollminlab-cluster.tail8b1511.ts.net` to `vollminlab-cluster` — the data source expects the device name only, not the FQDN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)