### PR TITLE
feat(prometheus): cut local retention to 24h (VM holds long-term history)

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -15,8 +15,7 @@ data:
       prometheusSpec:
         externalUrl: https://prometheus.vollminlab.com
         scrapeInterval: 30s
-        retention: 7d
-        retentionSize: 3GB
+        retention: 24h
         remoteWrite:
           - url: http://victoria-metrics-single-server.monitoring.svc.cluster.local:8428/api/v1/write
         serviceMonitorSelectorNilUsesHelmValues: false


### PR DESCRIPTION
## What

Follow-up to the VictoriaMetrics PR (#831). Drops Prometheus local retention **7d → 24h** and removes the `retentionSize: 3GB` cap.

## Why

VictoriaMetrics is live and verified ingesting via `remote_write` (`count(up)` returns current data). Prometheus only needs enough local TSDB to satisfy alerting + recording-rule evaluation windows — 24h is ample. Long-term history now lives in VM (90d), which Grafana already reads as the default datasource. This reclaims worker memory (Prometheus was measured at **2450Mi** under 7d retention, over its 1500Mi request).

## Scope note

Resource requests/limits are **intentionally unchanged** in this PR. The post-cut steady-state memory can't be observed at PR-open time, and lowering the limit on a guess risks OOM. A small follow-up PR will right-size `prometheus.prometheusSpec.resources` once the new usage is measured live after this merges.

## Verify after merge

- `kubectl top pod -n monitoring -l app.kubernetes.io/name=prometheus` → RSS drops materially vs the 2450Mi baseline.
- Grafana dashboards still render history beyond 24h (served by VM).
- Alerting/rule evaluation unaffected (`prometheus_rule_evaluation_failures_total` stays 0).

Spec: `docs/superpowers/specs/victoriametrics-longterm-design.md` · Plan Task 8: `docs/superpowers/plans/victoriametrics-longterm.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)