### PR TITLE
feat(longhorn): add daily trim CronJob to reclaim thin-provisioned space

### DIFF
--- a/clusters/vollminlab-cluster/longhorn-system/longhorn-trim/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn-trim/app/cronjob.yaml
@@ -1,0 +1,49 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: longhorn-trim
+  namespace: longhorn-system
+  labels:
+    app: longhorn-trim
+    env: production
+    category: storage
+spec:
+  schedule: "0 6 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: longhorn-trim
+            env: production
+            category: storage
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: trim
+              image: alpine:3.23.4
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  apk add --no-cache curl jq
+                  echo "Longhorn filesystem trim starting - $(date)"
+                  VOLS=$(curl -sf http://longhorn-backend:9500/v1/volumes | jq -r '.data[] | select(.state=="attached") | .id')
+                  COUNT=0
+                  for VOL in $VOLS; do
+                    echo "Trimming: $VOL"
+                    curl -sf -X POST "http://longhorn-backend:9500/v1/volumes/${VOL}?action=trimFilesystem" >/dev/null \
+                      && COUNT=$((COUNT + 1)) \
+                      || echo "Warning: trim failed for $VOL"
+                  done
+                  echo "Done: trimmed $COUNT volumes - $(date)"
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi

--- a/clusters/vollminlab-cluster/longhorn-system/longhorn-trim/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn-trim/app/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 metadata:
-  name: longhorn-system
+  name: longhorn-trim
 resources:
-  - namespace.yaml
-  - ./longhorn/app
-  - ./longhorn-trim/app
+  - cronjob.yaml


### PR DESCRIPTION
## Summary

- Adds a `longhorn-trim` CronJob in `longhorn-system` that fires at 06:00 daily
- Iterates all attached Longhorn volumes via the internal API (`http://longhorn-backend:9500`) and calls `trimFilesystem` on each
- Schedules after overnight backup jobs (Velero full at 03:00, B2 at 04:00) so kopia GC's freed blocks get reclaimed the same morning

## Why this is needed

Longhorn doesn't auto-trim. When data is deleted inside a volume (kopia GC cleaning old backups, CNPG VACUUM, log rotation), the filesystem frees the blocks but the Longhorn replica sparse files keep them allocated. This causes apparent disk pressure on replica nodes even though the data is gone.

Today this caused worker02 and worker05 to become unschedulable — 20GB of freed-but-untrimmed blocks on the MinIO volume pushed them below the 25% `storageMinimalAvailablePercentage` floor. Manual `trimFilesystem` via the Longhorn API immediately recovered the space on both nodes.

Running this daily keeps the trim debt from accumulating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)