### PR TITLE
chore(ci): right-size ARC runner memory limits and reduce minRunners

### DIFF
--- a/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/configmap.yaml
@@ -14,7 +14,7 @@ data:
 
     runnerScaleSetName: "vollminlab"
 
-    minRunners: 4
+    minRunners: 2
     maxRunners: 10
 
     controllerServiceAccount:
@@ -53,7 +53,7 @@ data:
                 memory: 512Mi
               limits:
                 cpu: 2000m
-                memory: 2Gi
+                memory: 1Gi
           - name: dind
             image: docker:26-dind
             securityContext:
@@ -68,7 +68,7 @@ data:
                 memory: 256Mi
               limits:
                 cpu: 2000m
-                memory: 2Gi
+                memory: 512Mi
 
     listenerTemplate:
       metadata:


### PR DESCRIPTION
## Summary

- Drop \`minRunners\` from 4 → 2; ARC auto-scales to \`maxRunners: 10\` when jobs queue
- Cut \`runner\` memory limit 2Gi → 1Gi
- Cut \`dind\` memory limit 2Gi → 512Mi

The main CI runs kubeconform, Kyverno CLI, and Trivy — no Docker builds. The b2-exporter Docker build (tags only, rare) is a small Go→Alpine image that fits easily in 512Mi dind.

Previous limits caused k8sworker01 (8GiB node, 75% actual memory) to go NodeNotReady when CI jobs fired, because 2 runner pods × 4GiB limit each could claim the entire node's RAM while it was already heavily loaded with Authentik, Harbor, Jellyfin, and Kyverno.