### PR TITLE
feat(victoriametrics): long-term metrics store + remote_write + datasource swap

### DIFF
--- a/clusters/vollminlab-cluster/clusterwide/kustomization.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - pv-tv.yaml
   - storageclass-smb.yaml
   - storageclass-longhorn-dmz.yaml
+  - storageclass-longhorn-r2.yaml
   - disk-cleanup-rbac.yaml
   - disk-cleanup-cronjob.yaml
   - onepassword-cluster-store.yaml

--- a/clusters/vollminlab-cluster/clusterwide/storageclass-longhorn-r2.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/storageclass-longhorn-r2.yaml
@@ -1,0 +1,18 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-r2
+  labels:
+    app: storageclass-longhorn-r2
+    env: production
+    category: storage
+provisioner: driver.longhorn.io
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  numberOfReplicas: "2"
+  dataLocality: "best-effort"
+  staleReplicaTimeout: "30"
+  fromBackup: ""
+  fsType: "ext4"

--- a/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
@@ -50,6 +50,7 @@ resources:
   - tofu-controller-helmrepository.yaml
   - trivy-operator-helmrepository.yaml
   - velero-helmrepository.yaml
+  - victoria-metrics-helmrepository.yaml
   - vmware-exporter-helmrepository.yaml
   - volsync-helmrepository.yaml
   - harbor-vollminlab-pull-externalsecret.yaml

--- a/clusters/vollminlab-cluster/flux-system/repositories/victoria-metrics-helmrepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/victoria-metrics-helmrepository.yaml
@@ -1,0 +1,13 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: victoria-metrics-repo
+  namespace: flux-system
+  labels:
+    app: victoria-metrics
+    env: production
+    category: observability
+spec:
+  interval: 5m
+  url: https://victoriametrics.github.io/helm-charts/
+  timeout: 3m

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -17,6 +17,8 @@ data:
         scrapeInterval: 30s
         retention: 7d
         retentionSize: 3GB
+        remoteWrite:
+          - url: http://victoria-metrics-single-server.monitoring.svc.cluster.local:8428/api/v1/write
         serviceMonitorSelectorNilUsesHelmValues: false
         serviceMonitorSelector: {}
         serviceMonitorNamespaceSelector: {}
@@ -79,7 +81,26 @@ data:
         accessModes:
           - ReadWriteOnce
 
+      sidecar:
+        datasources:
+          defaultDatasourceEnabled: false
       additionalDataSources:
+        - name: VictoriaMetrics
+          type: prometheus
+          uid: prometheus
+          access: proxy
+          url: http://victoria-metrics-single-server.monitoring.svc.cluster.local:8428
+          isDefault: true
+          jsonData:
+            timeInterval: 30s
+        - name: Prometheus (live)
+          type: prometheus
+          uid: prometheus-live
+          access: proxy
+          url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+          isDefault: false
+          jsonData:
+            timeInterval: 30s
         - name: Loki
           type: loki
           url: http://loki.monitoring.svc.cluster.local:3100

--- a/clusters/vollminlab-cluster/monitoring/kustomization.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - kube-prometheus-stack/app
   - loki/app
   - promtail/app
+  - victoria-metrics/app

--- a/clusters/vollminlab-cluster/monitoring/victoria-metrics/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/victoria-metrics/app/configmap.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: victoria-metrics-values
+  namespace: monitoring
+  labels:
+    app: victoria-metrics
+    env: production
+    category: observability
+data:
+  values.yaml: |
+    # Stable service name -> victoria-metrics-single-server.monitoring.svc:8428
+    fullnameOverride: victoria-metrics-single
+
+    server:
+      retentionPeriod: 90d
+
+      # StatefulSet (not Deployment) so the RWO Longhorn volume is handled via a
+      # volumeClaimTemplate and there is no rolling-update detach trap.
+      statefulSet:
+        enabled: true
+
+      persistentVolume:
+        enabled: true
+        storageClassName: longhorn-r2
+        accessModes:
+          - ReadWriteOnce
+        size: 30Gi
+
+      podLabels:
+        app: victoria-metrics
+        env: production
+        category: observability
+
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: "1"
+          memory: 1Gi

--- a/clusters/vollminlab-cluster/monitoring/victoria-metrics/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/victoria-metrics/app/configmap.yaml
@@ -15,10 +15,9 @@ data:
     server:
       retentionPeriod: 90d
 
-      # StatefulSet (not Deployment) so the RWO Longhorn volume is handled via a
+      # mode: statefulSet (not deployment) so the RWO Longhorn volume is handled via a
       # volumeClaimTemplate and there is no rolling-update detach trap.
-      statefulSet:
-        enabled: true
+      mode: statefulSet
 
       persistentVolume:
         enabled: true

--- a/clusters/vollminlab-cluster/monitoring/victoria-metrics/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/monitoring/victoria-metrics/app/helmrelease.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: victoria-metrics
+  namespace: monitoring
+  labels:
+    app: victoria-metrics
+    env: production
+    category: observability
+spec:
+  interval: 5m
+  releaseName: victoria-metrics
+  chart:
+    spec:
+      chart: victoria-metrics-single
+      version: 0.39.0
+      sourceRef:
+        kind: HelmRepository
+        name: victoria-metrics-repo
+        namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: victoria-metrics-values
+      valuesKey: values.yaml

--- a/clusters/vollminlab-cluster/monitoring/victoria-metrics/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/monitoring/victoria-metrics/app/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+  - helmrelease.yaml

--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -196,3 +196,16 @@ data:
           resourcePolicy:
             kind: ConfigMap
             name: velero-skip-smb-policy
+      victoria-metrics-b2:
+        disabled: false
+        schedule: "0 5 * * *"
+        useOwnerReferencesInBackup: false
+        template:
+          ttl: 2160h
+          storageLocation: b2
+          defaultVolumesToFsBackup: true
+          includedNamespaces:
+            - monitoring
+          labelSelector:
+            matchLabels:
+              app: victoria-metrics

--- a/docs/superpowers/plans/victoriametrics-longterm.md
+++ b/docs/superpowers/plans/victoriametrics-longterm.md
@@ -1,0 +1,497 @@
+# VictoriaMetrics Long-Term Metrics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an in-cluster single-node VictoriaMetrics as a long-term (90d), compressed, PromQL-native store that Prometheus `remote_write`s to, so Prometheus local retention can drop to 24h — restoring long-term metrics history while *reducing* the metrics stack's memory footprint.
+
+**Architecture:** Prometheus stays the sole scraper/alerter (24h local) and `remote_write`s every sample to VictoriaMetrics single (90d, 30Gi/2-replica Longhorn). Grafana's `prometheus` datasource UID is re-pointed at VM so all existing dashboards read full history with zero edits; the real Prometheus is kept as a secondary "Prometheus (live)" datasource. A dedicated Velero `Schedule` archives the VM PVC to the existing B2 BSL daily.
+
+**Tech Stack:** Flux CD, Helm (`victoria-metrics-single` chart v0.39.0), kube-prometheus-stack, Longhorn, Velero, Grafana.
+
+**Spec:** `docs/superpowers/specs/victoriametrics-longterm-design.md`
+
+**Repo conventions:** This is a GitOps repo with **no unit-test runner**. "Validation" for each task means the manifest renders (`kubectl kustomize <dir>`) and follows `.claude/rules/flux.md` + `kyverno.md`; correctness is confirmed async via Flux reconciliation after merge. Never `kubectl apply` under `clusters/`. Never push to `main` — PR only.
+
+**Two PRs:**
+- **PR #1 (this branch `feat/victoriametrics-longterm`):** Tasks 1–7 — deploy VM, remote_write, datasource swap, Velero backup. Prometheus retention stays 7d.
+- **PR #2 (separate branch, after PR #1 verified):** Task 8 — drop Prometheus retention to 24h.
+
+---
+
+### Task 1: VictoriaMetrics HelmRepository source
+
+**Files:**
+- Create: `clusters/vollminlab-cluster/flux-system/repositories/victoria-metrics-helmrepository.yaml`
+- Modify: `clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml`
+
+- [ ] **Step 1: Verify the chart version exists before pinning it**
+
+Run:
+```bash
+helm repo add vm https://victoriametrics.github.io/helm-charts/ 2>/dev/null; helm repo update vm >/dev/null
+helm search repo vm/victoria-metrics-single --versions | head -5
+```
+Expected: a row for `vm/victoria-metrics-single` with chart version `0.39.0` (or newer). If `0.39.0` is gone, pick the latest listed stable version and use it everywhere `0.39.0` appears in this plan.
+
+- [ ] **Step 2: Create the HelmRepository**
+
+`clusters/vollminlab-cluster/flux-system/repositories/victoria-metrics-helmrepository.yaml`:
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: victoria-metrics-repo
+  namespace: flux-system
+  labels:
+    app: victoria-metrics
+    env: production
+    category: observability
+spec:
+  interval: 5m
+  url: https://victoriametrics.github.io/helm-charts/
+  timeout: 3m
+```
+
+- [ ] **Step 3: Register it in the repositories index (keep alphabetical)**
+
+In `clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml`, add the line between `velero-helmrepository.yaml` and `vmware-exporter-helmrepository.yaml`:
+```yaml
+  - velero-helmrepository.yaml
+  - victoria-metrics-helmrepository.yaml
+  - vmware-exporter-helmrepository.yaml
+```
+
+- [ ] **Step 4: Validate render**
+
+Run: `kubectl kustomize clusters/vollminlab-cluster/flux-system/repositories/ >/dev/null && echo OK`
+Expected: `OK` (no error), and the rendered output contains `victoria-metrics-repo`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clusters/vollminlab-cluster/flux-system/repositories/victoria-metrics-helmrepository.yaml \
+        clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
+git commit -m "feat(victoriametrics): add victoria-metrics HelmRepository source"
+```
+
+---
+
+### Task 2: `longhorn-r2` StorageClass (2-replica, general workers)
+
+The default `longhorn` SC is 3-replica; `longhorn-dmz` is 2-replica but pinned to DMZ nodes. VM needs a 2-replica SC that spreads across general workers.
+
+**Files:**
+- Create: `clusters/vollminlab-cluster/clusterwide/storageclass-longhorn-r2.yaml`
+- Modify: `clusters/vollminlab-cluster/clusterwide/kustomization.yaml`
+
+- [ ] **Step 1: Create the StorageClass** (mirrors `storageclass-longhorn-dmz.yaml` minus the `nodeSelector`)
+
+`clusters/vollminlab-cluster/clusterwide/storageclass-longhorn-r2.yaml`:
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-r2
+  labels:
+    app: storageclass-longhorn-r2
+    env: production
+    category: storage
+provisioner: driver.longhorn.io
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  numberOfReplicas: "2"
+  dataLocality: "best-effort"
+  staleReplicaTimeout: "30"
+  fromBackup: ""
+  fsType: "ext4"
+```
+
+- [ ] **Step 2: Register it in the clusterwide index**
+
+In `clusters/vollminlab-cluster/clusterwide/kustomization.yaml`, add after `storageclass-longhorn-dmz.yaml`:
+```yaml
+  - storageclass-longhorn-dmz.yaml
+  - storageclass-longhorn-r2.yaml
+```
+
+- [ ] **Step 3: Validate render**
+
+Run: `kubectl kustomize clusters/vollminlab-cluster/clusterwide/ >/dev/null && echo OK`
+Expected: `OK`, rendered output contains `longhorn-r2` with `numberOfReplicas: "2"`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add clusters/vollminlab-cluster/clusterwide/storageclass-longhorn-r2.yaml \
+        clusters/vollminlab-cluster/clusterwide/kustomization.yaml
+git commit -m "feat(storage): add longhorn-r2 2-replica StorageClass for general workers"
+```
+
+---
+
+### Task 3: VictoriaMetrics app (HelmRelease + values)
+
+**Files:**
+- Create: `clusters/vollminlab-cluster/monitoring/victoria-metrics/app/helmrelease.yaml`
+- Create: `clusters/vollminlab-cluster/monitoring/victoria-metrics/app/configmap.yaml`
+- Create: `clusters/vollminlab-cluster/monitoring/victoria-metrics/app/kustomization.yaml`
+- Modify: `clusters/vollminlab-cluster/monitoring/kustomization.yaml`
+
+No SealedSecret/ExternalSecret is needed — backups go through Velero (Task 5), reusing existing credentials.
+
+- [ ] **Step 1: Create the values ConfigMap**
+
+`clusters/vollminlab-cluster/monitoring/victoria-metrics/app/configmap.yaml`:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: victoria-metrics-values
+  namespace: monitoring
+  labels:
+    app: victoria-metrics
+    env: production
+    category: observability
+data:
+  values.yaml: |
+    # Stable service name -> victoria-metrics-single-server.monitoring.svc:8428
+    fullnameOverride: victoria-metrics-single
+
+    server:
+      retentionPeriod: 90d
+
+      # StatefulSet (not Deployment) so the RWO Longhorn volume is handled via a
+      # volumeClaimTemplate and there is no rolling-update detach trap.
+      statefulSet:
+        enabled: true
+
+      persistentVolume:
+        enabled: true
+        storageClassName: longhorn-r2
+        accessModes:
+          - ReadWriteOnce
+        size: 30Gi
+
+      podLabels:
+        app: victoria-metrics
+        env: production
+        category: observability
+
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: "1"
+          memory: 1Gi
+```
+
+- [ ] **Step 2: Create the HelmRelease**
+
+`clusters/vollminlab-cluster/monitoring/victoria-metrics/app/helmrelease.yaml`:
+```yaml
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: victoria-metrics
+  namespace: monitoring
+  labels:
+    app: victoria-metrics
+    env: production
+    category: observability
+spec:
+  interval: 5m
+  releaseName: victoria-metrics
+  chart:
+    spec:
+      chart: victoria-metrics-single
+      version: 0.39.0
+      sourceRef:
+        kind: HelmRepository
+        name: victoria-metrics-repo
+        namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: victoria-metrics-values
+      valuesKey: values.yaml
+```
+
+- [ ] **Step 3: Create the app kustomization**
+
+`clusters/vollminlab-cluster/monitoring/victoria-metrics/app/kustomization.yaml`:
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+  - helmrelease.yaml
+```
+
+- [ ] **Step 4: Wire the app into the monitoring namespace**
+
+In `clusters/vollminlab-cluster/monitoring/kustomization.yaml`, add `- victoria-metrics/app` to `resources` (after `promtail/app`):
+```yaml
+  - promtail/app
+  - victoria-metrics/app
+```
+
+- [ ] **Step 5: Validate render**
+
+Run: `kubectl kustomize clusters/vollminlab-cluster/monitoring/ >/dev/null && echo OK`
+Expected: `OK`. Then confirm the values ConfigMap and HelmRelease are present:
+`kubectl kustomize clusters/vollminlab-cluster/monitoring/ | grep -E 'victoria-metrics-values|kind: HelmRelease' | head`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add clusters/vollminlab-cluster/monitoring/victoria-metrics/ \
+        clusters/vollminlab-cluster/monitoring/kustomization.yaml
+git commit -m "feat(victoriametrics): deploy single-node VictoriaMetrics (90d, 30Gi/2-replica)"
+```
+
+---
+
+### Task 4: Prometheus remote_write + Grafana datasource swap
+
+Edit the kube-prometheus-stack values ConfigMap: add remote_write to VM, and replace the auto-provisioned Prometheus datasource with VM-as-`prometheus` (default) + Prometheus-as-`prometheus-live` (secondary). Loki stays. **Prometheus retention stays `7d` in this PR.**
+
+**Files:**
+- Modify: `clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml`
+
+- [ ] **Step 1: Add `remoteWrite` under `prometheus.prometheusSpec`**
+
+In `configmap.yaml`, immediately after the `retention`/`retentionSize` lines inside `prometheusSpec`, add:
+```yaml
+        remoteWrite:
+          - url: http://victoria-metrics-single-server.monitoring.svc.cluster.local:8428/api/v1/write
+```
+(Indentation: `remoteWrite` aligns with `retention:` — 8 spaces under `prometheusSpec:`.)
+
+- [ ] **Step 2: Replace the Grafana `additionalDataSources` block and disable the default datasource**
+
+Find the existing `grafana:` → `additionalDataSources:` block (currently just Loki) and replace it with the block below, and add the `sidecar.datasources.defaultDatasourceEnabled: false` setting under `grafana:`:
+```yaml
+      sidecar:
+        datasources:
+          defaultDatasourceEnabled: false
+
+      additionalDataSources:
+        - name: VictoriaMetrics
+          type: prometheus
+          uid: prometheus
+          access: proxy
+          url: http://victoria-metrics-single-server.monitoring.svc.cluster.local:8428
+          isDefault: true
+          jsonData:
+            timeInterval: 30s
+        - name: Prometheus (live)
+          type: prometheus
+          uid: prometheus-live
+          access: proxy
+          url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+          isDefault: false
+          jsonData:
+            timeInterval: 30s
+        - name: Loki
+          type: loki
+          url: http://loki.monitoring.svc.cluster.local:3100
+          access: proxy
+```
+Notes:
+- `uid: prometheus` is the UID every existing dashboard pins, so VM transparently serves them.
+- `timeInterval: 30s` matches `scrapeInterval` so rate() windows render correctly.
+- If `grafana:` already has a `sidecar:` key, merge `datasources.defaultDatasourceEnabled: false` into it rather than adding a second `sidecar:`.
+
+- [ ] **Step 3: Validate render**
+
+Run: `kubectl kustomize clusters/vollminlab-cluster/monitoring/ >/dev/null && echo OK`
+Expected: `OK`. Confirm both datasource UIDs and the remote_write URL appear:
+`kubectl kustomize clusters/vollminlab-cluster/monitoring/ | grep -E 'prometheus-live|api/v1/write|defaultDatasourceEnabled'`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+git commit -m "feat(victoriametrics): remote_write Prometheus to VM and point Grafana at VM"
+```
+
+---
+
+### Task 5: Velero backup Schedule for the VM PVC → B2
+
+Add a dedicated `Schedule` scoped to only the VM volume, overriding the blanket `monitoring` exclusion on the existing schedules.
+
+**Files:**
+- Modify: `clusters/vollminlab-cluster/velero/velero/app/configmap.yaml`
+
+- [ ] **Step 1: Add the `victoria-metrics-b2` schedule**
+
+In the `schedules:` map (after the `monthly-b2:` block), add:
+```yaml
+      victoria-metrics-b2:
+        disabled: false
+        schedule: "0 5 * * *"
+        useOwnerReferencesInBackup: false
+        template:
+          ttl: 2160h
+          storageLocation: b2
+          defaultVolumesToFsBackup: true
+          includedNamespaces:
+            - monitoring
+          labelSelector:
+            matchLabels:
+              app: victoria-metrics
+```
+This captures only pods/PVCs labelled `app: victoria-metrics` (the VM pod via `server.podLabels`), so Prometheus/Loki volumes stay excluded. `ttl: 2160h` ≈ 90 days, matching `daily-b2`.
+
+- [ ] **Step 2: Validate render**
+
+Run: `kubectl kustomize clusters/vollminlab-cluster/velero/velero/app/ >/dev/null && echo OK`
+Expected: `OK`. Confirm the schedule is present:
+`kubectl kustomize clusters/vollminlab-cluster/velero/velero/app/ | grep -A2 victoria-metrics-b2`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+git commit -m "feat(victoriametrics): add Velero daily B2 backup schedule for VM PVC"
+```
+
+---
+
+### Task 6: Push branch and open PR #1
+
+- [ ] **Step 1: Push and open the PR**
+
+```bash
+git push -u origin feat/victoriametrics-longterm
+gh pr create --title "feat(victoriametrics): long-term metrics store + remote_write + datasource swap" \
+  --body "Deploys single-node VictoriaMetrics (90d, 30Gi/2-replica longhorn-r2), points Prometheus remote_write at it, re-points Grafana's prometheus datasource UID at VM (Prometheus kept as 'Prometheus (live)'), and adds a Velero B2 backup schedule scoped to the VM PVC. Prometheus retention stays 7d — the 24h cutover is a follow-up PR after VM ingestion is verified. Spec: docs/superpowers/specs/victoriametrics-longterm-design.md.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 2: Wait for CI**
+
+Run: `gh pr checks --watch`
+Expected: kyverno-cli test, Validate Terraform Modules (n/a), and Secret Scanning all pass. Fix any kyverno label/resource-limit failures before requesting merge. **Do not merge** — merging requires explicit user instruction.
+
+---
+
+### Task 7: Post-merge verification (after PR #1 merges)
+
+Run after Flux reconciles (~10m), or `flux reconcile kustomization monitoring --with-source`.
+
+- [ ] **Step 1: VM is healthy and the service name matches the remote_write URL**
+
+```bash
+flux get helmrelease victoria-metrics -n monitoring         # Ready=True
+kubectl get pods -n monitoring -l app=victoria-metrics      # Running
+kubectl get svc -n monitoring | grep victoria-metrics
+```
+Expected: a service named `victoria-metrics-single-server` on port 8428. **If the service name differs**, update the `remoteWrite` URL and the VictoriaMetrics datasource URL in `kube-prometheus-stack/app/configmap.yaml` to match, in a quick fix PR.
+
+- [ ] **Step 2: VM is ingesting remote_write samples**
+
+```bash
+VM=$(kubectl get pod -n monitoring -l app=victoria-metrics -o name | head -1)
+kubectl exec -n monitoring ${VM#pod/} -- wget -qO- \
+  'http://localhost:8428/api/v1/query?query=vm_rows_inserted_total' | head -c 300
+```
+Expected: a non-empty JSON result with a growing value (re-run; it should increase).
+
+- [ ] **Step 3: Prometheus remote_write queue is healthy** (Grafana Explore → "Prometheus (live)", or):
+
+```
+PromQL: rate(prometheus_remote_storage_samples_failed_total[5m])   # expect 0
+PromQL: prometheus_remote_storage_samples_pending                  # expect small/stable
+```
+
+- [ ] **Step 4: Dashboards read VM (full history) with no edits**
+
+In Grafana, open an existing dashboard (e.g. MinIO). Confirm: datasource list shows **VictoriaMetrics** (default), **Prometheus (live)**, **Loki**; and panels render for a range **older than 24h** once VM has accumulated that much — proving they hit VM, not Prometheus.
+
+- [ ] **Step 5: Alerting unaffected** (VM is not in the alert path)
+
+```bash
+kubectl get prometheusrules -n monitoring | head
+# In Alertmanager UI, confirm alerts still flow; no PrometheusRule errors in Prometheus UI → Status → Rules.
+```
+
+- [ ] **Step 6: First Velero VM backup succeeds** (after the 5am run, or trigger once):
+
+```bash
+kubectl get schedules.velero.io -n velero | grep victoria-metrics-b2
+kubectl get backups.velero.io -n velero -l velero.io/schedule-name=victoria-metrics-b2 \
+  --sort-by=.metadata.creationTimestamp \
+  -o custom-columns='NAME:.metadata.name,PHASE:.status.phase,ERRORS:.status.errors'
+```
+Expected: latest backup `Completed`, 0 errors. Confirm it captured a volume (not empty) via `velero backup describe <name> --details`.
+
+---
+
+### Task 8: Prometheus retention cutover to 24h (PR #2 — separate branch, after Task 7 passes)
+
+Only start this once Task 7 confirms VM is ingesting and dashboards read from it.
+
+**Files:**
+- Modify: `clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml`
+
+- [ ] **Step 1: New branch off fresh main**
+
+```bash
+git -C /home/vollmin/repos/vollminlab/k8s-vollminlab-cluster checkout main
+git -C /home/vollmin/repos/vollminlab/k8s-vollminlab-cluster pull
+git -C /home/vollmin/repos/vollminlab/k8s-vollminlab-cluster checkout -b feat/prometheus-24h-retention
+```
+
+- [ ] **Step 2: Drop retention to 24h**
+
+In `prometheus.prometheusSpec`, change:
+```yaml
+        retention: 7d
+        retentionSize: 3GB
+```
+to:
+```yaml
+        retention: 24h
+```
+(Remove `retentionSize` — at 24h the size cap is unnecessary. Leave the 20Gi PVC as-is; Longhorn can't shrink it and it simply won't fill.)
+
+- [ ] **Step 3: Optionally lower the Prometheus memory request/limit**
+
+Now that local TSDB holds only 24h, re-measure live usage first:
+```bash
+kubectl top pod -n monitoring -l app.kubernetes.io/name=prometheus
+```
+If steady-state RSS is well under the current `1500Mi` request, lower `prometheus.prometheusSpec.resources.requests.memory` (e.g. to `512Mi`) and `limits.memory` (e.g. `1Gi`) in the same PR. If unsure, leave resources unchanged and tune in a later PR.
+
+- [ ] **Step 4: Validate, commit, PR**
+
+```bash
+kubectl kustomize clusters/vollminlab-cluster/monitoring/ >/dev/null && echo OK
+git add clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+git commit -m "feat(prometheus): drop local retention to 24h now that VM holds history"
+git push -u origin feat/prometheus-24h-retention
+gh pr create --title "feat(prometheus): cut local retention to 24h (VM holds long-term)" \
+  --body "Follow-up to the VictoriaMetrics PR. VM ingestion + dashboard reads verified, so Prometheus local retention drops to 24h (enough for alerting/rule eval), reclaiming worker memory. Long-term history now lives in VM.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 5: Post-merge — confirm the memory win**
+
+```bash
+kubectl top pod -n monitoring -l app.kubernetes.io/name=prometheus
+```
+Expected: Prometheus RSS drops materially versus the pre-cutover baseline; dashboards still render full history (now served entirely by VM beyond 24h).
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** chart shape (Task 3), remote_write topology (Task 4), datasource swap (Task 4), PVC/replicas (Tasks 2–3), Velero backup (Task 5), two-stage cutover (Tasks 6–8) — all covered.
+- **No new secrets:** the Velero backup decision removed the B2-bucket/1Password/ExternalSecret prerequisite entirely.
+- **Build-time check retained:** the exact VM service name is verified post-deploy in Task 7 Step 1 with a concrete fix path, because it can't be confirmed before the chart renders in-cluster.

--- a/docs/superpowers/specs/victoriametrics-longterm-design.md
+++ b/docs/superpowers/specs/victoriametrics-longterm-design.md
@@ -1,56 +1,138 @@
 # VictoriaMetrics Long-Term Metrics — Design
 
 **Created:** 2026-05-30 (architecture decided 2026-05-28)
-**Status:** Draft — architecture agreed in principle, not yet implemented. Needs a focused brainstorm pass on the open questions below, then a `writing-plans` implementation plan.
-**Sequence:** After the ESO / 1Password Connect migration (`docs/superpowers/plans/1password-eso.md`). VictoriaMetrics' `vmbackup` needs B2 credentials, which should be ESO-managed rather than added as new SealedSecrets.
-
-> This spec was reconstructed from the 2026-05-28 design conversation, which was agreed but never written down. Treat the **Decided** section as settled and the **Open questions** section as the remaining brainstorm scope.
+**Finalized:** 2026-05-31 (open questions resolved in brainstorm)
+**Status:** Finalized — ready for implementation plan.
+**Sequence:** ESO / 1Password Connect is already complete (PRs #818–#830, sealed-secrets
+controller removed 2026-05-31), so the B2-via-ESO credential path this design relies on already
+exists.
 
 ## Problem
 
-Prometheus retention was cut **15GB → 3GB / 7d** (PR #782) to stop the TSDB OOM-growing on the (then 8GB, now 12GB) worker nodes. That stops the crashes but throws away long-term metrics history. We want months of history back without buying hardware or consuming shared VMware datastore space.
+Prometheus retention was cut **15GB → 3GB / 7d** (PR #782) to stop the TSDB OOM-growing on the
+memory-constrained worker nodes. That stopped the crashes but throws away long-term metrics
+history. We want months of history back without buying hardware or consuming shared VMware
+datastore space.
 
-The cluster has no spare RAM headroom (see `worker02-scheduling-rebalance` / the N+1 memory alert sitting ~1.9 GiB above its floor), so the fix must *reduce* the metrics stack's footprint, not grow it.
+The cluster has no spare RAM headroom (see the worker02 memory-pressure work / the N+1 memory
+alert sitting ~1.9 GiB above its floor), so the fix must *reduce* the metrics stack's footprint,
+not grow it.
 
 ## Goal
 
-Run **Prometheus and VictoriaMetrics together** so Prometheus keeps doing everything it does today while VictoriaMetrics owns long-term, compressed storage — net-lighter on memory than today, with a cheap B2 archive.
+Run **Prometheus and VictoriaMetrics together** so Prometheus keeps doing everything it does
+today while VictoriaMetrics owns long-term, compressed storage — net-lighter on memory than
+today, with a cheap B2 archive.
 
-## Decided architecture (settled 2026-05-28 — do not re-litigate)
+## Architecture
 
-- **Prometheus stays the scraper/alerter.** All scraping, alerting, recording rules, ServiceMonitors, and existing dashboards remain unchanged. Local retention drops to **24h** (enough for alerting + rule evaluation).
-- **Prometheus `remote_write` → in-cluster single-node VictoriaMetrics.** VM holds 30–90 days at 5–10× better compression than Prometheus and speaks **native PromQL**, so every existing dashboard, alert, and `PrometheusRule` (including the new vSphere N+1 alerts) keeps working against it.
-- **`vmbackup` → Backblaze B2** for long-term archive. B2 is already configured in-cluster; given VM's compression this is pennies/month.
-- **Grafana** queries VictoriaMetrics for history and Prometheus for the last 24h (datasource strategy is an open question — see below).
-- **In-cluster, not a dedicated VM.** A separate VictoriaMetrics VM was considered and rejected: VMware HA requires shared storage (defeating the goal of offloading shared-datastore pressure), and a local-disk VM would be pinned to one ESXi host with no HA. In-cluster is *lighter* overall and Longhorn provides the HA. No separate VM to manage.
-- **VictoriaMetrics single-node, not Thanos.** Thanos's multi-component overhead isn't justified at homelab scale; VM single-node is the right fit.
+```
+targets → [Prometheus: scrape + alert + eval PrometheusRules, 24h local]
+                 │ remote_write (continuous)
+                 ▼
+         [VictoriaMetrics single: 90d, 30Gi/2-replica Longhorn, :8428 PromQL]
+                 │                         │ PVC (RWO)
+                 │ PromQL                  ▼ Velero node-agent (Kopia FSB), daily
+         [Grafana dashboards]        [Backblaze B2 (existing Velero BSL) ← ttl retention]
+         [Alertmanager ← fired by Prometheus, not VM]
+```
+
+- **Prometheus stays the scraper/alerter.** All scraping, service discovery, alerting,
+  recording rules, ServiceMonitors, and existing dashboards remain unchanged. Local retention
+  drops to **24h** (enough for alerting + rule evaluation). Prometheus is **not** redundant — it
+  remains the sole scraper and the entire alert/recording-rule evaluation path. VictoriaMetrics
+  is a dumb PromQL storage backend that never scrapes or evaluates rules.
+- **Prometheus `remote_write` → in-cluster single-node VictoriaMetrics.** VM holds 90 days at
+  ~3× better on-disk efficiency than Prometheus and speaks **native PromQL**, so every existing
+  dashboard, alert, and `PrometheusRule` (including the vSphere N+1 alerts) keeps working
+  against it.
+- **Velero → Backblaze B2** for the long-term archive. A dedicated Velero `Schedule` scoped to
+  just the VM PVC (via `includedNamespaces: [monitoring]` + a `labelSelector` on the VM pod)
+  overrides the blanket `monitoring` exclusion on the existing schedules, and backs the volume up
+  daily to the **existing Velero B2 BSL** using the already-running node-agent (Kopia FSB).
+  Retention is the Schedule's `ttl`. This needs **no new B2 bucket, 1Password item, or
+  ExternalSecret** — it reuses the backup platform of record. Chosen over a `vmbackup` sidecar
+  because the sidecar would add an always-on container (counter to the memory goal) and a second
+  restore path; `vmbackupmanager`'s scheduler is Enterprise-only with no permanent free license.
+  Crash-consistent FSB is acceptable: VM recovers from crash-consistent on-disk state, and the
+  live store is already protected by 2 Longhorn replicas + continuous remote_write.
+- **Grafana** reads history from VictoriaMetrics. VM holds near-real-time data (via continuous
+  remote_write) *and* full history — a strict superset of Prometheus's local 24h — so a single
+  VM datasource serves dashboards for any time range.
+- **In-cluster, not a dedicated VM.** A separate VictoriaMetrics VM was considered and rejected:
+  VMware HA requires shared storage (defeating the goal of offloading shared-datastore
+  pressure), and a local-disk VM would be pinned to one ESXi host with no HA. In-cluster is
+  *lighter* overall and Longhorn provides the HA. No separate VM to manage.
+- **VictoriaMetrics single-node, not Thanos.** Thanos's multi-component overhead isn't justified
+  at homelab scale; VM single-node is the right fit.
 
 ### Memory math (the justification)
 
 | Component | Current | With VictoriaMetrics |
 |-----------|---------|----------------------|
 | Prometheus | 2400Mi | ~400Mi (24h retention only) |
-| VictoriaMetrics | — | ~400Mi (30+ days, ~10× compression) |
+| VictoriaMetrics | — | ~400Mi (90d, ~3× compression) |
 | **Total** | **2400Mi** | **~800Mi** |
 
-Nets **~1.6GB back** on a worker node *and* restores long-term retention. (Figures are the 2026-05-28 estimates; re-measure live TSDB size + ingest rate at planning time to size VM's PVC and resources.)
+Nets **~1.6GB back** on a worker node *and* restores long-term retention. (Figures are the
+2026-05-28 estimates; re-measure live TSDB size + ingest rate once VM is running to right-size
+VM's PVC and resources — the Prometheus image has no shell, so this could not be measured during
+planning.)
 
-## Future phase (agreed direction, not part of the first build)
+## Decisions (settled in brainstorm 2026-05-31 — do not re-litigate)
 
-- **VictoriaLogs for Loki:** same pattern — Promtail `remote_write` → VictoriaLogs, Grafana queries it, extending log retention from the current 30d toward ~1 year at far better efficiency. Sequence after the metrics side is stable.
+| Question | Decision | Rationale |
+|----------|----------|-----------|
+| **Chart / deployment shape** | `victoria-metrics-single` Helm chart (no Operator, no CRDs). Backups handled externally by Velero, not the chart's enterprise sidecar. | The Operator's main value (turning ServiceMonitors into scrape configs) is redundant — Prometheus stays the scraper. Single chart matches the existing HelmRelease pattern and avoids a controller pod. |
+| **remote_write topology** | Prometheus `remote_write` → VM. No `vmagent`. | Prometheus remains the only scraper; VM is a pure storage sink. |
+| **Grafana datasources** | VM owns `uid: prometheus` (display name "VictoriaMetrics", `isDefault: true`). Real Prometheus added as "Prometheus (live)" `uid: prometheus-live`. Loki unchanged. | Existing dashboards pin `uid: prometheus` (e.g. 84 panels in the MinIO dashboard). Pointing that UID at VM gives every dashboard full history with **zero edits**. The secondary datasource is a debugging escape hatch for inspecting Prometheus's freshest scrape. |
+| **PVC sizing + StorageClass** | 30Gi PVC, **2 Longhorn replicas**, 90d VM retention. Longhorn online-resize if ingest grows. | Live capacity measured 2026-05-31: general workers have 53–155Gi free, so 2×30Gi fits easily. 2 replicas balances HA against the tight cluster, justified because the store is also protected by remote_write replay + layered B2 backups. |
+| **Backup to B2** | Dedicated Velero `Schedule` (daily) scoped to the VM PVC → existing Velero B2 BSL, retention via `ttl` (~90d). No new bucket/credentials. | Reuses the backup platform of record and its already-running node-agent (zero new always-on footprint — decisive under the memory goal), with one restore runbook. A `vmbackup` sidecar was rejected (always-on container, second restore path) and `vmbackupmanager` is Enterprise-only with no permanent free license. Crash-consistent FSB is fine for VM; the live store also has 2 Longhorn replicas + remote_write. |
+| **Migration / cutover** | Two-stage: (1) deploy VM + remote_write + datasources with Prometheus still at 7d; verify ingestion; (2) drop Prometheus to 24h. No backfill of the existing 7d. | Avoids a history gap during transition. `remote_write` only forwards new samples; the old 7d ages out naturally. VM history begins at cutover — acceptable, since the goal is restoring *future* long-term retention. |
+| **Resource requests** | VM start: requests `cpu 100m / mem 256Mi`, limits `cpu 1000m / mem 1Gi`. | The ~400Mi figure is an estimate; re-tune after live TSDB measurement once VM is ingesting. |
 
-## Open questions (the brainstorm scope before writing the plan)
+### Longhorn capacity (measured 2026-05-31)
 
-1. **Chart/deployment shape:** `victoria-metrics-single` Helm chart vs the VictoriaMetrics Operator (`vmsingle`/`vmagent` CRDs). Operator integrates with existing ServiceMonitors but adds CRDs/controller; single chart is simpler. Decide.
-2. **remote_write topology:** does Prometheus remote_write to VM, or do we introduce `vmagent` to scrape and feed both? (Decided architecture implies Prom-remote_write; confirm.)
-3. **Grafana datasources:** single VM datasource for everything (simplest, since VM can also serve recent data), or keep Prom (24h) + VM (history) as two datasources? Affects dashboard variables.
-4. **PVC sizing + StorageClass:** how big, and Longhorn replica count (this interacts directly with the Longhorn capacity rules and the cluster's tight storage — size conservatively, see `.claude/rules/storage.md`).
-5. **vmbackup cadence + B2 bucket/credential:** schedule, retention on B2, and the ESO-managed B2 key (depends on ESO landing first).
-6. **Migration/cutover:** how to drop Prometheus retention to 24h without a history gap during the transition; backfill considerations.
-7. **Resource requests:** real numbers from live TSDB measurement at planning time (the ~400Mi figures are estimates).
+| Node | Available | Node | Available |
+|------|-----------|------|-----------|
+| k8sworker01 | 155 Gi | k8sworker04 | 75 Gi |
+| k8sworker02 | 64 Gi | k8sworker05 (DMZ) | 126 Gi |
+| k8sworker03 | 53 Gi | k8sworker06 (DMZ) | 125 Gi |
+
+### Backup (Velero)
+
+A dedicated Velero `Schedule` (`victoria-metrics-b2`) backs up only the VM PVC to the existing
+Velero **B2** BackupStorageLocation daily, with `defaultVolumesToFsBackup: true` so the
+node-agent (Kopia) captures the RWO Longhorn volume. It is scoped with
+`includedNamespaces: [monitoring]` plus a `labelSelector` matching the VM pod labels
+(`app: victoria-metrics`) so it captures *only* the VM volume and not the (deliberately excluded)
+Prometheus/Loki volumes. Retention is the Schedule `ttl` (~90 days = 2160h, matching the existing
+`daily-b2`). **No new B2 bucket, 1Password item, or ExternalSecret** — it reuses Velero's existing
+B2 credentials and node-agent. Restore uses the standard Velero workflow (`docs/runbooks` + the
+velero rules).
+
+## Rejected alternatives
+
+- **Replacing Prometheus** — rejected; they run together (Prometheus owns scrape + alert).
+- **Thanos / Mimir / Cortex** — rejected; multi-component overhead not justified at homelab scale.
+- **ClickHouse** — rejected. No native PromQL (would break ~25 dashboards + every PrometheusRule,
+  or require a translation layer) and a heavier RAM/Keeper footprint — counter to the two goals
+  here (PromQL drop-in + reduce memory). ClickHouse fits a from-scratch SQL-native unified
+  telemetry platform (SigNoz model), which is a different project. It is also not part of the
+  VictoriaMetrics stack (VM and VictoriaLogs use their own engines).
+
+## Future phase (agreed direction, separate spec)
+
+- **VictoriaLogs for Loki:** same vendor and pattern — Promtail → VictoriaLogs, Grafana queries
+  it, extending log retention from the current 30d toward ~1 year at far better efficiency.
+  **Deliberately decomposed out of this work**: the memory-pressure driver does not apply to logs
+  (Loki already stores chunks in MinIO/S3, not constrained local RAM), and the cutover and open
+  questions (ingestion path, whether Loki stays or is replaced, LogsQL vs LogQL) are distinct.
+  Sequence after the metrics side is stable; it will reuse the operational pattern established
+  here.
 
 ## Out of scope
 
-- Replacing Prometheus (explicitly rejected — they run together).
-- Thanos/Mimir/Cortex (rejected — overhead not worth it here).
-- VictoriaLogs (future phase, separate spec).
+- VictoriaLogs (future phase, separate spec — see above).
+- Backfilling Prometheus's existing 7d into VM (possible later via `vmctl` import of a
+  `promtool tsdb dump`, but not part of this work).


### PR DESCRIPTION
## What

Deploys single-node **VictoriaMetrics** as a long-term, compressed, PromQL-native metrics store that Prometheus `remote_write`s to — restoring long-term history while letting Prometheus local retention drop to 24h (follow-up PR), *reducing* the metrics stack's memory footprint.

This is **PR #1 of 2**. Prometheus retention stays **7d** here; the 24h cutover is a separate PR after VM ingestion is verified.

## Changes

- **`flux-system/repositories/`** — `victoria-metrics-repo` HelmRepository (chart `victoria-metrics-single` v0.39.0) + index.
- **`clusterwide/`** — new `longhorn-r2` 2-replica StorageClass (general workers; the existing 2-replica `longhorn-dmz` is DMZ-pinned).
- **`monitoring/victoria-metrics/app/`** — VictoriaMetrics single: 90d retention, 30Gi PVC on `longhorn-r2`, `server.mode: statefulSet` (RWO-safe), resource requests+limits.
- **`monitoring/kube-prometheus-stack/app/configmap.yaml`** — Prometheus `remoteWrite` → VM; Grafana datasources swapped so **VM owns `uid: prometheus`** (default) → all existing dashboards read full history with zero edits, Prometheus kept as `Prometheus (live)`, Loki unchanged.
- **`velero/velero/app/configmap.yaml`** — dedicated `victoria-metrics-b2` Velero Schedule scoped (includedNamespaces: monitoring + labelSelector) to *only* the VM PVC → existing B2 BSL, ttl ~90d. No new bucket/credentials.

## Why this shape

- `victoria-metrics-single` chart (no Operator/CRDs) — Prometheus stays the sole scraper, VM is just a remote_write sink.
- Backups via **Velero** (not `vmbackupmanager`, which is Enterprise-only; not a `vmbackup` sidecar, which would be an always-on container) — reuses the existing node-agent + B2 BSL, zero new always-on footprint.

Design spec: `docs/superpowers/specs/victoriametrics-longterm-design.md` · Plan: `docs/superpowers/plans/victoriametrics-longterm.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)