### PR TITLE
fix(eso): use creationPolicy Owner for authentik-db-credentials

### DIFF
--- a/clusters/vollminlab-cluster/authentik/cnpg/app/authentik-db-credentials-externalsecret.yaml
+++ b/clusters/vollminlab-cluster/authentik/cnpg/app/authentik-db-credentials-externalsecret.yaml
@@ -14,7 +14,7 @@ spec:
     kind: ClusterSecretStore
   target:
     name: authentik-db-credentials
-    creationPolicy: Merge
+    creationPolicy: Owner
   data:
     - secretKey: username
       remoteRef:


### PR DESCRIPTION
## Summary

- `authentik-db-credentials` was a SealedSecret-owned secret, not CNPG-managed
- PR #828 deleted the SealedSecret; `creationPolicy: Merge` cannot recreate a missing secret, only merge into one that already exists
- Authentik pods are currently running (cached connection), but will fail to start on next restart without this secret
- Fix: `creationPolicy: Owner` so ESO creates the secret from the 1Password vault item

**Root cause:** The migration plan noted "confirm before migrating" on this secret's CNPG classification — it was not actually CNPG-managed.