### PR TITLE
fix(descheduler): remove invalid evictStatefulSetPods field

### DIFF
--- a/clusters/vollminlab-cluster/kube-system/descheduler/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kube-system/descheduler/app/configmap.yaml
@@ -32,7 +32,6 @@ data:
             - name: DefaultEvictor
               args:
                 evictLocalStoragePods: false
-                evictStatefulSetPods: true
                 nodeFit: true
             - name: LowNodeUtilization
               args:


### PR DESCRIPTION
## Summary

- Removes `evictStatefulSetPods: true` from DefaultEvictor args
- descheduler v0.36.0 uses strict decoding and does not recognize this field, causing every CronJob run to fail with: `unknown field "evictStatefulSetPods"`
- StatefulSet pods are evictable by default in this version unless protected by a PodDisruptionBudget — the field is unnecessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)