### PR TITLE
fix(prometheus): right-size memory to real usage (24h cut didn't reduce RAM)

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -30,10 +30,14 @@ data:
         resources:
           requests:
             cpu: 500m
-            memory: 1500Mi
+            # ~2.5Gi reflects real steady-state usage (~2.7Gi observed). RAM here
+            # is driven by ~600k active head series, NOT retention — the 24h cut
+            # (PR #834) did not reduce it. Under-requesting silently over-commits
+            # the node and worsened memory pressure.
+            memory: 2560Mi
           limits:
             cpu: 2000m
-            memory: 3Gi
+            memory: 3584Mi
         storageSpec:
           volumeClaimTemplate:
             spec:


### PR DESCRIPTION
## Why

After the 24h retention cut (#834), Prometheus memory did **not** drop — it's **~2729Mi** (was 2450Mi at 7d). Prometheus RAM is driven by **~600k active head series** (`prometheus_tsdb_head_series`), not retention duration; retention only governs on-disk block lifetime. So the project's "Prom → ~400Mi" expectation was a category error.

The request was left at **1500Mi** — well under real usage — which silently over-commits whatever node Prometheus lands on (contributing to the cluster's memory pressure), with only ~270Mi headroom to the 3Gi limit.

## Change

- `requests.memory`: 1500Mi → **2560Mi** (≈ real steady-state, honest scheduling floor)
- `limits.memory`: 3Gi → **3584Mi** (OOM headroom)
- CPU unchanged.

This makes resourcing accurate; it does **not** reduce usage. The only lever to actually cut Prometheus RAM is reducing head-series cardinality (metricRelabelings) — tracked as a separate follow-up.

## Verify after merge

- `kubectl top pod -n monitoring -l app.kubernetes.io/name=prometheus` → ~2.7Gi, comfortably under the 3584Mi limit.
- `kubectl -n monitoring get pod prometheus-kube-prometheus-stack-prometheus-0 -o jsonpath='{.spec.containers[?(@.name=="prometheus")].resources}'` → new values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)