### PR TITLE
fix(velero): restore backupStorageLocation under configuration: (unstick failed upgrades)

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -63,22 +63,11 @@ data:
       # block all PVBs on the affected node indefinitely across multiple backup runs.
       podVolumeOperationTimeout: 30m
 
-    # Prefer not to land on the same node as media stack workloads.
-    # The Velero pod generates significant API/CPU load during backup runs, which
-    # interferes with the node-agent's gRPC data path initialization on that node.
-    affinity:
-      podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                  - key: category
-                    operator: In
-                    values:
-                      - media
-              topologyKey: kubernetes.io/hostname
-
+      # BackupStorageLocations MUST stay nested under configuration: — the velero
+      # chart reads configuration.backupStorageLocation. If this drifts out (e.g.
+      # displaced by an inserted sibling block), the chart synthesizes an invalid
+      # "default" BSL with no provider and every helm upgrade fails. (Regression
+      # from PR #790 left it under affinity: and broke velero upgrades for days.)
       backupStorageLocation:
         # Primary: in-cluster MinIO (fast restores, no egress cost)
         - name: minio
@@ -103,6 +92,22 @@ data:
           credential:
             name: velero-b2-credentials
             key: cloud
+
+    # Prefer not to land on the same node as media stack workloads.
+    # The Velero pod generates significant API/CPU load during backup runs, which
+    # interferes with the node-agent's gRPC data path initialization on that node.
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: category
+                    operator: In
+                    values:
+                      - media
+              topologyKey: kubernetes.io/hostname
 
     # node-agent DaemonSet runs kopia on every node for file-system PVC backups
     deployNodeAgent: true


### PR DESCRIPTION
## Problem

The Velero HelmRelease has been **stuck in a failed upgrade since 2026-05-28** (rev 28 deployed, rev 29+ failing):

```
Upgrade "velero" failed: BackupStorageLocation.velero.io "default" is invalid: spec.provider: Required value
```

**Root cause:** PR #790 ("anti-affinity + schedule shift") inserted the `affinity:` block between `configuration:`'s scalar keys and the `backupStorageLocation:` list, so the BSLs ended up nested under `affinity:` instead of `configuration:`. The velero chart reads `configuration.backupStorageLocation`; finding it empty, it synthesizes a single unnamed `default` BSL with no provider → invalid → every upgrade fails.

## Impact (and why it went unnoticed)

- Backups **kept running** on the last-good release (rev 28) — the `minio`/`b2` BSLs and original schedules persisted as CRs, so this was silent.
- But **no velero config change has applied since May 28** — including the `victoria-metrics-b2` VM backup schedule from #831, which never materialized as a Schedule CR (the VM PVC is not being backed up to B2 yet).

Surfaced while investigating alerts after the Prometheus 24h-retention merge (#834) — the alerts were unrelated, but this turned up in the process.

## Fix

Move `backupStorageLocation:` back under `configuration:` (verified: `configuration.backupStorageLocation` now parses with both `minio`+`b2`, providers intact; no stray copy under `affinity:`; `victoria-metrics-b2` schedule preserved). Added a guard comment so it can't silently drift out again.

## Verify after merge

- `kubectl -n velero get hr velero` → Ready=True, new helm revision deployed (no longer stuck on rev 28).
- `kubectl get schedules.velero.io -n velero` → `victoria-metrics-b2` now present.
- Existing backups continue; `kubectl get backupstoragelocations -n velero` still shows `minio`/`b2` Available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)