### PR TITLE
fix(homepage): grant nodes + metrics.k8s.io/nodes RBAC for kubernetes widget

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/rbac.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/rbac.yaml
@@ -7,39 +7,39 @@ metadata:
     env: production
     category: apps
 rules:
-- apiGroups:
-    - networking.k8s.io
-  resources:
-    - ingresses
-  verbs:
-    - get
-    - list
-    - watch
-- apiGroups:
-    - apps
-  resources:
-    - deployments
-  verbs:
-    - get
-    - list
-    - watch
-- apiGroups:
-    - ""
-  resources:
-    - nodes
-    - pods
-    - services
-  verbs:
-    - get
-    - list
-    - watch
-- apiGroups:
-    - metrics.k8s.io
-  resources:
-    - nodes
-  verbs:
-    - get
-    - list
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/clusters/vollminlab-cluster/homepage/homepage/app/rbac.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/rbac.yaml
@@ -26,12 +26,20 @@ rules:
 - apiGroups:
     - ""
   resources:
+    - nodes
     - pods
     - services
   verbs:
     - get
     - list
     - watch
+- apiGroups:
+    - metrics.k8s.io
+  resources:
+    - nodes
+  verbs:
+    - get
+    - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Summary

- Add `nodes` to the core API group in the homepage ClusterRole
- Add `metrics.k8s.io/nodes` get+list to the homepage ClusterRole

The `kubernetes` info widget (added in #871) calls `getNodeMetrics()` which lists nodes via the core API and then queries `metrics.k8s.io/nodes` for CPU/memory. Both were missing from the existing ClusterRole, producing a 403 and "API Error" in the widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)