### PR TITLE
fix(monitoring): exclude Succeeded/Failed pods from PodNotReady alert

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -159,7 +159,10 @@ spec:
 
         - alert: PodNotReady
           expr: |
-            kube_pod_status_ready{condition="true",namespace!~"trivy-system|velero"} == 0
+            (
+              kube_pod_status_ready{condition="true",namespace!~"trivy-system|velero"} == 0
+            ) unless on(pod, namespace)
+              kube_pod_status_phase{phase=~"Succeeded|Failed"} == 1
           for: 15m
           labels:
             severity: warning


### PR DESCRIPTION
## Summary

- Completed CronJob pods (descheduler, etcd-defrag, kopia-maintain jobs) were triggering `PodNotReady` because `kube_pod_status_ready{condition="true"} == 0` matches all non-ready pods, including those in terminal `Succeeded`/`Failed` phases
- Adds `unless on(pod, namespace) kube_pod_status_phase{phase=~"Succeeded|Failed"} == 1` to filter out terminal pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)