### PR TITLE
fix(trivy): reduce scan concurrency to 1 to prevent DB cache lock conflicts

### DIFF
--- a/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
@@ -14,7 +14,7 @@ data:
     operator:
       sbomReport:
         enabled: false
-      scanJobsConcurrentLimit: 3
+      scanJobsConcurrentLimit: 1
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
## Summary

- Reduces `scanJobsConcurrentLimit` from 3 → 1
- Root cause: all 3 concurrent scan jobs were landing on k8sworker03 simultaneously, competing for the Trivy DB/cache lock — causing "Failed to acquire cache or database lock" failures
- k8sworker03 has pre-existing I/O issues that make lock acquisition timeouts worse
- Serializing scans eliminates the race condition; scans take longer overall but complete reliably

🤖 Generated with [Claude Code](https://claude.com/claude-code)