### PR TITLE
fix(homepage): set resources widget to cluster mode for aggregate CPU/memory

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -415,6 +415,7 @@ data:
             memory: true
             show: true
             showLabel: true
+            mode: cluster
         - datetime:
             show: true
             showLabel: true


### PR DESCRIPTION
## Summary

- Adds `mode: cluster` to the homepage `resources` widget
- Widget was previously showing CPU/memory for whichever node homepage happens to be scheduled on (currently worker04), making it meaningless as a cluster health indicator
- With `mode: cluster`, it aggregates across all nodes via the metrics API — showing actual cluster-wide utilization

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>