### PR TITLE
fix(harbor): add resource limits and loosen liveness probes on core/jobservice

### DIFF
--- a/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
@@ -72,6 +72,34 @@ data:
       credentials:
         existingSecret: harbor-core-credentials
 
+    core:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+      livenessProbe:
+        timeoutSeconds: 5
+        failureThreshold: 5
+      readinessProbe:
+        timeoutSeconds: 5
+
+    jobservice:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+      livenessProbe:
+        timeoutSeconds: 5
+        failureThreshold: 5
+      readinessProbe:
+        timeoutSeconds: 5
+
     trivy:
       resources:
         requests:


### PR DESCRIPTION
## Summary

- Adds resource requests/limits to `core` and `jobservice` containers (were completely unconfigured)
- Increases liveness probe `timeoutSeconds` from 1→5 and `failureThreshold` from 2→5 on both components
- Chart defaults kill harbor-core after just 20s of Redis unresponsiveness (1s timeout × 2 failures), causing the 21-23 restart counts seen tonight
- Harbor core/jobservice actual usage is tiny (~51Mi / ~18Mi), so the 512Mi limits are very conservative

🤖 Generated with [Claude Code](https://claude.com/claude-code)