### PR TITLE
fix(cloudflare): skip bot challenges for jellyfin.vollminlab.com

### DIFF
--- a/docs/runbooks/jellyfin.md
+++ b/docs/runbooks/jellyfin.md
@@ -1,0 +1,71 @@
+# Jellyfin Runbook
+
+## Access architecture
+
+`jellyfin.vollminlab.com` resolves two ways (split-horizon DNS):
+
+- **Internally (Pi-hole):** → `192.168.152.244` (nginx ingress VIP). LAN clients stream
+  directly over the home network — full speed, never touches the internet.
+- **Externally (public DNS):** → proxied Cloudflare CNAME → the `vollminlab-Jellyfin`
+  Zero Trust tunnel (`cloudflared-jellyfin` deployment in `mediastack`) →
+  `jellyfin.mediastack.svc.cluster.local:8096`.
+
+Jellyfin's own `EnableRemoteAccess` is irrelevant to the tunnel path: requests arrive
+from the in-cluster cloudflared pod IP, which Jellyfin treats as local.
+
+## Symptom: media never starts playing ("stops at 0 ms")
+
+Client can browse, select a title, and press play, but playback never begins. Jellyfin
+logs show repeated `MediaInfoHelper: User policy for <user>` and
+`Playback stopped ... Stopped at 0 ms`, but **no `/Videos/.../stream` request** ever
+reaches the server.
+
+### Root cause (seen 2026-06-01)
+
+Cloudflare issues a **managed bot challenge** ("Just a moment…", header
+`cf-mitigated: challenge`, HTTP 403) on requests to `jellyfin.vollminlab.com`. Native
+players (Apple TV / tvOS, mobile apps) cannot solve a JavaScript challenge, so the
+stream request returns the HTML challenge page instead of video → playback fails.
+Small requests (metadata, artwork) often slip through, so browsing still works — which
+masks the problem.
+
+This is the same class of failure that affected `authentik.vollminlab.com` (PR #648).
+
+### Diagnosis
+
+```bash
+JF=$(kubectl get pod -n mediastack -l app.kubernetes.io/name=jellyfin -o name | head -1 | cut -d/ -f2)
+
+# 1. Is Jellyfin itself healthy? Stream in-cluster (expect HTTP 206, high MB/s).
+#    Authenticate with the "Jellyfin" 1Password item, then range-GET /Videos/<id>/stream
+#    against http://jellyfin.mediastack.svc.cluster.local:8096 from a pod in mediastack.
+
+# 2. Did stream requests reach the tunnel? (empty output = blocked at the edge)
+kubectl logs -n mediastack deploy/cloudflared-jellyfin --since=1h | grep '/Videos/'
+
+# 3. Reproduce the challenge from outside:
+#    curl -s -D - https://jellyfin.vollminlab.com/System/Info/Public | grep -i cf-mitigated
+#    cf-mitigated: challenge  →  Cloudflare is challenging clients.
+```
+
+If in-cluster streaming works but the tunnel path is challenged, the fix is on the
+Cloudflare side, not Jellyfin.
+
+### Fix
+
+- **External clients:** add a skip rule for `jellyfin.vollminlab.com` to the
+  `http_request_firewall_custom` ruleset in `terraform/cloudflare/security.tf`
+  (only one ruleset is allowed per zone — add a rule, don't create a new ruleset).
+  tofu-controller (`cloudflare-config` Terraform CR) auto-applies on merge.
+- **Home Apple TV / LAN clients:** point the device's DNS at Pi-hole so
+  `jellyfin.vollminlab.com` resolves to `192.168.152.244` and streams over the LAN,
+  bypassing Cloudflare entirely (Apple TV → Settings → Network → Wi-Fi → Configure DNS
+  → Manual → Pi-hole IP). This is the preferred path for large remux files.
+
+### Note on large remuxes over Cloudflare
+
+The library contains ~20 GB 1080p remuxes. Even with the challenge skipped, Cloudflare's
+free plan discourages sustained large-file/video proxying (TOS 2.8) and has previously
+terminated direct-play streams (`stream canceled by remote with error code 0`). For
+reliable remote streaming, prefer transcoded playback or a non-Cloudflare transport
+(e.g. Tailscale). Local playback over the LAN ingress is unaffected.

--- a/terraform/cloudflare/security.tf
+++ b/terraform/cloudflare/security.tf
@@ -1,18 +1,30 @@
 # ---------------------------------------------------------------------------
 # Cloudflare WAF Custom Rules — Security overrides
 #
-# Authentik handles all authentication itself, so Cloudflare's bot challenges
-# must be bypassed for authentik.vollminlab.com. Without this, a fresh browser
-# session (incognito, first visit) gets a managed challenge on the
-# /api/v3/flows/executor/ fetch, which returns HTML instead of JSON and
-# breaks the login flow with "Request failed and the interceptors did not
-# return an alternative response".
+# Some services behind the tunnel are accessed by non-browser API clients that
+# cannot solve a Cloudflare managed/JS challenge. When Cloudflare intercepts
+# their requests it returns the "Just a moment..." HTML challenge page
+# (cf-mitigated: challenge) instead of the expected response, which breaks the
+# client. These hosts must have Cloudflare's bot/security challenges skipped.
+#
+# - authentik.vollminlab.com: a fresh browser session (incognito, first visit)
+#   gets a managed challenge on the /api/v3/flows/executor/ fetch, which returns
+#   HTML instead of JSON and breaks the login flow with "Request failed and the
+#   interceptors did not return an alternative response". Authentik handles all
+#   authentication itself, so the challenge is redundant.
+# - jellyfin.vollminlab.com: native clients (Apple TV / tvOS, mobile apps)
+#   cannot solve JS challenges. Without this skip, /Videos/.../stream requests
+#   get a 403 challenge page and playback never starts (stops at 0 ms).
+#   Jellyfin has its own authentication. See docs/runbooks/jellyfin.md.
+#
+# NOTE: http_request_firewall_custom is an entrypoint ruleset — only ONE may
+# exist per zone, so every host skip must be a rule within this single ruleset.
 # ---------------------------------------------------------------------------
 
 resource "cloudflare_ruleset" "authentik_skip_challenges" {
   zone_id     = var.cloudflare_zone_id
-  name        = "Authentik — skip bot challenges"
-  description = "Bypass Cloudflare bot/security challenges for authentik.vollminlab.com so the login flow API calls are not intercepted"
+  name        = "Skip bot challenges for API/native clients"
+  description = "Bypass Cloudflare bot/security challenges for hosts whose clients cannot solve a managed challenge (Authentik login API, Jellyfin native players)"
   kind        = "zone"
   phase       = "http_request_firewall_custom"
 
@@ -25,6 +37,16 @@ resource "cloudflare_ruleset" "authentik_skip_challenges" {
       }
       expression  = "(http.host eq \"authentik.vollminlab.com\")"
       description = "Skip bot challenges for Authentik — IAM handles its own authentication"
+      enabled     = true
+    },
+    {
+      action = "skip"
+      action_parameters = {
+        phases   = ["http_ratelimit", "http_request_firewall_managed"]
+        products = ["bic", "hot", "rateLimit", "securityLevel", "uaBlock", "waf", "zoneLockdown"]
+      }
+      expression  = "(http.host eq \"jellyfin.vollminlab.com\")"
+      description = "Skip bot challenges for Jellyfin — native players (Apple TV/mobile) cannot solve JS challenges; Jellyfin handles its own authentication"
       enabled     = true
     }
   ]


### PR DESCRIPTION
## Problem

Media never starts playing on Jellyfin (Apple TV and external clients): you can browse, select a title, and press play, but it stalls and "stops at 0 ms".

## Root cause

Cloudflare issues a **managed bot challenge** (`cf-mitigated: challenge`, "Just a moment…", HTTP 403) on requests to `jellyfin.vollminlab.com`. Native players (tvOS/mobile) can't solve a JS challenge, so the `/Videos/.../stream` request gets the challenge HTML page instead of video → playback never begins. Small requests (metadata, artwork) slip through, which is why browsing works and masked the issue.

Verified during diagnosis:
- In-cluster stream of the same file: **HTTP 206, ~84 MB/s** — Jellyfin, storage, ffmpeg all healthy.
- Through Cloudflare (`jellyfin.vollminlab.com`): **HTTP 403 `cf-mitigated: challenge`** on every endpoint, regardless of User-Agent.
- Zero `/Videos/stream` requests reached the tunnel origin in the last 6h.

This is the same failure class as `authentik.vollminlab.com` (#648).

## Fix

Add a `skip` rule for `jellyfin.vollminlab.com` to the existing `http_request_firewall_custom` ruleset in `terraform/cloudflare/security.tf`. Cloudflare allows only one entrypoint ruleset per phase per zone, so the host skip is added as a rule within the existing ruleset (rather than a new ruleset). Applied automatically by the `cloudflare-config` tofu-controller CR on merge.

Also adds `docs/runbooks/jellyfin.md` documenting the split-horizon access architecture, the diagnosis procedure, and the LAN-vs-Cloudflare playback paths.

## Follow-up (not in this PR — manual)

- **Home Apple TV → direct LAN streaming:** point the Apple TV's DNS at Pi-hole so `jellyfin.vollminlab.com` resolves to the LAN ingress `192.168.152.244`, bypassing Cloudflare entirely (best for the ~20 GB remuxes). Apple TV → Settings → Network → Wi-Fi → Configure DNS → Manual.
- Large remuxes over Cloudflare free tier may still be throttled/terminated (TOS 2.8) even with the challenge lifted — see runbook note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)