### PR TITLE
fix(homepage): exclude Watchdog and InfoInhibitor from alertmanager widget counts

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -334,15 +334,15 @@ data:
                   url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
                   metrics:
                     - label: Firing
-                      query: count(ALERTS{alertstate="firing"}) or vector(0)
+                      query: count(ALERTS{alertstate="firing",alertname!~"Watchdog|InfoInhibitor"}) or vector(0)
                       format:
                         type: number
                     - label: Critical
-                      query: count(ALERTS{alertstate="firing",severity="critical"}) or vector(0)
+                      query: count(ALERTS{alertstate="firing",severity="critical",alertname!~"Watchdog|InfoInhibitor"}) or vector(0)
                       format:
                         type: number
                     - label: Warning
-                      query: count(ALERTS{alertstate="firing",severity="warning"}) or vector(0)
+                      query: count(ALERTS{alertstate="firing",severity="warning",alertname!~"Watchdog|InfoInhibitor"}) or vector(0)
                       format:
                         type: number
         - Tools:


### PR DESCRIPTION
## Summary

Add `alertname!~"Watchdog|InfoInhibitor"` to all three alert count queries.

- **Watchdog** — always-firing heartbeat alert built into kube-prometheus-stack to verify the alerting pipeline is alive. Not a real alert.
- **InfoInhibitor** — fires to trigger inhibition rules that suppress `info`-severity alerts. Also not a real alert.

Without this filter the widget counts 3 alerts firing when only 1 is real (e.g. MinioDiskUsageHigh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)