### PR TITLE
fix(velero): anti-affinity + schedule shift to fix stuck PVBs on k8sworker04

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/audiobookshelf/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/audiobookshelf/app/configmap.yaml
@@ -30,6 +30,18 @@ data:
       container:
         runAsUser: 0
         runAsGroup: 0
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - velero
+              topologyKey: kubernetes.io/hostname
     resources:
       requests:
         cpu: 100m

--- a/clusters/vollminlab-cluster/mediastack/bazarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr/app/configmap.yaml
@@ -44,6 +44,18 @@ data:
       app: bazarr
       env: production
       category: media
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - velero
+              topologyKey: kubernetes.io/hostname
     resources:
       requests:
         cpu: 100m

--- a/clusters/vollminlab-cluster/mediastack/jellyfin/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/jellyfin/app/configmap.yaml
@@ -38,6 +38,18 @@ data:
       app: jellyfin
       env: production
       category: media
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - velero
+              topologyKey: kubernetes.io/hostname
     resources:
       requests:
         cpu: 500m

--- a/clusters/vollminlab-cluster/mediastack/jellystat/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/jellystat/app/configmap.yaml
@@ -23,6 +23,18 @@ data:
       app: jellystat
       env: production
       category: media
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - velero
+              topologyKey: kubernetes.io/hostname
     resources:
       requests:
         cpu: 50m

--- a/clusters/vollminlab-cluster/mediastack/prowlarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/prowlarr/app/configmap.yaml
@@ -27,6 +27,18 @@ data:
       preStop:
         exec:
           command: ["/bin/sh", "-c", "sleep 10"]
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - velero
+              topologyKey: kubernetes.io/hostname
     resources:
       requests:
         cpu: 100m

--- a/clusters/vollminlab-cluster/mediastack/radarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/radarr/app/configmap.yaml
@@ -27,6 +27,18 @@ data:
       preStop:
         exec:
           command: ["/bin/sh", "-c", "sleep 10"]
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - velero
+              topologyKey: kubernetes.io/hostname
     resources:
       requests:
         cpu: 100m

--- a/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
@@ -31,6 +31,18 @@ data:
       preStop:
         exec:
           command: ["/bin/sh", "-c", "sleep 10"]
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - velero
+              topologyKey: kubernetes.io/hostname
     resources:
       requests:
         cpu: 100m

--- a/clusters/vollminlab-cluster/mediastack/sabnzbd/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sabnzbd/app/configmap.yaml
@@ -26,6 +26,18 @@ data:
       app: sabnzbd
       env: production
       category: media
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - velero
+              topologyKey: kubernetes.io/hostname
     resources:
       requests:
         cpu: 200m

--- a/clusters/vollminlab-cluster/mediastack/seerr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/seerr/app/configmap.yaml
@@ -22,6 +22,18 @@ data:
     ingress:
       enabled: false
 
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - velero
+              topologyKey: kubernetes.io/hostname
     resources:
       requests:
         cpu: 100m

--- a/clusters/vollminlab-cluster/mediastack/sonarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sonarr/app/configmap.yaml
@@ -43,6 +43,18 @@ data:
     podSecurityContext:
       fsGroup: 568
       fsGroupChangePolicy: "OnRootMismatch"
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - velero
+              topologyKey: kubernetes.io/hostname
     terminationGracePeriodSeconds: 60
     lifecycle:
       preStop:

--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -63,6 +63,22 @@ data:
       # block all PVBs on the affected node indefinitely across multiple backup runs.
       podVolumeOperationTimeout: 30m
 
+    # Prefer not to land on the same node as media stack workloads.
+    # The Velero pod generates significant API/CPU load during backup runs, which
+    # interferes with the node-agent's gRPC data path initialization on that node.
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: category
+                    operator: In
+                    values:
+                      - media
+              topologyKey: kubernetes.io/hostname
+
       backupStorageLocation:
         # Primary: in-cluster MinIO (fast restores, no egress cost)
         - name: minio
@@ -122,7 +138,7 @@ data:
     schedules:
       daily-full:
         disabled: false
-        schedule: "0 2 * * *"
+        schedule: "0 3 * * *"
         useOwnerReferencesInBackup: false
         template:
           ttl: 336h


### PR DESCRIPTION
## Summary

- Velero deployment gets soft anti-affinity against `category: media` pods
- All 10 mediastack apps get soft anti-affinity against `app: velero`
- daily-full schedule shifted 2am → 3am

## Why

The Velero pod was consistently landing on k8sworker04 alongside media stack workloads. During the 2am backup run, the Velero orchestration process generates heavy CPU and API call load, which interfered with the node-agent's gRPC connection initialization on that node — causing all k8sworker04 PVBs to hang indefinitely.

This was the root cause of weeks of consistent `PartiallyFailed` backups with exactly 10 errors every night.

## What changes

**Velero**: avoids nodes running any `category: media` pod. Single rule covers all current and future media stack apps.

**All mediastack apps** (audiobookshelf, bazarr, jellyfin, jellystat, prowlarr, radarr, readarr, sabnzbd, seerr, sonarr): each avoids the node running the `app: velero` pod. Rule lives on the workload itself, not on any node.

All rules are `preferredDuringSchedulingIgnoredDuringExecution` (soft/weight 100) — workers remain fully homogeneous, no node is pinned to anything.

**Schedule**: daily-full at 3am instead of 2am. Combined with `podVolumeOperationTimeout: 30m` (PR #789), this ensures any stuck PVBs from the 3am run time out and clean up before the 4am b2 backup starts — giving the b2 run a clean node-agent state.

## Layered defence (all three PRs together)

| Layer | PR | What it does |
|---|---|---|
| Prevent | This PR | Velero and media stack prefer different nodes |
| Detect & recover | #789 | Stuck PVBs fail at 30m instead of hanging all day |
| Schedule gap | This PR | 3am full + 4am b2 = 1hr gap for cleanup |

Generated with [Claude Code](https://claude.com/claude-code)