### PR TITLE
fix(jellyfin): raise CPU limit 2 → 4 cores

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/jellyfin/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/jellyfin/app/configmap.yaml
@@ -43,5 +43,5 @@ data:
         cpu: 500m
         memory: 512Mi
       limits:
-        cpu: 2000m
+        cpu: 4000m
         memory: 2Gi


### PR DESCRIPTION
## Summary

- Raises Jellyfin CPU limit from 2000m to 4000m
- Software 1080p H.264 transcode with subtitle burn-in (BD-ISO playback via libx264) requires 3–4 cores; the 2-core limit was causing CPUThrottlingHigh and NodeSystemSaturation alerts on k8sworker01

🤖 Generated with [Claude Code](https://claude.com/claude-code)