### PR TITLE
docs(networkpolicy): add rules file and CNPG port reference to close audit gap

### DIFF
--- a/.claude/rules/networkpolicy.md
+++ b/.claude/rules/networkpolicy.md
@@ -1,0 +1,69 @@
+---
+description: Mandatory port verification and checklist for writing or modifying NetworkPolicies
+---
+
+# NetworkPolicy Rules
+
+## The port trap — container port ≠ service port
+
+**NetworkPolicy is evaluated post-DNAT at the pod interface.** kube-proxy rewrites the destination
+port before the packet reaches the pod — so the port in a NetworkPolicy rule must be the
+**container port**, not the service port.
+
+Example: `cnpg-webhook-service` exposes port `443`, but the container (`webhook-server`) listens
+on `9443`. The NetworkPolicy must use `9443`. Using `443` silently allows nothing.
+
+**This class of bug has hit this cluster twice** — source-controller (PRs #548-549) and
+CNPG webhook (PR #875/876). It leaves no error on the NetworkPolicy itself; traffic is simply
+blocked with `context deadline exceeded` on the caller side.
+
+## Mandatory pre-write verification
+
+Before adding or changing any port in a NetworkPolicy, run both commands:
+
+```bash
+# 1. Find the service → targetPort mapping
+kubectl get svc -n <namespace> <service-name> -o yaml | grep -A5 "ports:"
+
+# 2. Confirm the actual containerPort on the pod
+kubectl get pod -n <namespace> -l <selector> \
+  -o jsonpath='{.items[0].spec.containers[*].ports}' | python3 -m json.tool
+```
+
+Use the `containerPort` value in the NetworkPolicy. If `targetPort` is a named port, look it up
+in the pod spec — named ports resolve to container ports.
+
+## Namespace container port reference
+
+Keep this table current whenever a new NetworkPolicy namespace is added.
+
+| Namespace | Container | Container port | Purpose | NetworkPolicy rule |
+|-----------|-----------|---------------|---------|-------------------|
+| `cnpg-system` | `manager` (cnpg-cloudnative-pg) | 9443 | webhook-server | allow-webhook-ingress ingress |
+| `cnpg-system` | `manager` (cnpg-cloudnative-pg) | 8080 | metrics | allow-monitoring-scrape ingress |
+| `cnpg-system` | n/a (egress target) | 8000 | CNPG instance status API (all namespaces) | allow-instance-status-egress egress |
+| `cnpg-system` | n/a (egress target) | 5432 | PostgreSQL (all namespaces) | *(not needed — operator doesn't connect directly)* |
+| `flux-system` | `source-controller` | 9090 | artifact serving | allow-source-controller-ingress ingress |
+
+Add a row here when writing a new NetworkPolicy with a port restriction. This is the source of
+truth — do not rely on service port numbers.
+
+## Checklist — before opening any NetworkPolicy PR
+
+- [ ] For every `port:` field, verify containerPort with `kubectl get pod ... ports` — not guessed, not from service YAML alone
+- [ ] For ingress rules: the port is reachable from the allowed source (test with `kubectl exec ... nc -zv <pod-ip> <port>` if uncertain)
+- [ ] For egress rules: the destination pod's containerPort is confirmed, not the service port
+- [ ] Default-deny policy exists in the namespace before allow rules are added (never add only allow rules without a deny)
+- [ ] DNS egress (UDP/TCP 53 to kube-dns) included if pods do any DNS lookups
+- [ ] Kube-apiserver egress (TCP 6443) included if the workload is a controller/operator watching CRDs
+- [ ] Monitoring ingress (from `monitoring` namespace) included for any pods with metrics endpoints
+
+## When adding a new namespace with default-deny
+
+Use the established template order:
+1. `default-deny-all` (podSelector: {}, both Ingress + Egress)
+2. `allow-dns` (UDP+TCP 53 to kube-dns)
+3. Ingress allows (webhook, monitoring scrape, etc.)
+4. Egress allows (kube-api, HTTPS, any cross-namespace ports)
+
+Always verify every port in the new namespace before committing — not after merge.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ GitOps-managed Kubernetes cluster using Flux CD. All workloads are Helm-based Fl
 - `.claude/rules/storage.md` — Longhorn capacity check before PVC sizing, replica math, online resize
 - `.claude/rules/velero.md` — backup schedules, circular backup check, kopia GC, status commands
 - `.claude/rules/git-workflow.md` — branch naming, session hygiene, /compact reminders
+- `.claude/rules/networkpolicy.md` — container port verification, per-namespace port table, pre-PR checklist
 
 **Operational runbooks** (reference when needed, not loaded every session):
 `docs/runbooks/` — flux-templates, kyverno-recovery, homepage, external-dns, incidents

--- a/docs/cluster-reference.md
+++ b/docs/cluster-reference.md
@@ -737,6 +737,29 @@ Two separate tunnels are deployed — one per externally-accessible media servic
 
 ---
 
+## CNPG (CloudNative-PG)
+
+Operator deployed in `cnpg-system`. Manages PostgreSQL clusters in other namespaces (authentik, harbor, mediastack/jellystat, shlink).
+
+### Container ports — cnpg-system operator pod
+
+| Port | Name | Purpose | NetworkPolicy rule |
+|------|------|---------|-------------------|
+| 9443 | `webhook-server` | Admission webhook — kube-apiserver calls this when validating CNPG CRs | `allow-webhook-ingress` ingress from CP node IPs |
+| 8080 | `metrics` | Prometheus metrics scrape | `allow-monitoring-scrape` ingress from `monitoring` ns |
+
+### Container ports — CNPG instance pods (all namespaces)
+
+| Port | Name | Purpose | NetworkPolicy rule |
+|------|------|---------|-------------------|
+| 5432 | `postgresql` | Client connections | per-namespace allow rule |
+| 9187 | `metrics` | Prometheus metrics | per-namespace allow rule |
+| 8000 | `status` | Instance manager status API — polled by CNPG operator | `allow-instance-status-egress` egress from cnpg-system |
+
+**Important**: `cnpg-webhook-service` exposes port `443` → `targetPort: 9443`. NetworkPolicies must use the container port `9443`, not the service port `443`. See `.claude/rules/networkpolicy.md` for the port-trap explanation.
+
+---
+
 ## Media Stack
 
 All apps in the `mediastack` namespace. Shared SMB storage mounted at the namespace level. App configs stored on Longhorn (5Gi RWO each, except Tautulli at 1Gi).


### PR DESCRIPTION
## Why

The webhook port bug (service port 443 vs container port 9443) has hit twice — source-controller (#548) and CNPG (#876). Root cause: the rule existed only in the auto-memory system, not in the `.claude/rules/` files that get loaded into context for every NetworkPolicy session. Memory requires proactive recall; a rules file is always present.

## What changed

**`.claude/rules/networkpolicy.md`** (new)
- Explains the post-DNAT port trap and why container port ≠ service port
- Mandatory pre-write verification commands (`kubectl get svc` + `kubectl get pod ... containerPort`)
- Per-namespace container port reference table (CNPG entries populated; add a row for each new namespace)
- Pre-PR checklist: DNS egress, kube-api egress, monitoring ingress, default-deny order

**`CLAUDE.md`**
- Adds `networkpolicy.md` to the essential reading list so it's loaded for every NetworkPolicy session

**`docs/cluster-reference.md`**
- New CNPG section documenting operator container ports (9443 webhook, 8080 metrics) and instance pod ports (5432, 9187, 8000)
- Explicit note that `cnpg-webhook-service` port 443 maps to container port 9443