### PR TITLE
fix(security): add PSS warn+audit=restricted labels to 19 app namespaces (H2 step 1)

### DIFF
--- a/clusters/vollminlab-cluster/1password/namespace.yaml
+++ b/clusters/vollminlab-cluster/1password/namespace.yaml
@@ -6,3 +6,5 @@ metadata:
     app: onepassword-connect
     env: production
     category: security
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/clusters/vollminlab-cluster/authentik/namespace.yaml
+++ b/clusters/vollminlab-cluster/authentik/namespace.yaml
@@ -7,3 +7,5 @@ metadata:
     env: production
     category: security
     goldilocks.fairwinds.com/enabled: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/clusters/vollminlab-cluster/cert-manager/namespace.yaml
+++ b/clusters/vollminlab-cluster/cert-manager/namespace.yaml
@@ -7,3 +7,5 @@ metadata:
     env: production
     category: security
     goldilocks.fairwinds.com/enabled: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/clusters/vollminlab-cluster/cnpg-system/namespace.yaml
+++ b/clusters/vollminlab-cluster/cnpg-system/namespace.yaml
@@ -7,3 +7,5 @@ metadata:
     env: production
     category: storage
     goldilocks.fairwinds.com/enabled: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/clusters/vollminlab-cluster/external-dns/namespace.yaml
+++ b/clusters/vollminlab-cluster/external-dns/namespace.yaml
@@ -7,3 +7,5 @@ metadata:
     env: production
     category: networking
     goldilocks.fairwinds.com/enabled: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/clusters/vollminlab-cluster/external-secrets/namespace.yaml
+++ b/clusters/vollminlab-cluster/external-secrets/namespace.yaml
@@ -6,3 +6,5 @@ metadata:
     app: external-secrets
     env: production
     category: security
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/clusters/vollminlab-cluster/goldilocks/namespace.yaml
+++ b/clusters/vollminlab-cluster/goldilocks/namespace.yaml
@@ -6,3 +6,5 @@ metadata:
     app: goldilocks
     env: production
     category: observability
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/clusters/vollminlab-cluster/harbor/namespace.yaml
+++ b/clusters/vollminlab-cluster/harbor/namespace.yaml
@@ -7,3 +7,5 @@ metadata:
     env: production
     category: storage
     goldilocks.fairwinds.com/enabled: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/clusters/vollminlab-cluster/homepage/namespace.yaml
+++ b/clusters/vollminlab-cluster/homepage/namespace.yaml
@@ -7,3 +7,5 @@ metadata:
     env: production
     category: apps
     goldilocks.fairwinds.com/enabled: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/clusters/vollminlab-cluster/mediastack/namespace.yaml
+++ b/clusters/vollminlab-cluster/mediastack/namespace.yaml
@@ -7,3 +7,5 @@ metadata:
     env: production
     category: media
     goldilocks.fairwinds.com/enabled: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/clusters/vollminlab-cluster/minio/namespace.yaml
+++ b/clusters/vollminlab-cluster/minio/namespace.yaml
@@ -7,3 +7,5 @@ metadata:
     env: production
     category: storage
     goldilocks.fairwinds.com/enabled: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/clusters/vollminlab-cluster/monitoring/namespace.yaml
+++ b/clusters/vollminlab-cluster/monitoring/namespace.yaml
@@ -7,3 +7,5 @@ metadata:
     env: production
     category: observability
     goldilocks.fairwinds.com/enabled: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/clusters/vollminlab-cluster/portainer/namespace.yaml
+++ b/clusters/vollminlab-cluster/portainer/namespace.yaml
@@ -7,3 +7,5 @@ metadata:
     env: production
     category: apps
     goldilocks.fairwinds.com/enabled: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/clusters/vollminlab-cluster/reloader/namespace.yaml
+++ b/clusters/vollminlab-cluster/reloader/namespace.yaml
@@ -6,3 +6,5 @@ metadata:
     app: reloader
     env: production
     category: core
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/clusters/vollminlab-cluster/renovate/namespace.yaml
+++ b/clusters/vollminlab-cluster/renovate/namespace.yaml
@@ -7,3 +7,5 @@ metadata:
     env: production
     category: apps
     goldilocks.fairwinds.com/enabled: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/clusters/vollminlab-cluster/shlink/namespace.yaml
+++ b/clusters/vollminlab-cluster/shlink/namespace.yaml
@@ -7,3 +7,5 @@ metadata:
     env: production
     category: apps
     goldilocks.fairwinds.com/enabled: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/clusters/vollminlab-cluster/tailscale/namespace.yaml
+++ b/clusters/vollminlab-cluster/tailscale/namespace.yaml
@@ -6,3 +6,5 @@ metadata:
     app: tailscale-operator
     env: production
     category: networking
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/clusters/vollminlab-cluster/tofu/namespace.yaml
+++ b/clusters/vollminlab-cluster/tofu/namespace.yaml
@@ -7,3 +7,5 @@ metadata:
     env: production
     category: core
     goldilocks.fairwinds.com/enabled: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/clusters/vollminlab-cluster/trivy-system/namespace.yaml
+++ b/clusters/vollminlab-cluster/trivy-system/namespace.yaml
@@ -7,3 +7,5 @@ metadata:
     env: production
     category: security
     goldilocks.fairwinds.com/enabled: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted


### PR DESCRIPTION
## Summary

First step of H2 remediation (Pod Security Standards gap, issue #796).

Adds `pod-security.kubernetes.io/warn: restricted` and `pod-security.kubernetes.io/audit: restricted` to all 19 app namespaces that previously had no PSS labels:

`1password`, `authentik`, `cert-manager`, `cnpg-system`, `external-dns`, `external-secrets`, `goldilocks`, `harbor`, `homepage`, `mediastack`, `minio`, `monitoring`, `portainer`, `reloader`, `renovate`, `shlink`, `tailscale`, `tofu`, `trivy-system`

**Warn/audit mode surfaces violations without blocking any pods.** This is the baseline-establishment step before tightening to `enforce` in a follow-up PR.

Infrastructure namespaces with known privilege requirements (`kube-system`, `longhorn-system`, `ingress-nginx`, `velero`, `volsync-system`, `kyverno`, etc.) are excluded from this PR — they will be addressed separately with appropriate PSS levels.

`dmz` and `metallb-system` already had PSS labels and were not modified.