### PR TITLE
fix(ingress-nginx): raise memory limit 128Mi→256Mi (audit M6)

### DIFF
--- a/clusters/vollminlab-cluster/ingress-nginx/ingress-nginx/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/ingress-nginx/ingress-nginx/app/configmap.yaml
@@ -16,3 +16,10 @@ data:
         use-forwarded-headers: "true"
       extraArgs:
         default-ssl-certificate: cert-manager/wildcard-tls
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 256Mi


### PR DESCRIPTION
## Summary

- Raises ingress-nginx controller memory limit from `128Mi` → `256Mi`
- Raises request from `90Mi` → `128Mi` to match the previous limit (guaranteed scheduling headroom)
- CPU unchanged at `100m` request / `500m` limit

**Why:** Controller was OOMKilled on 2026-05-26 (observed in `lastState`). Current idle usage is ~64Mi; 256Mi gives 4× headroom for TLS handshake/connection spikes without being wasteful.

Closes #803

🤖 Generated with [Claude Code](https://claude.com/claude-code)