### PR TITLE
fix(volsync): exclude mover pods from Velero FSB to fix PartiallyFailed backups (audit L4)

### DIFF
--- a/clusters/vollminlab-cluster/harbor/volsync/harbor-registry-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/harbor/volsync/harbor-registry-replicationsource.yaml
@@ -17,3 +17,7 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
+    moverPodTemplateSpec:
+      metadata:
+        annotations:
+          velero.io/exclude-from-backup: "true"

--- a/clusters/vollminlab-cluster/mediastack/volsync/audiobookshelf-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/audiobookshelf-config-replicationsource.yaml
@@ -17,3 +17,7 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
+    moverPodTemplateSpec:
+      metadata:
+        annotations:
+          velero.io/exclude-from-backup: "true"

--- a/clusters/vollminlab-cluster/mediastack/volsync/audiobookshelf-metadata-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/audiobookshelf-metadata-replicationsource.yaml
@@ -17,3 +17,7 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
+    moverPodTemplateSpec:
+      metadata:
+        annotations:
+          velero.io/exclude-from-backup: "true"

--- a/clusters/vollminlab-cluster/mediastack/volsync/bazarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/bazarr-config-replicationsource.yaml
@@ -17,3 +17,7 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
+    moverPodTemplateSpec:
+      metadata:
+        annotations:
+          velero.io/exclude-from-backup: "true"

--- a/clusters/vollminlab-cluster/mediastack/volsync/filebrowser-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/filebrowser-config-replicationsource.yaml
@@ -17,6 +17,10 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
+    moverPodTemplateSpec:
+      metadata:
+        annotations:
+          velero.io/exclude-from-backup: "true"
     moverSecurityContext:
       runAsUser: 1000
       runAsGroup: 1000

--- a/clusters/vollminlab-cluster/mediastack/volsync/jellyfin-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/jellyfin-config-replicationsource.yaml
@@ -17,3 +17,7 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
+    moverPodTemplateSpec:
+      metadata:
+        annotations:
+          velero.io/exclude-from-backup: "true"

--- a/clusters/vollminlab-cluster/mediastack/volsync/prowlarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/prowlarr-config-replicationsource.yaml
@@ -17,6 +17,10 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
+    moverPodTemplateSpec:
+      metadata:
+        annotations:
+          velero.io/exclude-from-backup: "true"
     moverSecurityContext:
       runAsUser: 568
       runAsGroup: 568

--- a/clusters/vollminlab-cluster/mediastack/volsync/qbittorrent-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/qbittorrent-config-replicationsource.yaml
@@ -17,3 +17,7 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
+    moverPodTemplateSpec:
+      metadata:
+        annotations:
+          velero.io/exclude-from-backup: "true"

--- a/clusters/vollminlab-cluster/mediastack/volsync/radarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/radarr-config-replicationsource.yaml
@@ -17,6 +17,10 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
+    moverPodTemplateSpec:
+      metadata:
+        annotations:
+          velero.io/exclude-from-backup: "true"
     moverSecurityContext:
       runAsUser: 568
       runAsGroup: 568

--- a/clusters/vollminlab-cluster/mediastack/volsync/readarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/readarr-config-replicationsource.yaml
@@ -17,6 +17,10 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
+    moverPodTemplateSpec:
+      metadata:
+        annotations:
+          velero.io/exclude-from-backup: "true"
     moverSecurityContext:
       runAsUser: 568
       runAsGroup: 568

--- a/clusters/vollminlab-cluster/mediastack/volsync/sabnzbd-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/sabnzbd-config-replicationsource.yaml
@@ -17,3 +17,7 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
+    moverPodTemplateSpec:
+      metadata:
+        annotations:
+          velero.io/exclude-from-backup: "true"

--- a/clusters/vollminlab-cluster/mediastack/volsync/seerr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/seerr-config-replicationsource.yaml
@@ -17,3 +17,7 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
+    moverPodTemplateSpec:
+      metadata:
+        annotations:
+          velero.io/exclude-from-backup: "true"

--- a/clusters/vollminlab-cluster/mediastack/volsync/sonarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/sonarr-config-replicationsource.yaml
@@ -17,6 +17,10 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
+    moverPodTemplateSpec:
+      metadata:
+        annotations:
+          velero.io/exclude-from-backup: "true"
     moverSecurityContext:
       runAsUser: 568
       runAsGroup: 568


### PR DESCRIPTION
## Summary

- Adds `velero.io/exclude-from-backup: "true"` to `moverPodTemplateSpec` on all 13 ReplicationSources (12 in `mediastack`, 1 in `harbor`)
- Root cause: VolumeSync mover pods (`volsync-src-*-restic-*`) run at 3am — the same time as Velero's `daily-full` backup schedule. Velero FSB discovers these ephemeral pods and tries to back up their `data` volume, but VolumeSync has already deleted the temporary PVC by the time the node-agent accesses it → 36 errors in today's backup
- This annotation tells Velero to skip these pods entirely at backup time. The actual data is protected by VolumeSync itself (restic to B2); Velero FSB of these mover pods is redundant and broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)