### PR TITLE
fix(trivy): exclude ARC runner namespaces from vulnerability scanning

### DIFF
--- a/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
@@ -11,6 +11,7 @@ data:
   values.yaml: |
     operator:
       scanJobsConcurrentLimit: 3
+      excludeNamespaces: "actions-runner-system,arc-controller"
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
## Summary

- Adds `operator.excludeNamespaces: "actions-runner-system,arc-controller"` to Trivy operator Helm values
- These namespaces run ephemeral GitHub ARC runner pods that use `docker:26-dind` from Docker Hub
- Trivy hits Docker Hub's unauthenticated pull rate limit (`TOOMANYREQUESTS`) when scanning these pods, causing repeated `scan-vulnerabilityreport-*` job failures
- CI runner images don't benefit from cluster CVE scanning — they're short-lived and the image is a known public base image

🤖 Generated with [Claude Code](https://claude.com/claude-code)