### PR TITLE
fix(longhorn): tighten storage scheduling thresholds to prevent over-allocation

### DIFF
--- a/clusters/vollminlab-cluster/longhorn-system/longhorn/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn/app/configmap.yaml
@@ -13,6 +13,8 @@ data:
       defaultReplicaCount: 3
       defaultDataPath: /var/lib/longhorn
       taintToleration: "dmz=true:NoSchedule;dmz=true:NoExecute"
+      storageOverProvisioningPercentage: 25
+      storageMinimalAvailablePercentage: 25
     longhornManager:
       podLabels:
         app: longhorn-manager


### PR DESCRIPTION
## Summary

- `storageOverProvisioningPercentage`: 100 → 25 (Longhorn's recommended default)
- `storageMinimalAvailablePercentage`: 15 → 25 (Longhorn's recommended default)

At 100% over-provisioning, Longhorn treats a 248Gi node as having 496Gi of schedulable capacity. This caused worker02 to accumulate 224Gi of replica allocations on a 248Gi disk (currently 84% full / 40Gi free). At 25%, nodes stop accepting new replicas when available disk drops to ~25%, preventing future over-allocation.

Does not rebalance existing replicas — only affects new scheduling decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)