### PR TITLE
fix(velero): set podVolumeOperationTimeout to 30m to unblock stuck PVBs

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -58,6 +58,11 @@ data:
       storeValidationFrequency: 1h
       backupSyncPeriod: 1h
 
+      # Force-fail PVBs stuck in InProgress/Prepared after 30 minutes.
+      # Without this, the node-agent's gRPC data path can get stuck silently and
+      # block all PVBs on the affected node indefinitely across multiple backup runs.
+      podVolumeOperationTimeout: 30m
+
       backupStorageLocation:
         # Primary: in-cluster MinIO (fast restores, no egress cost)
         - name: minio


### PR DESCRIPTION
## Summary

- Adds `podVolumeOperationTimeout: 30m` to the Velero server configuration
- Without this, stuck PVBs on k8sworker04 have been causing PartiallyFailed backups daily for weeks

## Root cause

The node-agent's gRPC data path routine silently fails its initial connection attempt to the runner pod. The routine is left in a broken state — `AddFileSystemBR` returns `nil` on every subsequent controller reconcile because the routine "already exists", but it never processes. All PVBs on the affected node are blocked indefinitely.

Today's pattern: both the 2am daily-full and 4am daily-b2 runs had 7 PVBs each stuck on k8sworker04 (sonarr + bazarr volumes). After manually restarting the node-agent at 10:40am, all 14 completed within seconds.

## Fix

Setting `podVolumeOperationTimeout: 30m` causes the backup controller to force-fail PVBs that have been stuck for 30 minutes. This triggers cleanup of the stale routine in the node-agent, so the next backup gets a clean start. With the 2-hour gap between daily-full (2am) and daily-b2 (4am), the b2 backup should now see clean state and succeed even if the full backup gets stuck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)