### PR TITLE
fix(portainer): hide internal auth login form (audit #797)

### DIFF
--- a/terraform/authentik/portainer.tf
+++ b/terraform/authentik/portainer.tf
@@ -11,7 +11,7 @@ resource "portainer_settings" "main" {
     user_identifier         = "preferred_username"
     scopes                  = "openid profile email groups"
     sso                     = true
-    hide_internal_auth      = false
+    hide_internal_auth      = true
     oauth_auto_create_users = true
     default_team_id         = 0
   }


### PR DESCRIPTION
## Summary

- Sets `hide_internal_auth = true` in `terraform/authentik/portainer.tf`
- Removes the local username/password login form from the Portainer UI when OAuth is active
- Portainer is already set to `AuthenticationMethod: 3 (OAuth)` — this closes the local-admin bypass confirmed via live API check

**Before:** Internal login form visible alongside "Login with Authentik" — local `admin` account usable as OAuth bypass  
**After:** Only "Login with Authentik" shown — no local credential path

Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)