### PR TITLE
fix(kyverno): move foreach message inside foreach item (M3 policy fix)

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-image-registries.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-image-registries.yaml
@@ -30,9 +30,9 @@ spec:
             - StatefulSet
             - DaemonSet
       validate:
-        message: "Image '{{ element.image }}' uses an unapproved registry."
         foreach:
           - list: "spec.template.spec.containers || `[]`"
+            message: "Image '{{ element.image }}' uses an unapproved registry."
             deny:
               conditions:
                 all:
@@ -51,9 +51,9 @@ spec:
             - StatefulSet
             - DaemonSet
       validate:
-        message: "initContainer image '{{ element.image }}' uses an unapproved registry."
         foreach:
           - list: "spec.template.spec.initContainers || `[]`"
+            message: "initContainer image '{{ element.image }}' uses an unapproved registry."
             deny:
               conditions:
                 all:


### PR DESCRIPTION
## Summary

- Moves `message` from `validate` level into each `foreach` item in `restrict-image-registries`
- `element.image` is only in scope within the foreach context; referencing it at `validate.message` causes the Kyverno admission webhook to reject the policy at creation time with: `variable 'element.image' present outside of foreach at path /validate/message`
- Fixes the `kyverno-policies` kustomization which has been `Ready: False` since PR #857 merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)