### PR TITLE
fix(etcd-defrag): run defrag daily instead of weekly

### DIFF
--- a/clusters/vollminlab-cluster/kube-system/etcd-defrag/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/kube-system/etcd-defrag/app/cronjob.yaml
@@ -8,7 +8,7 @@ metadata:
     env: production
     category: core
 spec:
-  schedule: "0 3 * * 0"
+  schedule: "0 3 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3


### PR DESCRIPTION
## Summary

- Changes etcd-defrag CronJob schedule from `0 3 * * 0` (weekly, Sunday) to `0 3 * * *` (daily at 3am)
- etcd fragmentation rebuilds to 53–54% within ~40h of a weekly defrag, triggering repeated `EtcdFragmentation` alerts; daily runs keep it well below the 50% threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)