### PR TITLE
fix(longhorn): durable 2 replicas for Prometheus; document MinIO patch

### DIFF
--- a/clusters/vollminlab-cluster/minio/minio/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/minio/minio/app/configmap.yaml
@@ -28,6 +28,15 @@ data:
 
     persistence:
       enabled: true
+      # storageClass stays "longhorn" (3-replica default) on purpose: this PVC's
+      # live Longhorn volume was patched to 2 replicas on 2026-06-01 to reclaim
+      # ~100G (backups also go to B2, so 2 in-cluster copies suffice). We do NOT
+      # switch to a 2-replica StorageClass here because storageClassName is
+      # immutable on the existing PVC and changing it would break this HelmRelease
+      # (and recreating the PVC would mean migrating 100G of backups).
+      # If this PVC is ever recreated it reverts to 3 replicas — re-apply with:
+      #   kubectl -n longhorn-system patch volumes.longhorn.io <minio-vol> \
+      #     --type=merge -p '{"spec":{"numberOfReplicas":2}}'
       storageClass: "longhorn"
       size: 100Gi
 

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -41,7 +41,12 @@ data:
         storageSpec:
           volumeClaimTemplate:
             spec:
-              storageClassName: longhorn
+              # longhorn-r2 = 2 replicas (vs longhorn's 3) — Prometheus is ephemeral
+              # now (24h retention; VM holds long-term history), so 2 replicas is
+              # plenty and reclaims Longhorn space. NOTE: VCT storageClassName is
+              # immutable, so this only takes effect after the StatefulSet + PVC are
+              # recreated (done once at merge time).
+              storageClassName: longhorn-r2
               accessModes:
                 - ReadWriteOnce
               resources:


### PR DESCRIPTION
## Context
Follow-up to the live Longhorn replica reduction (MinIO + Prometheus 3→2, freeing ~127G). Live volume patches aren't git-durable — a future PVC recreation would default back to 3 replicas. This makes the Prometheus reduction durable and documents the MinIO situation.

## Changes
- **Prometheus** storage → `longhorn-r2` (2-replica StorageClass). `storageClassName` is immutable on the existing VCT, so this only applies once the StatefulSet+PVC are recreated — a one-time controlled op done at merge (Prometheus is ephemeral: 24h retention, VM holds long-term history, so losing the local TSDB is fine).
- **MinIO** keeps `storageClass: "longhorn"` + an explanatory comment. We deliberately do **not** switch its SC: changing it on the existing PVC is immutable and would break the MinIO HelmRelease (Velero-style stuck upgrade), and recreating the PVC means migrating 100G of backups. The comment records the live 2-replica patch and the re-patch command if the PVC is ever recreated.

## Post-merge (manual, by me)
After this merges, I recreate the Prometheus StatefulSet+PVC so the `longhorn-r2` SC takes effect:
1. `kubectl -n monitoring delete statefulset prometheus-kube-prometheus-stack-prometheus --cascade=orphan`
2. delete the prometheus-0 pod + its PVC
3. prometheus-operator recreates STS → new PVC on `longhorn-r2` (2 replicas)

Brief (~1-2 min) Prometheus gap during recreation; alerting resumes on restart.

## Verify
- After recreation: `kubectl -n longhorn-system get volumes.longhorn.io <prom-vol> -o jsonpath='{.spec.numberOfReplicas}'` → `2`, and the new PVC's `storageClassName` is `longhorn-r2`.
- Grafana/MinIO StorageClasses unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)