### PR TITLE
fix(longhorn): restore over-provisioning to 200% to unblock VolumeSync backups

### DIFF
--- a/clusters/vollminlab-cluster/longhorn-system/longhorn/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn/app/configmap.yaml
@@ -13,7 +13,7 @@ data:
       defaultReplicaCount: 3
       defaultDataPath: /var/lib/longhorn
       taintToleration: "dmz=true:NoSchedule;dmz=true:NoExecute"
-      storageOverProvisioningPercentage: 25
+      storageOverProvisioningPercentage: 200
       storageMinimalAvailablePercentage: 25
     longhornManager:
       podLabels:


### PR DESCRIPTION
## Summary

- Restores `storageOverProvisioningPercentage` from 25 → 200 (Longhorn default)
- PR #853 set this to 25%, which caps schedulable replicas at ~66GB per node (25% of 267GB disk max)
- All nodes already exceed 66GB scheduled from existing healthy volumes → no new replicas can be placed anywhere
- This blocked VolumeSync nightly backups at 03:00 UTC: all 13 `*-restic-src` clone volumes faulted because no nodes were schedulable
- `storageMinimalAvailablePercentage=25` (25% free floor) is retained — that setting is correct

## Root cause

`storageOverProvisioningPercentage` controls how much of the disk max can be allocated as thin-provisioned replicas. At 25%, a node with 267GB disk can only schedule 66.75GB total. Worker nodes already have 70–80GB of healthy PVC replicas scheduled, so any new replica (including VolumeSync temp clones) is rejected.

At 200%, the limit is 534GB — thin-provisioning is assumed, and actual free space (`storageMinimalAvailablePercentage=25`) acts as the real guard.

## Post-merge manual steps

After Flux reconciles the Longhorn HelmRelease:
1. Delete the 13 faulted `*-restic-src` PVCs in `mediastack` and `harbor` namespaces (VolumeSync temp clones, no persistent data)
2. Delete orphaned error-state instance manager `instance-manager-c947a6fd6746cbb145e38c668c64b20b` on k8sworker03

🤖 Generated with [Claude Code](https://claude.com/claude-code)