### PR TITLE
fix(velero): increase memory limit to 1500Mi to prevent OOMKill

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -20,7 +20,7 @@ data:
         memory: 512Mi
       limits:
         cpu: 1000m
-        memory: 512Mi
+        memory: 1500Mi
 
     # AWS plugin provides S3-compatible support for both MinIO and Backblaze B2
     initContainers:


### PR DESCRIPTION
## Summary
- Velero pod was OOMKilled nightly during the full backup window (02:00-04:00 UTC), causing all backups to fail since 2026-05-22
- Root cause: 512Mi memory limit too low for kopia file-system backups across all cluster namespaces
- Fix: raise memory limit from 512Mi to 1500Mi (request stays at 512Mi)

🤖 Generated with [Claude Code](https://claude.com/claude-code)