### PR TITLE
fix(homepage): cluster-wide resource widget + alertmanager firing alert counts

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -310,6 +310,22 @@ data:
                 icon: alertmanager.png
                 namespace: monitoring
                 app: alertmanager
+                widget:
+                  type: prometheusmetric
+                  url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+                  metrics:
+                    - label: Firing
+                      query: count(ALERTS{alertstate="firing"}) or vector(0)
+                      format:
+                        type: number
+                    - label: Critical
+                      query: count(ALERTS{alertstate="firing",severity="critical"}) or vector(0)
+                      format:
+                        type: number
+                    - label: Warning
+                      query: count(ALERTS{alertstate="firing",severity="warning"}) or vector(0)
+                      format:
+                        type: number
         - Tools:
             - Homepage:
                 description: This dashboard
@@ -410,12 +426,14 @@ data:
         - search:
             provider: google
             target: _blank
-        - resources:
-            cpu: true
-            memory: true
-            show: true
-            showLabel: true
-            mode: cluster
+        - kubernetes:
+            cluster:
+              show: true
+              cpu: true
+              memory: true
+              showLabel: true
+            nodes:
+              show: false
         - datetime:
             show: true
             showLabel: true


### PR DESCRIPTION
## Summary

- Replace the `resources` info widget (which reads only the local node homepage runs on) with the `kubernetes` info widget, which queries metrics-server and aggregates CPU/memory across all cluster nodes — makes the top-bar widget actually reflect cluster state
- Remove the `mode: cluster` option that was silently ignored by the `resources` widget (merged in #870 but had no effect)
- Add a `prometheusmetric` widget to the AlertManager service card showing total firing, critical, and warning alert counts queried directly from Prometheus — replaces the need to open the Alertmanager UI just to see if anything is on fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)