### PR TITLE
fix(kyverno): promote require-standard-labels Audit→Enforce (audit M4)

### DIFF
--- a/.claude/rules/kyverno.md
+++ b/.claude/rules/kyverno.md
@@ -14,10 +14,11 @@ description: Kyverno policy rules, required labels, DMZ constraints, and enforce
 | No `hostPath`        | `hostPath` volumes are blocked                                            |
 | No default namespace | Pods may not run in the `default` namespace                               |
 | DMZ placement        | DMZ pods must run on `k8sworker05`/`k8sworker06` (injected automatically) |
+| Required labels      | Every pod/controller/namespace must have `app`, `env`, `category` labels  |
 
 ## Audit-mode policies (violations logged, not blocked)
 
-- Required labels (`app`, `env`, `category`) — pods missing these labels are logged but not blocked
+- None currently — all policies are in Enforce mode
 
 ## Valid `category` label values
 

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/require-labels.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/require-labels.yaml
@@ -13,7 +13,7 @@ metadata:
     env: production
     category: security
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: require-labels-on-controllers


### PR DESCRIPTION
## Summary

- Flips `validationFailureAction: Audit` → `Enforce` on the `require-standard-labels` ClusterPolicy
- Updates `.claude/rules/kyverno.md` to reflect the policy is now Enforce mode

**Pre-flight check:** Zero violations on `require-standard-labels` confirmed via `kubectl get policyreport -A` before opening this PR. Every pod, Deployment, StatefulSet, DaemonSet, and Namespace in the cluster already carries the required `app`, `env`, and `category` labels.

**Effect:** New pods/controllers/namespaces missing any of the three required labels will be blocked at admission. Existing running workloads are unaffected (Enforce only blocks new admissions, not existing pods).

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)