### PR TITLE
fix(eso): add dockerconfigjson type to harbor pull secret ExternalSecrets

### DIFF
--- a/clusters/vollminlab-cluster/dmz/masters-league/app/harbor-vollminlab-pull-externalsecret.yaml
+++ b/clusters/vollminlab-cluster/dmz/masters-league/app/harbor-vollminlab-pull-externalsecret.yaml
@@ -15,6 +15,9 @@ spec:
   target:
     name: harbor-vollminlab-pull
     creationPolicy: Owner
+    template:
+      type: kubernetes.io/dockerconfigjson
+      engineVersion: v2
   data:
     - secretKey: .dockerconfigjson
       remoteRef:

--- a/clusters/vollminlab-cluster/flux-system/repositories/harbor-vollminlab-pull-externalsecret.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/harbor-vollminlab-pull-externalsecret.yaml
@@ -15,6 +15,9 @@ spec:
   target:
     name: harbor-vollminlab-pull
     creationPolicy: Owner
+    template:
+      type: kubernetes.io/dockerconfigjson
+      engineVersion: v2
   data:
     - secretKey: .dockerconfigjson
       remoteRef:


### PR DESCRIPTION
## Summary

- `dmz/masters-league` and `flux-system/repositories` ExternalSecrets for `harbor-vollminlab-pull` were missing `template.type: kubernetes.io/dockerconfigjson`
- ESO defaults to `Opaque` when type is omitted; containerd requires `kubernetes.io/dockerconfigjson` for imagePullSecrets
- This caused `masters-league` pods to get `no basic auth credentials` on Harbor pulls despite the secret existing
- `monitoring/` and `shlink/` copies already had the correct type — aligns all four

🤖 Generated with [Claude Code](https://claude.com/claude-code)