### PR TITLE
fix(clusterwide): use external-secrets.io/v1 for ClusterSecretStore

### DIFF
--- a/clusters/vollminlab-cluster/clusterwide/onepassword-cluster-store.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/onepassword-cluster-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: onepassword-cluster-store


### PR DESCRIPTION
## Summary

- `ClusterSecretStore` was created with `apiVersion: external-secrets.io/v1beta1`
- ESO v2.5.0 registers `v1beta1` in the CRD but sets `served: false` — only `v1` is served
- This caused kustomize-controller dry-run to fail: `no matches for kind "ClusterSecretStore" in version "external-secrets.io/v1beta1"`
- Fix: change apiVersion to `external-secrets.io/v1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)