### PR TITLE
fix(longhorn): tighten over-provisioning to 100% as steady-state

### DIFF
--- a/clusters/vollminlab-cluster/longhorn-system/longhorn/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn/app/configmap.yaml
@@ -13,7 +13,7 @@ data:
       defaultReplicaCount: 3
       defaultDataPath: /var/lib/longhorn
       taintToleration: "dmz=true:NoSchedule;dmz=true:NoExecute"
-      storageOverProvisioningPercentage: 25
+      storageOverProvisioningPercentage: 200
       storageMinimalAvailablePercentage: 25
     longhornManager:
       podLabels:

--- a/clusters/vollminlab-cluster/longhorn-system/longhorn/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn/app/configmap.yaml
@@ -13,7 +13,7 @@ data:
       defaultReplicaCount: 3
       defaultDataPath: /var/lib/longhorn
       taintToleration: "dmz=true:NoSchedule;dmz=true:NoExecute"
-      storageOverProvisioningPercentage: 200
+      storageOverProvisioningPercentage: 100
       storageMinimalAvailablePercentage: 25
     longhornManager:
       podLabels:


### PR DESCRIPTION
## Summary

- Sets `storageOverProvisioningPercentage` from 200 → 100 as the permanent steady-state value
- Follows #867 (already merged), which set 25 → 200 to recover from the VolumeSync backup incident

## Rationale

- **200%** (#867) was a temporary recovery value — enough headroom to immediately unblock scheduling on all nodes
- **100%** is the correct steady-state: thin-provisioned replicas are capped at one full disk's worth of allocation per node
- `storageMinimalAvailablePercentage=25` (retained) is the real free-space guard — it prevents scheduling when less than 25% of actual disk space is free
- Together these mean: you can commit up to 100% of disk as PVC allocations, but never let real free space drop below 25%

🤖 Generated with [Claude Code](https://claude.com/claude-code)