### PR TITLE
fix(netpol): add UDP/53 for Connect DNS; remove unused TCP/443 from ESO

### DIFF
--- a/clusters/vollminlab-cluster/1password/1password-connect/app/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/1password/1password-connect/app/networkpolicy.yaml
@@ -27,6 +27,8 @@ spec:
         - protocol: TCP
           port: 443
     - ports:
+        - protocol: UDP
+          port: 53
         - protocol: TCP
           port: 53
       to:

--- a/clusters/vollminlab-cluster/external-secrets/external-secrets/app/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/external-secrets/external-secrets/app/networkpolicy.yaml
@@ -21,9 +21,6 @@ spec:
           port: 8080
     - ports:
         - protocol: TCP
-          port: 443
-    - ports:
-        - protocol: TCP
           port: 6443
     - ports:
         - protocol: UDP


### PR DESCRIPTION
## Summary

Two NetworkPolicy corrections found during security review:

**`1password/onepassword-connect`** — add `UDP/53` to kube-system DNS egress
- DNS uses UDP by default; only `TCP/53` was permitted
- The `connect-sync` container needs DNS to resolve `my.1password.com` for vault sync
- Currently appears to work due to startup-time DNS caching (race before policy takes effect), but fails on pod restart

**`external-secrets/external-secrets`** — remove unrestricted `TCP/443` egress
- ESO only needs: `TCP/8080` → 1Password Connect, `TCP/6443` → Kubernetes API, `UDP+TCP/53` → CoreDNS
- ESO never calls external HTTPS directly (all provider communication goes through the Connect server)
- Removing this closes an unnecessary outbound internet hole

🤖 Generated with [Claude Code](https://claude.com/claude-code)