### PR TITLE
fix(cnpg-netpol): correct webhook port 443→9443 and add instance status egress (port 8000)

### DIFF
--- a/clusters/vollminlab-cluster/cnpg-system/networkpolicies/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/cnpg-system/networkpolicies/networkpolicy.yaml
@@ -41,7 +41,9 @@ spec:
         - protocol: TCP
           port: 53
 ---
-# Allow kube-apiserver (CP nodes) to call CNPG admission webhook (cnpg-webhook-service:443)
+# Allow kube-apiserver (CP nodes) to call CNPG admission webhook.
+# Service port is 443 but container (webhook-server) listens on 9443 — NetworkPolicy
+# is evaluated post-DNAT at the pod interface, so container port must be used.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -65,7 +67,7 @@ spec:
             cidr: 192.168.152.10/32
       ports:
         - protocol: TCP
-          port: 443
+          port: 9443
 ---
 # Allow Prometheus scraping from monitoring namespace
 apiVersion: networking.k8s.io/v1
@@ -124,3 +126,25 @@ spec:
     - ports:
         - protocol: TCP
           port: 443
+---
+# Allow CNPG operator to reach instance manager status API (port 8000) on database
+# pods in any namespace (authentik, harbor, mediastack, shlink, etc.)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-instance-status-egress
+  namespace: cnpg-system
+  labels:
+    app: cnpg
+    env: production
+    category: security
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 8000


### PR DESCRIPTION
## Summary

- **`allow-webhook-ingress`**: correct container port from 443 → 9443. NetworkPolicy is evaluated post-DNAT at the pod interface; the CNPG webhook container (`webhook-server`) listens on 9443, not the service port 443. The wrong port caused kube-apiserver webhook calls to time out, producing `ReconciliationFailed` on all kustomizations containing CNPG `Cluster` or `ScheduledBackup` objects (shlink, mediastack, authentik, harbor).
- **`allow-instance-status-egress`** (new): allow egress from cnpg-system to port 8000 in any namespace. The CNPG operator polls instance pods in other namespaces on port 8000 (instance manager status API). Without this, all 4 CNPG clusters logged `Instance Status Extraction Error: HTTP communication issue`.

Both bugs were introduced alongside the initial default-deny policy in PR #875 and discovered during post-merge service verification.