### PR TITLE
fix(external-secrets): add UDP/53 egress for DNS resolution

### DIFF
--- a/clusters/vollminlab-cluster/external-secrets/external-secrets/app/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/external-secrets/external-secrets/app/networkpolicy.yaml
@@ -26,6 +26,8 @@ spec:
         - protocol: TCP
           port: 6443
     - ports:
+        - protocol: UDP
+          port: 53
         - protocol: TCP
           port: 53
       to:


### PR DESCRIPTION
## Summary

- ESO NetworkPolicy only allowed `TCP/53` egress to `kube-system`
- DNS uses `UDP/53` by default — CoreDNS was unreachable from ESO pods
- Result: `i/o timeout` on every DNS lookup for `onepassword-connect.1password.svc.cluster.local`
- Fix: add `UDP/53` alongside the existing `TCP/53` rule

Root cause of earlier nil-pointer panics in `findItem`: the DNS timeout on the first HTTP request caused an unexpected nil response path in the Connect SDK before proper error handling took over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)