### PR TITLE
fix(etcd-defrag): add --command-timeout=120s to etcdctl defrag calls

### DIFF
--- a/clusters/vollminlab-cluster/kube-system/etcd-defrag/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/kube-system/etcd-defrag/app/cronjob.yaml
@@ -37,15 +37,15 @@ spec:
                   echo "etcd defrag started at $(date)"
 
                   echo "Defragging k8scp01 (follower)..."
-                  kubectl exec -n kube-system etcd-k8scp01 -- etcdctl --endpoints=https://192.168.152.8:2379 $CERTS defrag
+                  kubectl exec -n kube-system etcd-k8scp01 -- etcdctl --endpoints=https://192.168.152.8:2379 $CERTS --command-timeout=120s defrag
                   sleep 10
 
                   echo "Defragging k8scp03 (follower)..."
-                  kubectl exec -n kube-system etcd-k8scp03 -- etcdctl --endpoints=https://192.168.152.10:2379 $CERTS defrag
+                  kubectl exec -n kube-system etcd-k8scp03 -- etcdctl --endpoints=https://192.168.152.10:2379 $CERTS --command-timeout=120s defrag
                   sleep 10
 
                   echo "Defragging k8scp02 (leader)..."
-                  kubectl exec -n kube-system etcd-k8scp02 -- etcdctl --endpoints=https://192.168.152.9:2379 $CERTS defrag
+                  kubectl exec -n kube-system etcd-k8scp02 -- etcdctl --endpoints=https://192.168.152.9:2379 $CERTS --command-timeout=120s defrag
 
                   echo "etcd defrag complete at $(date)"
               resources:


### PR DESCRIPTION
## Summary

- Adds `--command-timeout=120s` to all three `etcdctl defrag` calls in the CronJob script
- The 3am daily run failed with `context deadline exceeded` after 5.08s on k8scp01 — etcdctl defaults to a 5-second command timeout, which is too short when the cluster is under load (VolSync backups, tofu drift checks, and ARC runners all run at 3am)
- 120s gives the defrag operation plenty of headroom; etcd defrag on a lightly-fragmented member typically takes under 10s, but can take longer on a busy node

🤖 Generated with [Claude Code](https://claude.com/claude-code)