### PR TITLE
fix(shlink): remove invalid namespaces filter from namespaced Kyverno Policy

### DIFF
--- a/clusters/vollminlab-cluster/shlink/shlink/app/kyverno-policy.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink/app/kyverno-policy.yaml
@@ -17,8 +17,6 @@ spec:
           - resources:
               kinds:
                 - Pod
-              namespaces:
-                - shlink
               selector:
                 matchLabels:
                   app.kubernetes.io/name: shlink-backend


### PR DESCRIPTION
## Summary

- Removes `namespaces:` from `match.any.resources` in the namespaced `patch-shlink-backend-probes` Policy
- Kyverno webhook was rejecting the policy dry-run with: `spec.rules[0].match.any[0].namespaces: Forbidden: Filtering namespaces not allowed in namespaced policies`
- Namespaced Policy resources are already implicitly scoped to their own namespace — the `namespaces` filter is only valid in ClusterPolicy
- This was preventing the shlink Flux Kustomization from reconciling and the probe mutation from taking effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)