### PR TITLE
feat(homepage): add VMware cluster CPU/memory/vmstore metrics to vCenter card

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -152,6 +152,25 @@ data:
                 href: https://vcenter.vollminlab.com
                 icon: vmware-esxi.png
                 ping: https://vcenter.vollminlab.com
+                widget:
+                  type: prometheusmetric
+                  url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+                  metrics:
+                    - label: CPU
+                      query: round(sum(vmware_host_cpu_usage{cluster_name="vollminlab-ESXi-Cluster"}) / sum(vmware_host_cpu_max{cluster_name="vollminlab-ESXi-Cluster"}) * 100, 0.1)
+                      format:
+                        type: number
+                        suffix: "%"
+                    - label: Memory
+                      query: round(sum(vmware_host_memory_usage{cluster_name="vollminlab-ESXi-Cluster"}) / sum(vmware_host_memory_max{cluster_name="vollminlab-ESXi-Cluster"}) * 100, 0.1)
+                      format:
+                        type: number
+                        suffix: "%"
+                    - label: vmstore
+                      query: round((1 - sum(vmware_datastore_freespace_size{ds_name=~"vmstore1|vmstore2"}) / sum(vmware_datastore_capacity_size{ds_name=~"vmstore1|vmstore2"})) * 100, 0.1)
+                      format:
+                        type: number
+                        suffix: "%"
             - ESXi 01:
                 description: VMware ESXi hypervisor 1
                 href: https://esxi01.vollminlab.com/ui/


### PR DESCRIPTION
## Summary

- Add `prometheusmetric` widget to the existing vCenter service card showing live VMware cluster metrics from `vmware_exporter` (already running in `monitoring`)
- **CPU%** — `sum(vmware_host_cpu_usage) / sum(vmware_host_cpu_max)` across all 3 ESXi hosts
- **Memory%** — same pattern for host memory
- **vmstore%** — `(1 - free/capacity)` for `vmstore1` + `vmstore2` combined (the primary shared datastores; local ESXi datastores excluded as they're mostly empty scratch space)

No new infrastructure needed — `vmware_exporter` is already scraping vCenter and Prometheus is already ingesting it.

Note on kubernetes widget disk: the homepage `kubernetes` info widget backend has no disk support (queries metrics-server for CPU/memory only). The `longhorn` info widget already in the top bar covers k8s storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)