### PR TITLE
fix(volsync): remove moverPodTemplateSpec from all ReplicationSources

### DIFF
--- a/clusters/vollminlab-cluster/harbor/volsync/harbor-registry-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/harbor/volsync/harbor-registry-replicationsource.yaml
@@ -17,7 +17,3 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
-    moverPodTemplateSpec:
-      metadata:
-        annotations:
-          velero.io/exclude-from-backup: "true"

--- a/clusters/vollminlab-cluster/mediastack/volsync/audiobookshelf-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/audiobookshelf-config-replicationsource.yaml
@@ -17,7 +17,3 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
-    moverPodTemplateSpec:
-      metadata:
-        annotations:
-          velero.io/exclude-from-backup: "true"

--- a/clusters/vollminlab-cluster/mediastack/volsync/audiobookshelf-metadata-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/audiobookshelf-metadata-replicationsource.yaml
@@ -17,7 +17,3 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
-    moverPodTemplateSpec:
-      metadata:
-        annotations:
-          velero.io/exclude-from-backup: "true"

--- a/clusters/vollminlab-cluster/mediastack/volsync/bazarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/bazarr-config-replicationsource.yaml
@@ -17,7 +17,3 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
-    moverPodTemplateSpec:
-      metadata:
-        annotations:
-          velero.io/exclude-from-backup: "true"

--- a/clusters/vollminlab-cluster/mediastack/volsync/filebrowser-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/filebrowser-config-replicationsource.yaml
@@ -17,10 +17,6 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
-    moverPodTemplateSpec:
-      metadata:
-        annotations:
-          velero.io/exclude-from-backup: "true"
     moverSecurityContext:
       runAsUser: 1000
       runAsGroup: 1000

--- a/clusters/vollminlab-cluster/mediastack/volsync/jellyfin-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/jellyfin-config-replicationsource.yaml
@@ -17,7 +17,3 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
-    moverPodTemplateSpec:
-      metadata:
-        annotations:
-          velero.io/exclude-from-backup: "true"

--- a/clusters/vollminlab-cluster/mediastack/volsync/prowlarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/prowlarr-config-replicationsource.yaml
@@ -17,10 +17,6 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
-    moverPodTemplateSpec:
-      metadata:
-        annotations:
-          velero.io/exclude-from-backup: "true"
     moverSecurityContext:
       runAsUser: 568
       runAsGroup: 568

--- a/clusters/vollminlab-cluster/mediastack/volsync/qbittorrent-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/qbittorrent-config-replicationsource.yaml
@@ -17,7 +17,3 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
-    moverPodTemplateSpec:
-      metadata:
-        annotations:
-          velero.io/exclude-from-backup: "true"

--- a/clusters/vollminlab-cluster/mediastack/volsync/radarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/radarr-config-replicationsource.yaml
@@ -17,10 +17,6 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
-    moverPodTemplateSpec:
-      metadata:
-        annotations:
-          velero.io/exclude-from-backup: "true"
     moverSecurityContext:
       runAsUser: 568
       runAsGroup: 568

--- a/clusters/vollminlab-cluster/mediastack/volsync/readarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/readarr-config-replicationsource.yaml
@@ -17,10 +17,6 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
-    moverPodTemplateSpec:
-      metadata:
-        annotations:
-          velero.io/exclude-from-backup: "true"
     moverSecurityContext:
       runAsUser: 568
       runAsGroup: 568

--- a/clusters/vollminlab-cluster/mediastack/volsync/sabnzbd-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/sabnzbd-config-replicationsource.yaml
@@ -17,7 +17,3 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
-    moverPodTemplateSpec:
-      metadata:
-        annotations:
-          velero.io/exclude-from-backup: "true"

--- a/clusters/vollminlab-cluster/mediastack/volsync/seerr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/seerr-config-replicationsource.yaml
@@ -17,7 +17,3 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
-    moverPodTemplateSpec:
-      metadata:
-        annotations:
-          velero.io/exclude-from-backup: "true"

--- a/clusters/vollminlab-cluster/mediastack/volsync/sonarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/sonarr-config-replicationsource.yaml
@@ -17,10 +17,6 @@ spec:
     copyMethod: Clone
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
-    moverPodTemplateSpec:
-      metadata:
-        annotations:
-          velero.io/exclude-from-backup: "true"
     moverSecurityContext:
       runAsUser: 568
       runAsGroup: 568


### PR DESCRIPTION
## Summary

- Removes the invalid `moverPodTemplateSpec` field (+ `metadata`/`annotations`/`velero.io/exclude-from-backup`) from all 13 VolSync ReplicationSource files across harbor and mediastack namespaces
- This field does not exist in the installed VolSync CRD schema — its presence causes Flux to reject the manifests, leaving both kustomizations stuck at commit `24e0ca31` with `READY: False`
- The Velero exclusion goal (preventing mover pods from appearing as backup errors) is already handled by the Velero schedule `labelSelector` (`app.kubernetes.io/created-by: NotIn [volsync]`) added in PR #850 — so nothing is lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)