### PR TITLE
fix(jellyfin): allow HTTP to fix Quick Connect on LAN clients

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/jellyfin/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/jellyfin/app/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: jellyfin-ingress
   namespace: mediastack
   annotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
     shlink.vollminlab.com/slug: jellyfin
   labels:
     app: jellyfin


### PR DESCRIPTION
## Summary

- Removes `ssl-redirect: true` from the Jellyfin ingress so LAN clients with saved HTTP server URLs (e.g. TV apps) can reach the API without being 301-redirected
- Quick Connect polling was silently failing because the TV received a redirect instead of the approval response
- HTTPS still works; external access is via Cloudflare tunnel (unaffected); SSO uses SchemeOverride:https so Authentik redirects are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)