### PR TITLE
fix(masters-league): use IfNotPresent pull policy on pinned tag

### DIFF
--- a/clusters/vollminlab-cluster/dmz/masters-league/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/dmz/masters-league/app/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
         - name: masters-league
           image: harbor.vollminlab.com/vollminlab/masters-league:v1.1.1
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000
               protocol: TCP


### PR DESCRIPTION
## Problem

masters-league pods are stuck in `ImagePullBackOff` on the dmz nodes. The deployment pins `:v1.1.1` but uses `imagePullPolicy: Always`, which forces a Harbor manifest check on every pod start. The `v1.1.1` tag in Harbor has incomplete/GC'd blobs, so the check fails with `not found` — even though the `v1.1.1` image is cached locally on **both** dmz nodes (k8sworker05 + k8sworker06).

This surfaced during the node maintenance window: when pods rescheduled off a drained node, `Always` ignored the cache and hard-failed against the broken Harbor tag.

## Fix

Change `imagePullPolicy: Always` → `IfNotPresent`. The kubelet then uses the cached image and the pods start.

`Always` is appropriate for mutable tags (e.g. `latest`); a pinned version tag should be `IfNotPresent`. This both unblocks the deployment and corrects the manifest.

## Not in scope (separate follow-up)

Does **not** repair the broken `v1.1.1` blobs in Harbor. masters-league also has no working image-publish path (CI has never run; no proxy cache for Docker Hub base images). Tracked as a follow-up: stand up a Harbor pull-through cache for Docker Hub, then rebuild + push complete blobs via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)