### PR TITLE
fix(authentik-db): reduce CNPG backup retention 14d → 7d

### DIFF
--- a/clusters/vollminlab-cluster/authentik/cnpg/app/cluster.yaml
+++ b/clusters/vollminlab-cluster/authentik/cnpg/app/cluster.yaml
@@ -42,4 +42,4 @@ spec:
       wal:
         compression: gzip
         maxParallel: 2
-    retentionPolicy: "14d"
+    retentionPolicy: "7d"


### PR DESCRIPTION
## Why

`authentik-db`'s barman WAL archive in MinIO had grown to **22 GB** (34 GB total backup) because Authentik's Postgres-backed task queue generated ~1.5 GB compressed WAL/day (root cause: perpetual tofu drift, fixed in #832; expired-task backlog of 517k rows purged separately).

With the WAL source fixed, cutting retention **14d → 7d**:
- ages out the existing 22 GB WAL backlog in half the time
- caps the local PITR window at a level appropriate for this DB

## Safety

Offsite coverage unchanged — velero `daily-b2` (90d) and `monthly-b2` (365d) still back up the `authentik` namespace to Backblaze B2. Local velero `daily-full` (MinIO, 14d) also covers it via FSB.

## Scope

`authentik-db` only — the other CNPG clusters (harbor 1.1G, jellystat 2.5G, shlink 930M) are small and stay at 14d.