### PR TITLE
feat(monitoring): N+1 HA capacity alerts for the vSphere cluster

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/vmware-exporter/app/prometheusrule.yaml
+++ b/clusters/vollminlab-cluster/monitoring/vmware-exporter/app/prometheusrule.yaml
@@ -39,6 +39,35 @@ spec:
             summary: "ESXi host {{ $labels.host_name }} memory > 90%"
             description: "{{ $labels.host_name }} memory at {{ $value | printf \"%.0f\" }}% for 15m."
 
+    - name: vmware.capacity
+      rules:
+        # N+1 HA: if any one ESXi host fails, its VMs must fit on the survivors.
+        # Hosts are uniform (~98,033 MB / ~95.7 GiB each), so the requirement is
+        # simply: cluster-wide free memory must stay >= one host's capacity.
+        # Free = sum(max) - sum(usage), divided by 1024 to express in GiB.
+        # Floor 95.7 GiB = one ESXi host. Static per uniform-host spec; bump if
+        # host memory is ever right-sized upward.
+        - alert: VMwareClusterMemoryN1Violation
+          expr: (sum(vmware_host_memory_max) - sum(vmware_host_memory_usage)) / 1024 < 95.7
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "vSphere cluster below N+1 memory headroom"
+            description: "Cluster free memory is {{ $value | printf \"%.1f\" }} GiB; N+1 HA needs >= 95.7 GiB free (one ESXi host's worth) so all VMs survive a single host failure. Right-size workloads or add capacity before the next node-maintenance window."
+
+        # CPU N+1: same principle, one host's CPU (~17,970 MHz / ~18 GHz) must
+        # stay free. CPU overcommit degrades gracefully (scheduling contention),
+        # so this is warning-only, unlike a memory shortfall which risks OOM.
+        - alert: VMwareClusterCPUN1Violation
+          expr: (sum(vmware_host_cpu_max) - sum(vmware_host_cpu_usage)) / 1000 < 18
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "vSphere cluster below N+1 CPU headroom"
+            description: "Cluster free CPU is {{ $value | printf \"%.1f\" }} GHz; N+1 HA needs >= 18 GHz free (one ESXi host's worth) to absorb a single host failure without CPU contention."
+
     - name: vmware.datastores
       rules:
         - alert: DatastoreLowFreeSpace

--- a/clusters/vollminlab-cluster/monitoring/vmware-exporter/app/prometheusrule.yaml
+++ b/clusters/vollminlab-cluster/monitoring/vmware-exporter/app/prometheusrule.yaml
@@ -54,7 +54,7 @@ spec:
             severity: warning
           annotations:
             summary: "vSphere cluster below N+1 memory headroom"
-            description: "Cluster free memory is {{ $value | printf \"%.1f\" }} GiB; N+1 HA needs >= 95.7 GiB free (one ESXi host's worth) so all VMs survive a single host failure. Right-size workloads or add capacity before the next node-maintenance window."
+            description: "Cluster free memory is {{ $value | printf \"%.1f\" }} GiB; N+1 HA needs >= 95.7 GiB free (one ESXi host) to survive a host failure. Right-size or add capacity."
 
         # CPU N+1: same principle, one host's CPU (~17,970 MHz / ~18 GHz) must
         # stay free. CPU overcommit degrades gracefully (scheduling contention),


### PR DESCRIPTION
## What

Two Prometheus alerts that fire when the vSphere cluster drops below **N+1 HA headroom** — i.e. losing a single ESXi host would overcommit the surviving hosts. Added as a new `vmware.capacity` rule group on the existing `vmware-exporter` PrometheusRule.

## Why

Surfaced during 2026-05-30 node-maintenance prep: the cluster is bumping up against its memory N+1 limit, and there's no alert for it. Maintenance that drains/reboots a host assumes the others can absorb the load — this makes that assumption observable.

## Logic

All 3 ESXi hosts are uniform spec, so N+1 reduces to a static floor of **one host's capacity**:

| Alert | Expr (simplified) | Floor | Severity | Live value |
|-------|-------------------|-------|----------|------------|
| `VMwareClusterMemoryN1Violation` | `(sum(host_memory_max) - sum(host_memory_usage)) / 1024 < 95.7` | 95.7 GiB | warning, 15m | **97.6 GiB free** (~1.9 GiB above line) |
| `VMwareClusterCPUN1Violation` | `(sum(host_cpu_max) - sum(host_cpu_usage)) / 1000 < 18` | 18 GHz | warning, 15m | **39.9 GHz free** |

- **Memory is the binding constraint** — only ~1.9 GiB above the floor today, so this is a real early warning. The durable fix is workload right-sizing (tracked separately).
- **CPU is warning-only** — overcommit degrades gracefully (scheduling contention) vs memory OOM; ample headroom today.
- Storage deliberately excluded — datastores are TrueNAS-backed shared disk, already covered by the existing `DatastoreLowFreeSpace` / `CriticalFreeSpace` rules.

## Verification

- Metric units confirmed from live data: memory in **MB**, CPU in **MHz**.
- Both alert expressions evaluated against live Prometheus before commit — correct values, neither firing.
- 15m / warning matches the existing ESXi host rules (avoids flapping during vMotion).

Floors are static per the uniform-host spec; bump them if host memory/CPU is ever right-sized upward (noted in the rule comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)