### PR TITLE
fix(flaresolverr): right-size memory to real usage

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/flaresolverr/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/flaresolverr/app/deployment.yaml
@@ -32,7 +32,10 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 512Mi
+              # Idles at ~0-100Mi; spikes only briefly during a headless-Chromium
+              # Cloudflare solve. 192Mi request / 768Mi limit keeps solve headroom
+              # while reclaiming the over-provisioned 512Mi/2Gi.
+              memory: 192Mi
             limits:
               cpu: 1000m
-              memory: 2Gi
+              memory: 768Mi


### PR DESCRIPTION
## What
Lower flaresolverr memory from `512Mi`/`2Gi` to `192Mi`/`768Mi` (request/limit).

## Why
Right-sizing pass found flaresolverr heavily over-provisioned: it idles at ~0–100Mi and only spikes briefly when launching headless Chromium for a Cloudflare solve. Reclaims ~320Mi of request reservation and ~1.3Gi of limit-overcommit, while 768Mi keeps comfortable headroom for a solve (so Prowlarr indexer challenges won't OOM).

The cluster isn't memory-starved (general workers at 43–62% usage); this is the one clearly-safe trim — other big reservers (minecraft, renovate, ARC runners, velero node-agent) are bursty and were deliberately left alone.

## Verify after merge
- `kubectl top pod -n mediastack -l app.kubernetes.io/name=flaresolverr` stays well under 768Mi.
- Prowlarr indexer tests still pass (flaresolverr solves succeed, no OOMKill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)