### PR TITLE
fix(trivy): use top-level excludeNamespaces key

### DIFF
--- a/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
@@ -9,9 +9,10 @@ metadata:
     category: security
 data:
   values.yaml: |
+    excludeNamespaces: "actions-runner-system,arc-controller"
+
     operator:
       scanJobsConcurrentLimit: 3
-      excludeNamespaces: "actions-runner-system,arc-controller"
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
## Summary

- Moves `excludeNamespaces` from under `operator:` to the chart root level
- The previous location (`operator.excludeNamespaces`) is not a recognized chart value — it had no effect and `OPERATOR_EXCLUDE_NAMESPACES` remained empty after upgrade
- The correct key per the chart's `values.yaml` schema is top-level `excludeNamespaces`
- After this merges, the Trivy operator will restart with `OPERATOR_EXCLUDE_NAMESPACES=actions-runner-system,arc-controller` and stop spawning scan jobs for ARC runner pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)