### PR TITLE
feat(security): add restrict-image-registries Kyverno policy and Renovate pinDigests (M3)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1278,7 +1278,7 @@ jobs:
             fi
             
             # Skip policy files themselves to avoid circular validation
-            if [[ "$file" =~ /kyverno/.*/policies/.*\.ya\?ml$ ]]; then
+            if [[ "$file" =~ /kyverno/.*/policies/.*\.(yaml|yml)$ ]]; then
               echo "Skipping policy file (avoiding circular validation): $file"
               continue
             fi

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/kustomization.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - require-labels.yaml
   - require-resources.yaml
   - restrict-default.yaml
+  - restrict-image-registries.yaml
   - restrict-hostpath.yaml
   - restrict-latest-tag.yaml
   - restrict-loadbalancer.yaml

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-image-registries.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-image-registries.yaml
@@ -1,0 +1,69 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-image-registries
+  annotations:
+    kyverno.io/enable-background: "true"
+    policies.kyverno.io/title: Restrict Image Registries
+    policies.kyverno.io/category: Supply Chain Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      Images must be pulled from approved registries. Short names without an
+      explicit registry domain (defaulting to docker.io) are also permitted.
+      Running in Audit mode — violations are reported but not blocked.
+  labels:
+    app: kyverno
+    env: production
+    category: security
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: restrict-image-registries-containers
+      match:
+        resources:
+          kinds:
+            - Deployment
+            - StatefulSet
+            - DaemonSet
+      validate:
+        message: "Image '{{ element.image }}' uses an unapproved registry. Allowed: harbor.vollminlab.com, ghcr.io, quay.io, registry.k8s.io, docker.io, mirror.gcr.io, oci.trueforge.org, reg.kyverno.io, us-docker.pkg.dev"
+        foreach:
+          - list: "request.object.spec.template.spec.containers"
+            deny:
+              conditions:
+                all:
+                  # Has an explicit registry domain (contains a dot before the first slash)
+                  - key: "{{ regex_match('^[a-z0-9][a-z0-9._-]*\\.[a-z]', element.image) }}"
+                    operator: Equals
+                    value: true
+                  # AND it is not one of the approved registries
+                  - key: "{{ regex_match('^(harbor\\.vollminlab\\.com|ghcr\\.io|quay\\.io|registry\\.k8s\\.io|docker\\.io|mirror\\.gcr\\.io|oci\\.trueforge\\.org|reg\\.kyverno\\.io|us-docker\\.pkg\\.dev)/', element.image) }}"
+                    operator: Equals
+                    value: false
+
+    - name: restrict-image-registries-init-containers
+      match:
+        resources:
+          kinds:
+            - Deployment
+            - StatefulSet
+            - DaemonSet
+      preconditions:
+        all:
+          - key: "{{ request.object.spec.template.spec.initContainers[] | length(@) }}"
+            operator: GreaterThanOrEquals
+            value: 1
+      validate:
+        message: "initContainer image '{{ element.image }}' uses an unapproved registry. Allowed: harbor.vollminlab.com, ghcr.io, quay.io, registry.k8s.io, docker.io, mirror.gcr.io, oci.trueforge.org, reg.kyverno.io, us-docker.pkg.dev"
+        foreach:
+          - list: "request.object.spec.template.spec.initContainers"
+            deny:
+              conditions:
+                all:
+                  - key: "{{ regex_match('^[a-z0-9][a-z0-9._-]*\\.[a-z]', element.image) }}"
+                    operator: Equals
+                    value: true
+                  - key: "{{ regex_match('^(harbor\\.vollminlab\\.com|ghcr\\.io|quay\\.io|registry\\.k8s\\.io|docker\\.io|mirror\\.gcr\\.io|oci\\.trueforge\\.org|reg\\.kyverno\\.io|us-docker\\.pkg\\.dev)/', element.image) }}"
+                    operator: Equals
+                    value: false

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-image-registries.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-image-registries.yaml
@@ -39,31 +39,7 @@ spec:
                   - key: "{{ regex_match('^[a-z0-9][a-z0-9._-]*\\.[a-z]', element.image) }}"
                     operator: Equals
                     value: true
-                  - key: "{{ starts_with(element.image, 'harbor.vollminlab.com/') }}"
-                    operator: Equals
-                    value: false
-                  - key: "{{ starts_with(element.image, 'ghcr.io/') }}"
-                    operator: Equals
-                    value: false
-                  - key: "{{ starts_with(element.image, 'quay.io/') }}"
-                    operator: Equals
-                    value: false
-                  - key: "{{ starts_with(element.image, 'registry.k8s.io/') }}"
-                    operator: Equals
-                    value: false
-                  - key: "{{ starts_with(element.image, 'docker.io/') }}"
-                    operator: Equals
-                    value: false
-                  - key: "{{ starts_with(element.image, 'mirror.gcr.io/') }}"
-                    operator: Equals
-                    value: false
-                  - key: "{{ starts_with(element.image, 'oci.trueforge.org/') }}"
-                    operator: Equals
-                    value: false
-                  - key: "{{ starts_with(element.image, 'reg.kyverno.io/') }}"
-                    operator: Equals
-                    value: false
-                  - key: "{{ starts_with(element.image, 'us-docker.pkg.dev/') }}"
+                  - key: "{{ regex_match('^(harbor\\.vollminlab\\.com|ghcr\\.io|quay\\.io|registry\\.k8s\\.io|docker\\.io|mirror\\.gcr\\.io|oci\\.trueforge\\.org|reg\\.kyverno\\.io|us-docker\\.pkg\\.dev)/', element.image) }}"  # yamllint disable-line rule:line-length
                     operator: Equals
                     value: false
 
@@ -89,30 +65,6 @@ spec:
                   - key: "{{ regex_match('^[a-z0-9][a-z0-9._-]*\\.[a-z]', element.image) }}"
                     operator: Equals
                     value: true
-                  - key: "{{ starts_with(element.image, 'harbor.vollminlab.com/') }}"
-                    operator: Equals
-                    value: false
-                  - key: "{{ starts_with(element.image, 'ghcr.io/') }}"
-                    operator: Equals
-                    value: false
-                  - key: "{{ starts_with(element.image, 'quay.io/') }}"
-                    operator: Equals
-                    value: false
-                  - key: "{{ starts_with(element.image, 'registry.k8s.io/') }}"
-                    operator: Equals
-                    value: false
-                  - key: "{{ starts_with(element.image, 'docker.io/') }}"
-                    operator: Equals
-                    value: false
-                  - key: "{{ starts_with(element.image, 'mirror.gcr.io/') }}"
-                    operator: Equals
-                    value: false
-                  - key: "{{ starts_with(element.image, 'oci.trueforge.org/') }}"
-                    operator: Equals
-                    value: false
-                  - key: "{{ starts_with(element.image, 'reg.kyverno.io/') }}"
-                    operator: Equals
-                    value: false
-                  - key: "{{ starts_with(element.image, 'us-docker.pkg.dev/') }}"
+                  - key: "{{ regex_match('^(harbor\\.vollminlab\\.com|ghcr\\.io|quay\\.io|registry\\.k8s\\.io|docker\\.io|mirror\\.gcr\\.io|oci\\.trueforge\\.org|reg\\.kyverno\\.io|us-docker\\.pkg\\.dev)/', element.image) }}"  # yamllint disable-line rule:line-length
                     operator: Equals
                     value: false

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-image-registries.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-image-registries.yaml
@@ -29,6 +29,11 @@ spec:
             - Deployment
             - StatefulSet
             - DaemonSet
+      preconditions:
+        all:
+          - key: "{{ request.object.spec.template.spec.containers[] | length(@) }}"
+            operator: GreaterThanOrEquals
+            value: 1
       validate:
         message: "Image '{{ element.image }}' uses an unapproved registry."
         foreach:

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-image-registries.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-image-registries.yaml
@@ -8,9 +8,12 @@ metadata:
     policies.kyverno.io/category: Supply Chain Security
     policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
-      Images must be pulled from approved registries. Short names without an
-      explicit registry domain (defaulting to docker.io) are also permitted.
-      Running in Audit mode — violations are reported but not blocked.
+      Images must be pulled from approved registries: harbor.vollminlab.com,
+      ghcr.io, quay.io, registry.k8s.io, docker.io, mirror.gcr.io,
+      oci.trueforge.org, reg.kyverno.io, us-docker.pkg.dev. Short names
+      without an explicit registry domain (defaulting to docker.io) are
+      also permitted. Running in Audit mode — violations are reported but
+      not blocked.
   labels:
     app: kyverno
     env: production
@@ -27,18 +30,40 @@ spec:
             - StatefulSet
             - DaemonSet
       validate:
-        message: "Image '{{ element.image }}' uses an unapproved registry. Allowed: harbor.vollminlab.com, ghcr.io, quay.io, registry.k8s.io, docker.io, mirror.gcr.io, oci.trueforge.org, reg.kyverno.io, us-docker.pkg.dev"
+        message: "Image '{{ element.image }}' uses an unapproved registry."
         foreach:
           - list: "request.object.spec.template.spec.containers"
             deny:
               conditions:
                 all:
-                  # Has an explicit registry domain (contains a dot before the first slash)
                   - key: "{{ regex_match('^[a-z0-9][a-z0-9._-]*\\.[a-z]', element.image) }}"
                     operator: Equals
                     value: true
-                  # AND it is not one of the approved registries
-                  - key: "{{ regex_match('^(harbor\\.vollminlab\\.com|ghcr\\.io|quay\\.io|registry\\.k8s\\.io|docker\\.io|mirror\\.gcr\\.io|oci\\.trueforge\\.org|reg\\.kyverno\\.io|us-docker\\.pkg\\.dev)/', element.image) }}"
+                  - key: "{{ starts_with(element.image, 'harbor.vollminlab.com/') }}"
+                    operator: Equals
+                    value: false
+                  - key: "{{ starts_with(element.image, 'ghcr.io/') }}"
+                    operator: Equals
+                    value: false
+                  - key: "{{ starts_with(element.image, 'quay.io/') }}"
+                    operator: Equals
+                    value: false
+                  - key: "{{ starts_with(element.image, 'registry.k8s.io/') }}"
+                    operator: Equals
+                    value: false
+                  - key: "{{ starts_with(element.image, 'docker.io/') }}"
+                    operator: Equals
+                    value: false
+                  - key: "{{ starts_with(element.image, 'mirror.gcr.io/') }}"
+                    operator: Equals
+                    value: false
+                  - key: "{{ starts_with(element.image, 'oci.trueforge.org/') }}"
+                    operator: Equals
+                    value: false
+                  - key: "{{ starts_with(element.image, 'reg.kyverno.io/') }}"
+                    operator: Equals
+                    value: false
+                  - key: "{{ starts_with(element.image, 'us-docker.pkg.dev/') }}"
                     operator: Equals
                     value: false
 
@@ -55,7 +80,7 @@ spec:
             operator: GreaterThanOrEquals
             value: 1
       validate:
-        message: "initContainer image '{{ element.image }}' uses an unapproved registry. Allowed: harbor.vollminlab.com, ghcr.io, quay.io, registry.k8s.io, docker.io, mirror.gcr.io, oci.trueforge.org, reg.kyverno.io, us-docker.pkg.dev"
+        message: "initContainer image '{{ element.image }}' uses an unapproved registry."
         foreach:
           - list: "request.object.spec.template.spec.initContainers"
             deny:
@@ -64,6 +89,30 @@ spec:
                   - key: "{{ regex_match('^[a-z0-9][a-z0-9._-]*\\.[a-z]', element.image) }}"
                     operator: Equals
                     value: true
-                  - key: "{{ regex_match('^(harbor\\.vollminlab\\.com|ghcr\\.io|quay\\.io|registry\\.k8s\\.io|docker\\.io|mirror\\.gcr\\.io|oci\\.trueforge\\.org|reg\\.kyverno\\.io|us-docker\\.pkg\\.dev)/', element.image) }}"
+                  - key: "{{ starts_with(element.image, 'harbor.vollminlab.com/') }}"
+                    operator: Equals
+                    value: false
+                  - key: "{{ starts_with(element.image, 'ghcr.io/') }}"
+                    operator: Equals
+                    value: false
+                  - key: "{{ starts_with(element.image, 'quay.io/') }}"
+                    operator: Equals
+                    value: false
+                  - key: "{{ starts_with(element.image, 'registry.k8s.io/') }}"
+                    operator: Equals
+                    value: false
+                  - key: "{{ starts_with(element.image, 'docker.io/') }}"
+                    operator: Equals
+                    value: false
+                  - key: "{{ starts_with(element.image, 'mirror.gcr.io/') }}"
+                    operator: Equals
+                    value: false
+                  - key: "{{ starts_with(element.image, 'oci.trueforge.org/') }}"
+                    operator: Equals
+                    value: false
+                  - key: "{{ starts_with(element.image, 'reg.kyverno.io/') }}"
+                    operator: Equals
+                    value: false
+                  - key: "{{ starts_with(element.image, 'us-docker.pkg.dev/') }}"
                     operator: Equals
                     value: false

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-image-registries.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-image-registries.yaml
@@ -29,15 +29,10 @@ spec:
             - Deployment
             - StatefulSet
             - DaemonSet
-      preconditions:
-        all:
-          - key: "{{ request.object.spec.template.spec.containers[] | length(@) }}"
-            operator: GreaterThanOrEquals
-            value: 1
       validate:
         message: "Image '{{ element.image }}' uses an unapproved registry."
         foreach:
-          - list: "request.object.spec.template.spec.containers"
+          - list: "spec.template.spec.containers || `[]`"
             deny:
               conditions:
                 all:
@@ -55,15 +50,10 @@ spec:
             - Deployment
             - StatefulSet
             - DaemonSet
-      preconditions:
-        all:
-          - key: "{{ request.object.spec.template.spec.initContainers[] | length(@) }}"
-            operator: GreaterThanOrEquals
-            value: 1
       validate:
         message: "initContainer image '{{ element.image }}' uses an unapproved registry."
         foreach:
-          - list: "request.object.spec.template.spec.initContainers"
+          - list: "spec.template.spec.initContainers || `[]`"
             deny:
               conditions:
                 all:

--- a/renovate.json5
+++ b/renovate.json5
@@ -52,7 +52,8 @@
     {
       "description": "Require manual review for all Flux HelmRelease updates",
       "matchManagers": ["flux"],
-      "automerge": false
+      "automerge": false,
+      "pinDigests": true
     },
     {
       "description": "Flag major updates with an additional label",


### PR DESCRIPTION
## Summary

Addresses security audit finding **M3 (Supply Chain Security)**.

- **New Kyverno ClusterPolicy `restrict-image-registries`** in Audit mode — violations are logged to policy reports but pods are not blocked. Approved registries: `harbor.vollminlab.com`, `ghcr.io`, `quay.io`, `registry.k8s.io`, `docker.io`, `mirror.gcr.io`, `oci.trueforge.org`, `reg.kyverno.io`, `us-docker.pkg.dev`. Short image names without an explicit registry domain (defaulting to docker.io) pass through. Covers `containers` and `initContainers` on `Deployment`, `StatefulSet`, `DaemonSet`.
- **Renovate `pinDigests: true`** added to the `flux` packageRule so OCIRepository refs automatically get digest pins on next Renovate run.

Audit mode is intentional — establishes a baseline of current violations before tightening to Enforce in a follow-up PR.