### PR TITLE
fix(pss): add PSA labels to infrastructure namespaces (H2 step 2)

### DIFF
--- a/clusters/vollminlab-cluster/actions-runner-system/namespace.yaml
+++ b/clusters/vollminlab-cluster/actions-runner-system/namespace.yaml
@@ -6,4 +6,7 @@ metadata:
     app: actions-runner-controller
     env: production
     category: ci
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
     goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/arc-controller/namespace.yaml
+++ b/clusters/vollminlab-cluster/arc-controller/namespace.yaml
@@ -6,4 +6,6 @@ metadata:
     app: arc-controller
     env: production
     category: ci
+    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/audit: baseline
     goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/ingress-nginx/namespace.yaml
+++ b/clusters/vollminlab-cluster/ingress-nginx/namespace.yaml
@@ -6,4 +6,6 @@ metadata:
     app: ingress-nginx
     env: production
     category: networking
+    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/audit: baseline
     goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/kube-system/namespace.yaml
+++ b/clusters/vollminlab-cluster/kube-system/namespace.yaml
@@ -6,3 +6,6 @@ metadata:
     app: kube-system
     env: production
     category: core
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/clusters/vollminlab-cluster/kyverno/namespace.yaml
+++ b/clusters/vollminlab-cluster/kyverno/namespace.yaml
@@ -6,4 +6,6 @@ metadata:
     app: kyverno
     env: production
     category: security
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted
     goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/local-path-storage/namespace.yaml
+++ b/clusters/vollminlab-cluster/local-path-storage/namespace.yaml
@@ -6,4 +6,6 @@ metadata:
     app: local-path-provisioner
     env: production
     category: storage
+    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/audit: baseline
     goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/longhorn-system/namespace.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/namespace.yaml
@@ -6,4 +6,7 @@ metadata:
     app: longhorn
     env: production
     category: storage
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
     goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/velero/namespace.yaml
+++ b/clusters/vollminlab-cluster/velero/namespace.yaml
@@ -6,4 +6,6 @@ metadata:
     app: velero
     env: production
     category: storage
+    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/audit: baseline
     goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/vollminlab-cluster/volsync-system/namespace.yaml
+++ b/clusters/vollminlab-cluster/volsync-system/namespace.yaml
@@ -6,4 +6,6 @@ metadata:
     app: volsync
     env: production
     category: storage
+    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/audit: baseline
     goldilocks.fairwinds.com/enabled: "true"


### PR DESCRIPTION
## Summary

- **privileged** (enforce+audit+warn): `kube-system`, `longhorn-system`, `actions-runner-system` — confirmed privileged containers live (kube-proxy, CSI-SMB, Longhorn engine/instance-manager/CSI, ARC runner DinD)
- **baseline** (warn+audit only): `ingress-nginx`, `velero`, `volsync-system`, `local-path-storage`, `arc-controller` — NET_BIND_SERVICE cap add or empty securityContext blocks restricted; warn/audit documents intended level
- **restricted** (warn+audit only): `kyverno` — all main controllers already compliant (runAsNonRoot=true, seccomp=RuntimeDefault); surfacing any edge cases (e.g. webhook-patcher Job)

Each namespace was inspected live before choosing the level. No enforce labels on baseline/restricted namespaces until violation baseline is reviewed.

Closes part of #796 (H2 step 2 of 3 — infra PSA labels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)