### PR TITLE
fix(velero): exclude VolSync mover pods from backups (stop PartiallyFailed)

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -161,6 +161,16 @@ data:
           resourcePolicy:
             kind: ConfigMap
             name: velero-skip-smb-policy
+          # Skip VolSync's transient mover pods/PVCs (label app.kubernetes.io/created-by:
+          # volsync). They are created then deleted mid-sync, so Velero hits "PVC not
+          # found" -> benign errors -> PartiallyFailed. NotIn also keeps all unlabeled
+          # resources (incl. the real app config PVCs), so actual data is still backed up.
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/created-by
+                operator: NotIn
+                values:
+                  - volsync
       daily-b2:
         disabled: false
         schedule: "0 4 * * *"
@@ -181,6 +191,16 @@ data:
           resourcePolicy:
             kind: ConfigMap
             name: velero-skip-smb-policy
+          # Skip VolSync's transient mover pods/PVCs (label app.kubernetes.io/created-by:
+          # volsync). They are created then deleted mid-sync, so Velero hits "PVC not
+          # found" -> benign errors -> PartiallyFailed. NotIn also keeps all unlabeled
+          # resources (incl. the real app config PVCs), so actual data is still backed up.
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/created-by
+                operator: NotIn
+                values:
+                  - volsync
       monthly-b2:
         disabled: false
         schedule: "0 6 1 * *"
@@ -201,6 +221,16 @@ data:
           resourcePolicy:
             kind: ConfigMap
             name: velero-skip-smb-policy
+          # Skip VolSync's transient mover pods/PVCs (label app.kubernetes.io/created-by:
+          # volsync). They are created then deleted mid-sync, so Velero hits "PVC not
+          # found" -> benign errors -> PartiallyFailed. NotIn also keeps all unlabeled
+          # resources (incl. the real app config PVCs), so actual data is still backed up.
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/created-by
+                operator: NotIn
+                values:
+                  - volsync
       victoria-metrics-b2:
         disabled: false
         schedule: "0 5 * * *"


### PR DESCRIPTION
## Problem
Velero `daily-full` (03:00) keeps showing **PartiallyFailed** (36 errors on Jun 2). Root cause: it runs at the exact time all VolSync ReplicationSources sync (03:00), so Velero catches VolSync's **transient mover pods** (`volsync-src-*`) and then can't find their ephemeral clone PVCs (VolSync deletes them mid-sync) → benign `PVC not found` errors.

**No data is lost** — all 82 real PVCs backed up successfully (PVBs Completed). It's pure noise that fires the `VeleroBackupPartiallyFailed` alert and masks genuine failures. Off-schedule backups (not overlapping 03:00) show 0 errors.

## Fix
Add a `labelSelector` to the `daily-full`, `daily-b2`, and `monthly-b2` schedule templates excluding VolSync-created resources:
```yaml
labelSelector:
  matchExpressions:
    - key: app.kubernetes.io/created-by
      operator: NotIn
      values: [volsync]
```
`NotIn` keeps all resources *without* the label (incl. the real app config PVCs), so backup coverage is unchanged — it only skips the transient movers. Mover label confirmed live (`app.kubernetes.io/created-by=volsync`). `victoria-metrics-b2` keeps its own selector.

## Why not the prior approach
PR #759 tried an `exclude:` field on the VolSync **ReplicationSource** — an invalid field on the wrong side — and was reverted. This is the correct **Velero-side** mechanism (`template.labelSelector` is natively supported on Schedules).

## Verify after merge
Next `daily-full` (03:00) should be **Completed** with 0 errors:
`kubectl get backups.velero.io -n velero -l velero.io/schedule-name=velero-daily-full --sort-by=.metadata.creationTimestamp -o custom-columns='NAME:.metadata.name,PHASE:.status.phase,ERR:.status.errors'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)