### PR TITLE
feat(secrets): deploy 1Password Connect + External Secrets Operator (Phase 0)

### DIFF
--- a/clusters/vollminlab-cluster/1password/1password-connect/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/1password/1password-connect/app/configmap.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: onepassword-connect-values
+  namespace: 1password
+  labels:
+    app: onepassword-connect
+    env: production
+    category: security
+data:
+  values.yaml: |
+    commonLabels:
+      app: onepassword-connect
+      env: production
+      category: security
+    connect:
+      credentialsName: onepassword-connect
+      credentialsKey: 1password-credentials.json
+      api:
+        serviceMonitor:
+          enabled: true
+          interval: 30s
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+      sync:
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 50m
+            memory: 64Mi

--- a/clusters/vollminlab-cluster/1password/1password-connect/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/1password/1password-connect/app/helmrelease.yaml
@@ -1,0 +1,23 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: onepassword-connect
+  namespace: 1password
+  labels:
+    app: onepassword-connect
+    env: production
+    category: security
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: connect
+      version: "2.4.1"
+      sourceRef:
+        kind: HelmRepository
+        name: 1password-connect-repo
+        namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: onepassword-connect-values
+      valuesKey: values.yaml

--- a/clusters/vollminlab-cluster/1password/1password-connect/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/1password/1password-connect/app/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: onepassword-connect
+resources:
+  - helmrelease.yaml
+  - configmap.yaml

--- a/clusters/vollminlab-cluster/1password/1password-connect/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/1password/1password-connect/app/kustomization.yaml
@@ -5,3 +5,4 @@ metadata:
 resources:
   - helmrelease.yaml
   - configmap.yaml
+  - networkpolicy.yaml

--- a/clusters/vollminlab-cluster/1password/1password-connect/app/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/1password/1password-connect/app/networkpolicy.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: onepassword-connect
+  namespace: 1password
+  labels:
+    app: onepassword-connect
+    env: production
+    category: security
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: connect
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: external-secrets
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    - ports:
+        - protocol: TCP
+          port: 443
+    - ports:
+        - protocol: TCP
+          port: 53
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system

--- a/clusters/vollminlab-cluster/1password/kustomization.yaml
+++ b/clusters/vollminlab-cluster/1password/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: 1password
+resources:
+  - namespace.yaml
+  - 1password-connect/app

--- a/clusters/vollminlab-cluster/1password/namespace.yaml
+++ b/clusters/vollminlab-cluster/1password/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: 1password
+  labels:
+    app: onepassword-connect
+    env: production
+    category: security

--- a/clusters/vollminlab-cluster/clusterwide/kustomization.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - storageclass-longhorn-dmz.yaml
   - disk-cleanup-rbac.yaml
   - disk-cleanup-cronjob.yaml
+  - onepassword-cluster-store.yaml

--- a/clusters/vollminlab-cluster/clusterwide/onepassword-cluster-store.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/onepassword-cluster-store.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword-cluster-store
+  labels:
+    app: onepassword-cluster-store
+    env: production
+    category: security
+spec:
+  provider:
+    onepassword:
+      connectHost: http://onepassword-connect.1password.svc.cluster.local:8080
+      vaults:
+        Homelab: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect
+            namespace: 1password
+            key: token

--- a/clusters/vollminlab-cluster/external-secrets/external-secrets/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/external-secrets/external-secrets/app/configmap.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: external-secrets-values
+  namespace: external-secrets
+  labels:
+    app: external-secrets
+    env: production
+    category: security
+data:
+  values.yaml: |
+    podLabels:
+      app: external-secrets
+      env: production
+      category: security
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 256Mi
+    webhook:
+      podLabels:
+        app: external-secrets-webhook
+        env: production
+        category: security
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          cpu: 50m
+          memory: 128Mi
+    certController:
+      podLabels:
+        app: external-secrets-cert-controller
+        env: production
+        category: security
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          cpu: 50m
+          memory: 128Mi

--- a/clusters/vollminlab-cluster/external-secrets/external-secrets/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/external-secrets/external-secrets/app/helmrelease.yaml
@@ -1,0 +1,23 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-secrets
+  namespace: external-secrets
+  labels:
+    app: external-secrets
+    env: production
+    category: security
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: external-secrets
+      version: "2.5.0"
+      sourceRef:
+        kind: HelmRepository
+        name: external-secrets-repo
+        namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: external-secrets-values
+      valuesKey: values.yaml

--- a/clusters/vollminlab-cluster/external-secrets/external-secrets/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/external-secrets/external-secrets/app/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: external-secrets-deployment
+resources:
+  - helmrelease.yaml
+  - configmap.yaml

--- a/clusters/vollminlab-cluster/external-secrets/external-secrets/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/external-secrets/external-secrets/app/kustomization.yaml
@@ -5,3 +5,4 @@ metadata:
 resources:
   - helmrelease.yaml
   - configmap.yaml
+  - networkpolicy.yaml

--- a/clusters/vollminlab-cluster/external-secrets/external-secrets/app/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/external-secrets/external-secrets/app/networkpolicy.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: external-secrets
+  namespace: external-secrets
+  labels:
+    app: external-secrets
+    env: production
+    category: security
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: 1password
+      ports:
+        - protocol: TCP
+          port: 8080
+    - ports:
+        - protocol: TCP
+          port: 443
+    - ports:
+        - protocol: TCP
+          port: 6443
+    - ports:
+        - protocol: TCP
+          port: 53
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system

--- a/clusters/vollminlab-cluster/external-secrets/kustomization.yaml
+++ b/clusters/vollminlab-cluster/external-secrets/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: external-secrets
+resources:
+  - namespace.yaml
+  - external-secrets/app

--- a/clusters/vollminlab-cluster/external-secrets/namespace.yaml
+++ b/clusters/vollminlab-cluster/external-secrets/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-secrets
+  labels:
+    app: external-secrets
+    env: production
+    category: security

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/1password-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/1password-kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: 1password
+  namespace: flux-system
+  labels:
+    app: onepassword-connect
+    env: production
+    category: security
+spec:
+  interval: 10m
+  path: ./clusters/vollminlab-cluster/1password
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: 1password
+  timeout: 5m

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/external-secrets-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/external-secrets-kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: external-secrets
+  namespace: flux-system
+  labels:
+    app: external-secrets
+    env: production
+    category: security
+spec:
+  interval: 10m
+  path: ./clusters/vollminlab-cluster/external-secrets
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: external-secrets
+  timeout: 5m
+  dependsOn:
+    - name: 1password

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 metadata:
   name: flux-kustomizations
 resources:
+  - 1password-kustomization.yaml
   - cnpg-system-kustomization.yaml
   - cert-manager-kustomization.yaml
   - clusterwide-kustomization.yaml

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml
@@ -24,6 +24,7 @@ resources:
   - actions-runner-system-kustomization.yaml
   - actions-runner-system-runners-kustomization.yaml
   - external-dns-kustomization.yaml
+  - external-secrets-kustomization.yaml
   - homepage-kustomization.yaml
   - local-path-storage-kustomization.yaml
   - longhorn-system-kustomization.yaml

--- a/clusters/vollminlab-cluster/flux-system/repositories/1password-connect-helmrepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/1password-connect-helmrepository.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: 1password-connect-repo
+  namespace: flux-system
+  labels:
+    app: onepassword-connect
+    env: production
+    category: security
+spec:
+  interval: 1h
+  url: https://1password.github.io/connect-helm-charts/

--- a/clusters/vollminlab-cluster/flux-system/repositories/external-secrets-helmrepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/external-secrets-helmrepository.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: external-secrets-repo
+  namespace: flux-system
+  labels:
+    app: external-secrets
+    env: production
+    category: security
+spec:
+  interval: 1h
+  url: https://charts.external-secrets.io

--- a/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
@@ -7,6 +7,7 @@ metadata:
     env: production
     category: system
 resources:
+  - 1password-connect-helmrepository.yaml
   - arc-controller-ocirepository.yaml
   - arc-runners-ocirepository.yaml
   - audiobookshelf-ocirepository.yaml
@@ -16,6 +17,7 @@ resources:
   - cnpg-helmrepository.yaml
   - descheduler-helmrepository.yaml
   - external-dns-helmrepository.yaml
+  - external-secrets-helmrepository.yaml
   - goldilocks-helmrepository.yaml
   - grafana-helmrepository.yaml
   - harbor-helmrepository.yaml

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-default.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-default.yaml
@@ -51,6 +51,7 @@ spec:
                 - ClusterAdmissionReport
                 - BackgroundScanReport
                 - ClusterBackgroundScanReport
+                - ClusterSecretStore
       validate:
         message: "Do not deploy resources into the 'default' namespace."
         deny: {}

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - alertmanager-pushover-config-sealedsecret.yaml
   - grafana-admin-credentials-sealedsecret.yaml
   - prometheusrule-custom.yaml
+  - prometheusrule-eso.yaml
   - nodes-dashboard-configmap.yaml
   - longhorn-dashboard-configmap.yaml
   - minio-dashboard-configmap.yaml

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-eso.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-eso.yaml
@@ -1,0 +1,30 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: eso-sync-alerts
+  namespace: monitoring
+  labels:
+    app: kube-prometheus-stack
+    env: production
+    category: observability
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: external-secrets
+      rules:
+        - alert: ExternalSecretSyncError
+          expr: externalsecret_status_condition{type="Ready",status="False"} > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "ExternalSecret sync failure"
+            description: "ExternalSecret {{ $labels.name }} in namespace {{ $labels.namespace }} has not synced successfully for 15 minutes."
+        - alert: ExternalSecretSyncErrorCritical
+          expr: externalsecret_status_condition{type="Ready",status="False",namespace=~"authentik|harbor|shlink"} > 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Critical ExternalSecret sync failure in auth-path namespace"
+            description: "ExternalSecret {{ $labels.name }} in {{ $labels.namespace }} has not synced for 5 minutes."


### PR DESCRIPTION
## Summary

- Add HelmRepository sources for `1password/connect` (2.4.1) and `external-secrets/external-secrets` (2.5.0)
- Deploy 1Password Connect Server in new `1password` namespace with in-chart ServiceMonitor
- Deploy External Secrets Operator in new `external-secrets` namespace (depends on `1password`)
- Add `ClusterSecretStore` (`onepassword-cluster-store`) to `clusterwide` kustomization
- Add NetworkPolicies for both namespaces (Connect: egress to 1password.com:443 + ingress from external-secrets; ESO: egress to Connect:8080 + k8s API + DNS)
- Add `PrometheusRule` for ESO sync failure alerting (warning at 15m, critical at 5m for auth-path namespaces)

## ⚠️ Bootstrap requirement — apply secret before merging

The Connect pod needs a secret that cannot be committed to git. Run this **before merging**:

```bash
op signin  # if session expired

CREDS_JSON=$(op item get "Connect Server Credentials" \
  --vault Homelab --format json | python3 -c \
  "import json,sys; d=json.load(sys.stdin); print(next(f['value'] for f in d['fields'] if f['label']=='credentials_json'))")

ESO_TOKEN=$(op item get "Connect Server Credentials" \
  --vault Homelab --format json | python3 -c \
  "import json,sys; d=json.load(sys.stdin); print(next(f['value'] for f in d['fields'] if f['label']=='eso_token'))")

kubectl create namespace 1password --dry-run=client -o yaml | kubectl apply -f -

kubectl create secret generic onepassword-connect \
  -n 1password \
  --from-literal=1password-credentials.json="$CREDS_JSON" \
  --from-literal=token="$ESO_TOKEN" \
  --dry-run=client -o yaml | kubectl apply -f -
```

After merging, verify:
```bash
kubectl get pods -n 1password          # connect Running 2/2
kubectl get pods -n external-secrets   # all Running
kubectl get clustersecretstore onepassword-cluster-store  # READY True
```