### PR TITLE
fix(mediastack): right-size gluetun and bazarr-exportarr memory (audit L7)

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/bazarr-exportarr/app/bazarr-exportarr-deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr-exportarr/app/bazarr-exportarr-deployment.yaml
@@ -42,7 +42,7 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 32Mi
+              memory: 64Mi
             limits:
               cpu: 150m
-              memory: 64Mi
+              memory: 128Mi

--- a/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
@@ -90,10 +90,10 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 64Mi
+              memory: 128Mi
             limits:
               cpu: 200m
-              memory: 128Mi
+              memory: 256Mi
           env:
             - name: VPN_SERVICE_PROVIDER
               value: "private internet access"


### PR DESCRIPTION
## Summary

- gluetun VPN sidecar (qbittorrent pod): 128Mi limit → 256Mi (request 64Mi → 128Mi)
- bazarr-exportarr: 64Mi limit → 128Mi (request 32Mi → 64Mi)
- Both containers OOMKilled on 2026-05-26; limits unchanged since then

🤖 Generated with [Claude Code](https://claude.com/claude-code)