### PR TITLE
docs: ESO migration prep — token rotation runbook, CNPG rotation runbook, vault naming rules

### DIFF
--- a/.claude/rules/secrets.md
+++ b/.claude/rules/secrets.md
@@ -126,3 +126,14 @@ extraEnv:
 Examples: `harbor-db-credentials`, `renovate-token`, `alertmanager-pushover-config`
 
 Wrong: `harbor-admin-sealedsecret.yaml` containing `metadata.name: harbor-admin-credentials` — the base (`harbor-admin`) doesn't match the name (`harbor-admin-credentials`).
+
+## 1Password vault item naming — cluster infrastructure
+
+After ESO migration, vault item names and field labels are cluster infrastructure:
+
+- Never rename a vault item referenced by an ExternalSecret without first updating the
+  ExternalSecret CR and merging the PR
+- Field label names are locked — use: `username`, `password`, `api_key`, `token`,
+  `credentials_json`, `access_key_id`, `secret_access_key`, `dockerconfigjson`
+- Procedure: update ExternalSecret CR → merge PR → Flux reconciles → verify Ready → rename in 1Password
+- Note on vault items: add "Referenced by ExternalSecret — do not rename fields" to item notes

--- a/docs/runbooks/cnpg-password-rotation.md
+++ b/docs/runbooks/cnpg-password-rotation.md
@@ -1,0 +1,34 @@
+# CNPG Password Rotation
+
+CNPG ExternalSecrets use `refreshInterval: "0"` (create-once). Rotation is coordinated.
+
+## Procedure
+
+1. Update the password in 1Password vault item (field: `password`).
+
+2. Force one ESO sync:
+   ```bash
+   kubectl patch externalsecret <name> -n <namespace> \
+     --type=merge -p '{"spec":{"refreshInterval":"1s"}}'
+   ```
+
+3. Confirm sync completed (check Ready=True, last sync timestamp updated):
+   ```bash
+   kubectl get externalsecret <name> -n <namespace> -o wide
+   ```
+
+4. IMMEDIATELY reset to prevent continuous re-sync:
+   ```bash
+   kubectl patch externalsecret <name> -n <namespace> \
+     --type=merge -p '{"spec":{"refreshInterval":"0"}}'
+   ```
+
+5. Rotate the password in the database:
+   ```bash
+   kubectl cnpg psql <cluster-name> -n <namespace>
+   # In psql: ALTER ROLE <username> WITH PASSWORD '<new-password>';
+   # Verify: \du
+   # Exit: \q
+   ```
+
+6. Verify app connectivity (check app logs for auth errors).

--- a/docs/runbooks/eso-token-rotation.md
+++ b/docs/runbooks/eso-token-rotation.md
@@ -1,0 +1,41 @@
+# ESO Token Rotation
+
+Use when the ESO access token needs to be rotated (compromise, periodic rotation).
+
+## Procedure
+
+1. Sign in: `op signin`
+
+2. List current tokens to find the token ID:
+   ```bash
+   op connect token list --server "vollminlab-k8s"
+   ```
+
+3. Create a new token:
+   ```bash
+   op connect token create "eso-access-token" --server "vollminlab-k8s" --vaults Homelab
+   # Copy the new token value
+   ```
+
+4. Update the vault item:
+   ```bash
+   op item edit "Connect Server Credentials" --vault Homelab "eso_token[concealed]=<new-token>"
+   ```
+
+5. Update the cluster secret:
+   ```bash
+   kubectl create secret generic onepassword-connect -n 1password \
+     --from-literal=token="<new-token>" \
+     --dry-run=client -o yaml | kubectl apply -f -
+   ```
+
+6. Verify ESO reconnects:
+   ```bash
+   kubectl get clustersecretstore onepassword-cluster-store
+   # Status should return to Ready within 30s
+   ```
+
+7. Revoke the old token:
+   ```bash
+   op connect token revoke --server "vollminlab-k8s" --token <old-token-id>
+   ```


### PR DESCRIPTION
## Summary

- Add `docs/runbooks/eso-token-rotation.md` — step-by-step procedure for rotating the ESO Connect access token (create new → update vault item → patch cluster secret → verify → revoke old)
- Add `docs/runbooks/cnpg-password-rotation.md` — coordinated CNPG password rotation via ESO `refreshInterval` patch, database ALTER ROLE, and immediate reset to `"0"`
- Append vault naming discipline section to `.claude/rules/secrets.md` — locks down 1Password item names and field labels as cluster infrastructure once referenced by an ExternalSecret CR

Part of the 1Password ESO integration (Task 8: Pre-Migration Preparation). Phase 0 infrastructure is complete and verified (PRs #814–817).

**Vault item audit results for Phase 1 (monitoring namespace):**

All secrets exist in the Homelab vault but under different names than the plan assumed. Field mapping for Task 9:

| K8s secret | Vault item | Field mapping |
|---|---|---|
| `grafana-admin-credentials` | `Grafana Admin Password` | `username`→`admin-user`, `password`→`admin-password` |
| `alertmanager-pushover-config` | `Pushover` (userKey+credential) | Requires ExternalSecret templating to build `alertmanager.yaml` |
| `loki-minio-credentials` | `loki - Minio` | `accessKey`→`access-key`, `credential`→`secret-key` |
| `b2-exporter-credentials` | `Backblaze B2 Homepage Exporter` | `keyID`→`B2_APPLICATION_KEY_ID`, `credential`→`B2_APPLICATION_KEY`; `B2_BUCKET_NAME` needs to be added to vault item |
| `vmware-exporter-credentials` | `vCenter Metrics` | Requires ExternalSecret templating to build `helm-values.yaml` |
| `harbor-vollminlab-pull` | `Harbor Cluster Pull Robot Account` | Requires dockerconfig assembly from `username`+`password` |