### PR TITLE
fix(metallb): increase frr liveness probe failureThreshold to 6

### DIFF
--- a/clusters/vollminlab-cluster/metallb-system/metallb/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/metallb-system/metallb/app/configmap.yaml
@@ -47,6 +47,7 @@ data:
               memory: 32Mi
         livenessProbe:
           timeoutSeconds: 5
+          failureThreshold: 6
         readinessProbe:
           timeoutSeconds: 5
     speaker:


### PR DESCRIPTION
## Summary

- Raises `frrk8s.livenessProbe.failureThreshold` from 3 → 6 in the MetalLB configmap
- The `frr` container's liveness probe hits `/livez:9141` with a 1s timeout that is **not exposed as a chart value** (the template omits `timeoutSeconds` for the frr container, only setting it for the controller container)
- Under memory pressure (86% RAM + Velero backup I/O causing 720+ major page faults/s on k8sworker04), the probe times out and kills the container after 30s (3 × 10s periods), causing CrashLoopBackOff and BGP disruption
- Doubling the window to 60s gives the node time to recover from transient pressure without cycling FRR

🤖 Generated with [Claude Code](https://claude.com/claude-code)