### PR TITLE
fix(eso): use creationPolicy Owner for jellystat-db-credentials

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/jellystat-db/app/jellystat-db-credentials-externalsecret.yaml
+++ b/clusters/vollminlab-cluster/mediastack/jellystat-db/app/jellystat-db-credentials-externalsecret.yaml
@@ -14,7 +14,7 @@ spec:
     kind: ClusterSecretStore
   target:
     name: jellystat-db-credentials
-    creationPolicy: Merge
+    creationPolicy: Owner
   data:
     - secretKey: username
       remoteRef:


### PR DESCRIPTION
## Summary

- Changes `creationPolicy` from `Merge` to `Owner` in `jellystat-db-credentials-externalsecret.yaml`
- `Merge` policy requires the Secret to already exist — ESO will only inject fields into it, never create it from scratch
- CNPG only *reads* `jellystat-db-credentials` during cluster bootstrap (`spec.bootstrap.initdb.secret.name`); it does not write to this Secret
- After PR #821 merged and the old SealedSecret was removed, the Secret was missing and `Merge` policy left it in `SecretMissing` state
- Live cluster was patched via `kubectl patch` immediately after discovery; this PR reconciles git with the running state

🤖 Generated with [Claude Code](https://claude.com/claude-code)