### PR TITLE
fix(authentik): stop perpetual tofu drift flooding authentik-db WAL

### DIFF
--- a/terraform/authentik/applications.tf
+++ b/terraform/authentik/applications.tf
@@ -47,11 +47,12 @@ resource "authentik_application" "grafana" {
 }
 
 resource "authentik_application" "goldilocks" {
-  name            = "Goldilocks"
-  slug            = "goldilocks"
-  meta_launch_url = "https://goldilocks.vollminlab.com"
-  meta_icon       = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/goldilocks.png"
-  open_in_new_tab = false
+  name             = "Goldilocks"
+  slug             = "goldilocks"
+  meta_description = "VPA resource recommendations dashboard"
+  meta_launch_url  = "https://goldilocks.vollminlab.com"
+  meta_icon        = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/goldilocks.png"
+  open_in_new_tab  = false
 }
 
 resource "authentik_application" "haproxy" {
@@ -92,6 +93,7 @@ resource "authentik_application" "homepage" {
   name            = "Homepage"
   slug            = "homepage"
   meta_launch_url = "https://homepage.vollminlab.com"
+  meta_icon       = "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/homepage.png"
   open_in_new_tab = false
 }
 
@@ -105,11 +107,12 @@ resource "authentik_application" "jellyfin" {
 }
 
 resource "authentik_application" "jellystat" {
-  name            = "Jellystat"
-  slug            = "jellystat"
-  meta_launch_url = "https://jellystat.vollminlab.com"
-  meta_icon       = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/jellystat.svg"
-  open_in_new_tab = false
+  name             = "Jellystat"
+  slug             = "jellystat"
+  meta_description = "Jellyfin statistics"
+  meta_launch_url  = "https://jellystat.vollminlab.com"
+  meta_icon        = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/jellystat.svg"
+  open_in_new_tab  = false
 }
 
 resource "authentik_application" "longhorn" {
@@ -214,6 +217,7 @@ resource "authentik_application" "seerr" {
   name              = "Seerr"
   slug              = "seerr"
   protocol_provider = authentik_provider_oauth2.seerr.id
+  meta_description  = "Media request management"
   meta_launch_url   = "https://seerr.vollminlab.com"
   meta_icon         = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/seerr.svg"
   open_in_new_tab   = false
@@ -248,5 +252,6 @@ resource "authentik_application" "vollminlab_forward_auth" {
   slug              = "vollminlab-forward-auth"
   protocol_provider = authentik_provider_proxy.vollminlab_forward_auth.id
   meta_launch_url   = "https://authentik.vollminlab.com"
+  meta_icon         = "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/authentik.png"
   open_in_new_tab   = false
 }

--- a/terraform/authentik/providers_oauth2.tf
+++ b/terraform/authentik/providers_oauth2.tf
@@ -14,6 +14,7 @@ resource "authentik_provider_oauth2" "grafana" {
   invalidation_flow  = data.authentik_flow.default_provider_invalidation.id
   signing_key        = data.authentik_certificate_key_pair.self_signed.id
   sub_mode           = "hashed_user_id"
+  logout_uri         = "https://grafana.vollminlab.com/login"
 
   allowed_redirect_uris = [
     {
@@ -35,6 +36,7 @@ resource "authentik_provider_oauth2" "headlamp" {
   invalidation_flow  = data.authentik_flow.default_provider_invalidation.id
   signing_key        = data.authentik_certificate_key_pair.self_signed.id
   sub_mode           = "hashed_user_id"
+  logout_uri         = "https://headlamp.vollminlab.com"
 
   allowed_redirect_uris = [
     {
@@ -57,6 +59,7 @@ resource "authentik_provider_oauth2" "minio" {
   invalidation_flow  = data.authentik_flow.default_provider_invalidation.id
   signing_key        = data.authentik_certificate_key_pair.self_signed.id
   sub_mode           = "hashed_user_id"
+  logout_uri         = "https://minio.vollminlab.com"
 
   allowed_redirect_uris = [
     {
@@ -78,6 +81,7 @@ resource "authentik_provider_oauth2" "jellyfin" {
   invalidation_flow  = data.authentik_flow.default_provider_invalidation.id
   signing_key        = data.authentik_certificate_key_pair.self_signed.id
   sub_mode           = "hashed_user_id"
+  logout_uri         = "https://jellyfin.vollminlab.com"
 
   allowed_redirect_uris = [
     {
@@ -99,6 +103,7 @@ resource "authentik_provider_oauth2" "harbor" {
   invalidation_flow  = data.authentik_flow.default_provider_invalidation.id
   signing_key        = data.authentik_certificate_key_pair.self_signed.id
   sub_mode           = "hashed_user_id"
+  logout_uri         = "https://harbor.vollminlab.com"
 
   allowed_redirect_uris = [
     {
@@ -120,6 +125,7 @@ resource "authentik_provider_oauth2" "portainer" {
   invalidation_flow  = data.authentik_flow.default_provider_invalidation.id
   signing_key        = data.authentik_certificate_key_pair.self_signed.id
   sub_mode           = "hashed_user_id"
+  logout_uri         = "https://portainer.vollminlab.com"
 
   allowed_redirect_uris = [
     {
@@ -164,6 +170,7 @@ resource "authentik_provider_oauth2" "audiobookshelf" {
   invalidation_flow  = data.authentik_flow.default_provider_invalidation.id
   signing_key        = data.authentik_certificate_key_pair.self_signed.id
   sub_mode           = "hashed_user_id"
+  logout_uri         = "https://audiobookshelf.vollminlab.com"
 
   allowed_redirect_uris = [
     {

--- a/terraform/authentik/providers_proxy.tf
+++ b/terraform/authentik/providers_proxy.tf
@@ -5,5 +5,5 @@ resource "authentik_provider_proxy" "vollminlab_forward_auth" {
   invalidation_flow  = data.authentik_flow.default_provider_invalidation.id
   mode               = "forward_domain"
   cookie_domain      = "vollminlab.com"
-
+  skip_path_regex    = "^/api/socket\\.io/"
 }

--- a/terraform/authentik/scope_mappings.tf
+++ b/terraform/authentik/scope_mappings.tf
@@ -5,9 +5,10 @@ resource "authentik_property_mapping_provider_scope" "groups" {
 }
 
 resource "authentik_property_mapping_provider_scope" "minio_policy" {
-  name       = "MinIO Policy"
-  scope_name = "minio"
-  expression = <<-EOT
+  name        = "MinIO Policy"
+  description = "Mapping for Minio Admins"
+  scope_name  = "minio"
+  expression  = <<-EOT
     if ak_is_group_member(request.user, name="MinIO Admins"):
         return {"policy": "consoleAdmin"}
     return {"policy": "readwrite"}


### PR DESCRIPTION
## Problem

`tofu/authentik-config` re-applies on **every 10-minute reconcile** (status perpetually `Plan generated` → `Applied successfully`, never `No drift`). Root cause: **14 resources carry server-side field values that are absent from the `.tf` config**. The pinned provider (`goauthentik/authentik ~> 2026.2.0`, while the server runs **2026.5.2**) plans to `null` them each cycle, but the apply never clears them on the server — so drift returns forever.

## Impact (how this surfaced)

Each re-apply re-saves ~15 objects → one `model_updated` audit event each → every event fans out to `1 event_trigger_dispatch + 4 event_trigger_handler` tasks in the **Postgres-backed task queue** (Redis was removed in Authentik 2026.x). Measured consequences:

- ~75k `model_updated` events (94% of all task volume)
- **517k-row `authentik_tasks_task` backlog** (expired-task cleanup never runs)
- **~1.5 GB compressed WAL/day** → **22 GB** retained over the 14-day CNPG window
- **34 GB `authentik-db` CNPG backup** in MinIO, replicated ×3 by Longhorn
- → root-disk pressure on **k8sworker03**

## Fix

Bring the orphaned server values under Terraform management so `plan` == server state (0 changes), preserving functional config rather than nulling it:

| Resource(s) | Field restored |
|---|---|
| 7 × `authentik_provider_oauth2` (audiobookshelf, grafana, harbor, headlamp, jellyfin, minio, portainer) | `logout_uri` (RP-initiated logout) |
| `authentik_provider_proxy.vollminlab_forward_auth` | `skip_path_regex` (socket.io bypass) |
| apps goldilocks, jellystat, seerr | `meta_description` |
| apps homepage, vollminlab_forward_auth | `meta_icon` |
| `minio_policy` scope mapping | `description` |

All values taken verbatim from the live `tofu plan` diff.

## Validation

- `tofu fmt -check -recursive` → clean
- `tofu init -backend=false && tofu validate` → `Success! The configuration is valid.` (new attributes valid in the pinned provider schema)

After merge, the next reconcile should report **0 to add, 0 to change** — ending the `model_updated`/WAL flood at the source.

## Follow-ups (separate, not in this PR)

- Purge the 517k expired `done` tasks + `VACUUM` (immediate ~850 MB reclaim; needs prod-DB write).
- Optional: CNPG `retentionPolicy` 14d→7d (~11 GB off MinIO; B2 keeps 90/365d offsite).
- Provider bump 2026.2.0→2026.5.x as hygiene (values now pinned in config either way).