### PR TITLE
fix(volsync): replace invalid exclude with moverSecurityContext for arr apps

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/volsync/prowlarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/prowlarr-config-replicationsource.yaml
@@ -17,5 +17,7 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
-    exclude:
-      - asp/
+    moverSecurityContext:
+      runAsUser: 568
+      runAsGroup: 568
+      fsGroup: 568

--- a/clusters/vollminlab-cluster/mediastack/volsync/radarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/radarr-config-replicationsource.yaml
@@ -17,5 +17,7 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
-    exclude:
-      - asp/
+    moverSecurityContext:
+      runAsUser: 568
+      runAsGroup: 568
+      fsGroup: 568

--- a/clusters/vollminlab-cluster/mediastack/volsync/readarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/readarr-config-replicationsource.yaml
@@ -17,5 +17,7 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
-    exclude:
-      - asp/
+    moverSecurityContext:
+      runAsUser: 568
+      runAsGroup: 568
+      fsGroup: 568

--- a/clusters/vollminlab-cluster/mediastack/volsync/sonarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/sonarr-config-replicationsource.yaml
@@ -17,5 +17,7 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
-    exclude:
-      - asp/
+    moverSecurityContext:
+      runAsUser: 568
+      runAsGroup: 568
+      fsGroup: 568


### PR DESCRIPTION
## Summary

- Removes `spec.restic.exclude` from radarr/sonarr/prowlarr/readarr ReplicationSources — this field is not in the Volsync CRD schema and was causing the entire mediastack Flux kustomization dry-run to fail since PR #748 merged
- Adds `moverSecurityContext: runAsUser/runAsGroup/fsGroup: 568` to those four files so the restic mover runs as the app UID and can read all PVC contents
- Filebrowser's `moverSecurityContext: 1000` fix (already committed in PR #748) will be applied automatically once this unblocks the kustomization

🤖 Generated with [Claude Code](https://claude.com/claude-code)