### PR TITLE
feat(victoriametrics): enable serviceMonitor for VM self-metrics

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/victoria-metrics/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/victoria-metrics/app/configmap.yaml
@@ -38,3 +38,14 @@ data:
         limits:
           cpu: "1"
           memory: 1Gi
+
+      # Let Prometheus scrape VM's own /metrics so VM health (ingestion rate,
+      # dedup, disk growth, uptime) is visible in Grafana. Prometheus scrapes all
+      # ServiceMonitors (serviceMonitorSelectorNilUsesHelmValues: false), so
+      # enabling this is sufficient. Marginal cardinality (single vmsingle).
+      serviceMonitor:
+        enabled: true
+        extraLabels:
+          app: victoria-metrics
+          env: production
+          category: observability


### PR DESCRIPTION
## What

Enables `server.serviceMonitor` on VictoriaMetrics so Prometheus scrapes VM's own `/metrics`.

## Why

VM's self-metrics (ingestion rate, dedup ratio, disk growth, active series, uptime) are currently only on the live `/metrics` endpoint — not in any TSDB, so they can't be graphed or alerted on. With the ServiceMonitor, Prometheus scrapes them → remote-writes to VM → visible in Grafana. This lets us monitor the long-term-metrics store itself.

Prometheus scrapes all ServiceMonitors (`serviceMonitorSelectorNilUsesHelmValues: false`), so `enabled: true` is sufficient. Cardinality cost is marginal (a single vmsingle instance — a few hundred series, not the ~600k that drive Prometheus memory).

## Verify after merge

- `kubectl get servicemonitor -n monitoring | grep victoria` → present.
- Prometheus Targets (or `count(vm_app_uptime_seconds)` in Grafana) shows VM being scraped.
- VM panels available via the `vm_*` metric family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)