### PR TITLE
fix(jellyfin): add nginx proxy annotations for media streaming

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/jellyfin/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/mediastack/jellyfin/app/ingress.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: mediastack
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     shlink.vollminlab.com/slug: jellyfin
   labels:
     app: jellyfin


### PR DESCRIPTION
## Summary

- Adds `proxy-buffering: off` and `proxy-request-buffering: off` so nginx streams HLS segments directly to the client instead of buffering the entire response in memory
- Adds `proxy-body-size: 0` and 1-hour read/send timeouts to prevent nginx killing long-lived streaming connections

## Context

Jellyfin streaming was failing with a black screen for clients on the internal nginx ingress path. Login and API calls worked fine (small, short-lived requests), but HLS segment fetches were being killed by nginx's default proxy buffering. Clients going through the Cloudflare tunnel were unaffected as they bypass nginx entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)