### PR TITLE
fix(authentik): fix policy-reporter icon URL

### DIFF
--- a/terraform/authentik/applications.tf
+++ b/terraform/authentik/applications.tf
@@ -149,7 +149,7 @@ resource "authentik_application" "policy_reporter" {
   name            = "Policy Reporter"
   slug            = "policy-reporter"
   meta_launch_url = "https://policyreporter.vollminlab.com"
-  meta_icon       = "https://kyverno.io/icons/icon-512x512.png"
+  meta_icon       = "https://raw.githubusercontent.com/kyverno/kyverno/main/img/logo.png"
   open_in_new_tab = false
 }
 


### PR DESCRIPTION
`kyverno.io/icons/icon-512x512.png` returns `text/html` — the URL resolves to a web page, not an image.

Switch to the actual PNG from the Kyverno GitHub repo: `https://raw.githubusercontent.com/kyverno/kyverno/main/img/logo.png` (verified `200 image/png`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)