### PR TITLE
fix(velero): reduce daily-full TTL to 7 days and add MinIO disk alerts

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -203,3 +203,27 @@ spec:
           annotations:
             summary: "Longhorn node {{ $labels.node }} storage below 15% free"
             description: "Longhorn storage node {{ $labels.node }} has less than 15% free. New replicas may fail to schedule. Expand the disk or evict replicas."
+
+    - name: minio
+      rules:
+        - alert: MinioDiskUsageHigh
+          expr: |
+            kubelet_volume_stats_available_bytes{namespace="minio"}
+              / kubelet_volume_stats_capacity_bytes{namespace="minio"} < 0.20
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "MinIO PVC {{ $labels.persistentvolumeclaim }} below 20% free"
+            description: "MinIO PVC {{ $labels.persistentvolumeclaim }} has {{ $value | humanizePercentage }} free. Review Velero backup TTLs, Loki retention, and kopia GC status."
+
+        - alert: MinioDiskUsageCritical
+          expr: |
+            kubelet_volume_stats_available_bytes{namespace="minio"}
+              / kubelet_volume_stats_capacity_bytes{namespace="minio"} < 0.10
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "MinIO PVC {{ $labels.persistentvolumeclaim }} below 10% free"
+            description: "MinIO PVC {{ $labels.persistentvolumeclaim }} has {{ $value | humanizePercentage }} free. Immediate action required — node kubelet eviction threshold is ~10-15%."

--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -146,7 +146,7 @@ data:
         schedule: "0 3 * * *"
         useOwnerReferencesInBackup: false
         template:
-          ttl: 336h
+          ttl: 168h
           storageLocation: minio
           defaultVolumesToFsBackup: true
           excludedNamespaces:


### PR DESCRIPTION
## Summary

- Reduces `velero-daily-full` MinIO retention from 14 days (336h) to 7 days (168h) — halves steady-state kopia repo size in MinIO. Older data remains in B2 (daily-b2 at 90d, monthly-b2 at 365d, victoria-metrics-b2 at 90d).
- Adds `MinioDiskUsageHigh` (warning at <20%) and `MinioDiskUsageCritical` (critical at <10%) PrometheusRule alerts on MinIO PVC free space so disk pressure is caught before the kubelet eviction threshold (~10-15%) is hit.

## Context

Root cause of the 2026-06-03 worker04 DiskPressure cascade: gradual MinIO growth from 14 days of kopia FSB repos across all non-excluded namespaces, combined with Longhorn over-provisioning (fixed in #853) masking the headroom reduction. No alerting existed to catch the growth before kubelet eviction fired.

Note: the `monitoring` namespace was already excluded from `daily-full` and `daily-b2`; VictoriaMetrics is covered by the dedicated `victoria-metrics-b2` schedule. No namespace exclusion changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)