### PR TITLE
fix(kyverno): use static validate.message for restrict-image-registries foreach.deny

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-image-registries.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-image-registries.yaml
@@ -30,9 +30,13 @@ spec:
             - StatefulSet
             - DaemonSet
       validate:
+        message: >-
+          Image uses a registry not in the approved list. Approved:
+          harbor.vollminlab.com, ghcr.io, quay.io, registry.k8s.io, docker.io,
+          mirror.gcr.io, oci.trueforge.org, reg.kyverno.io, us-docker.pkg.dev.
+          Short names without an explicit domain are also permitted.
         foreach:
           - list: "spec.template.spec.containers || `[]`"
-            message: "Image '{{ element.image }}' uses an unapproved registry."
             deny:
               conditions:
                 all:
@@ -51,9 +55,13 @@ spec:
             - StatefulSet
             - DaemonSet
       validate:
+        message: >-
+          initContainer image uses a registry not in the approved list. Approved:
+          harbor.vollminlab.com, ghcr.io, quay.io, registry.k8s.io, docker.io,
+          mirror.gcr.io, oci.trueforge.org, reg.kyverno.io, us-docker.pkg.dev.
+          Short names without an explicit domain are also permitted.
         foreach:
           - list: "spec.template.spec.initContainers || `[]`"
-            message: "initContainer image '{{ element.image }}' uses an unapproved registry."
             deny:
               conditions:
                 all:


### PR DESCRIPTION
## Summary

- Replaces `element.image` references in `validate.message` with static text listing the approved registries
- The policy logic (foreach deny conditions) is **unchanged**

## Why

Kyverno v1.18.1 enforces two constraints that rule out dynamic `element.*` messages:

1. The engine rejects `element.*` variables at the `validate.message` level: `variable 'element.image' present outside of foreach at path /validate/message`
2. Neither `kyverno.io/v1` nor `v2beta1` CRD schemas declare a `message` field on `ForEachValidation` items — so moving message inside `foreach` (PR #859) also fails: `field not declared in schema`

Static message at `validate` level is the only form accepted by both the CRD schema and the admission webhook on v1.18.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)