### PR TITLE
fix(shlink): patch liveness probe timeout via Kyverno Policy

### DIFF
--- a/clusters/vollminlab-cluster/shlink/shlink/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ingress.yaml
   - vollm-in-certificate.yaml
   - shlink-credentials-sealedsecret.yaml
+  - kyverno-policy.yaml

--- a/clusters/vollminlab-cluster/shlink/shlink/app/kyverno-policy.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink/app/kyverno-policy.yaml
@@ -1,0 +1,36 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: patch-shlink-backend-probes
+  namespace: shlink
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: none
+  labels:
+    app: shlink
+    env: production
+    category: apps
+spec:
+  rules:
+    - name: patch-probe-timeout
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              namespaces:
+                - shlink
+              selector:
+                matchLabels:
+                  app.kubernetes.io/name: shlink-backend
+      mutate:
+        patchStrategicMerge:
+          spec:
+            containers:
+              - (name): shlink-backend
+                livenessProbe:
+                  timeoutSeconds: 5
+                  initialDelaySeconds: 30
+                  failureThreshold: 5
+                readinessProbe:
+                  timeoutSeconds: 5
+                  initialDelaySeconds: 30


### PR DESCRIPTION
## Summary
- shlink-backend has had 12 pod restarts in 4 days (exit 137) due to liveness probe timing out
- Root cause: chart hardcodes `timeoutSeconds: 1, initialDelaySeconds: 0` with no way to override via values
- The `/rest/health` DB connectivity check occasionally exceeds 1s (especially under backup load at 2-4am UTC)
- Fix: Kyverno `Policy` in the shlink namespace mutates matching pods to use `timeout: 5s, initialDelay: 30s, failureThreshold: 5`
- `autogen-controllers: none` annotation prevents broken controller-scope mutation (per kyverno.md rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)