### PR TITLE
fix(kyverno): disable pod-level SA token automount for default SA pods (audit M7)

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/kustomization.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - inject-pod-labels.yaml
   - inject-resource-requirements.yaml
   - mutate-default-sa-automount.yaml
+  - mutate-default-sa-pod-automount.yaml
   - require-labels.yaml
   - require-resources.yaml
   - restrict-default.yaml

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/mutate-default-sa-pod-automount.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/mutate-default-sa-pod-automount.yaml
@@ -1,0 +1,48 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: mutate-default-sa-pod-automount
+  annotations:
+    policies.kyverno.io/title: Disable Pod Token Automounting for Default SA
+    policies.kyverno.io/category: Security
+    policies.kyverno.io/severity: medium
+    pod-policies.kyverno.io/autogen-controllers: none
+    policies.kyverno.io/description: >-
+      Sets automountServiceAccountToken=false at the pod spec level for pods
+      using the default ServiceAccount in non-system namespaces. Complements
+      mutate-default-sa-automount by overriding charts that hardcode
+      automountServiceAccountToken=true in the pod template (e.g. bazarr
+      k8s-home-lab chart which is not configurable via Helm values).
+  labels:
+    app: kyverno
+    env: production
+    category: security
+spec:
+  background: false
+  rules:
+    - name: disable-pod-automount-for-default-sa
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              namespaceSelector:
+                matchExpressions:
+                  - key: kubernetes.io/metadata.name
+                    operator: NotIn
+                    values:
+                      - kube-system
+                      - kube-public
+                      - kube-node-lease
+                      - calico-system
+                      - calico-apiserver
+                      - tigera-operator
+      preconditions:
+        all:
+          - key: "{{ request.object.spec.serviceAccountName || 'default' }}"
+            operator: Equals
+            value: default
+      mutate:
+        patchStrategicMerge:
+          spec:
+            automountServiceAccountToken: false


### PR DESCRIPTION
## Summary

- Adds `mutate-default-sa-pod-automount` ClusterPolicy targeting pods running as the `default` ServiceAccount
- Precondition matches pods with explicit or inherited `default` SA; namespace exclusions match the SA-level policy
- `pod-policies.kyverno.io/autogen-controllers: none` prevents autogen from generating broken controller variants
- Complements PR #847 (SA-level mutation) by handling charts like bazarr (k8s-home-lab chart) that hardcode `automountServiceAccountToken: true` in the pod template with no Helm values override
- Also: manually patched all 31 existing default SAs to `automountServiceAccountToken: false` (background scan would have taken ~1h; direct patch is safe since these are not Flux-managed objects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)