### PR TITLE
fix(monitoring): exclude VolumeSync mover pods from PodNotReady alert

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -161,7 +161,7 @@ spec:
         - alert: PodNotReady
           expr: |
             (
-              kube_pod_status_ready{condition="true",namespace!~"trivy-system|velero"} == 0
+              kube_pod_status_ready{condition="true",namespace!~"trivy-system|velero",pod!~"volsync-src-.*"} == 0
             ) unless on(pod, namespace)
               kube_pod_status_phase{phase=~"Succeeded|Failed"} == 1
           for: 15m


### PR DESCRIPTION
## Summary

- VolumeSync mover pods (`volsync-src-*`) run nightly at **03:00 UTC** cloning Longhorn PVCs for restic backup. The clone attachment routinely takes >15 minutes, tripping the `PodNotReady` alert for audiobookshelf, harbor, and all mediastack apps.
- Fix: add `pod!~"volsync-src-.*"` to the `PodNotReady` expression — one label selector change.
- Mover pods are short-lived Jobs; stuck movers are surfaced by the VolumeSync `ReplicationSource` status, not by `PodNotReady`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)