### PR TITLE
fix(netpol): fix CNPG webhook timeout (ipBlock+IPIP RPF) and operator port 8000 gaps

### DIFF
--- a/.claude/rules/networkpolicy.md
+++ b/.claude/rules/networkpolicy.md
@@ -33,17 +33,49 @@ kubectl get pod -n <namespace> -l <selector> \
 Use the `containerPort` value in the NetworkPolicy. If `targetPort` is a named port, look it up
 in the pod spec — named ports resolve to container ports.
 
+## ipBlock is unsafe for cross-node host→pod traffic in Calico IPIP mode
+
+**Never use `ipBlock` to restrict which CP nodes can call a webhook.**
+
+On this cluster (Calico IPIP, Ubuntu 24.04), the kernel evaluates `rp_filter` on `tunl0` **before** nftables/Calico policy chains run. With `rp_filter=2` (strict mode), the kernel drops IPIP-decapsulated packets whose source IP's expected return route is the physical NIC rather than `tunl0`. The packet is silently discarded before Calico ever sees it — the nftables ipBlock rule sits at 0 counter matches, traffic appears blocked at the NetworkPolicy, but the real cause is the kernel RPF.
+
+**Symptoms:** `context deadline exceeded` on the caller; nftables counters for the ipBlock rule show 0 packets; `namespaceSelector`-based rules to the same pod work fine.
+
+**The fix:** For any ingress policy where the source is a CP/host IP (webhook callbacks, kubelet, etc.), use `from: []` (open to all sources) restricted only by `ports:`. The admission webhook itself provides TLS authentication; the port restriction alone is sufficient.
+
+```yaml
+# CORRECT — open source, port-restricted
+ingress:
+  - ports:
+      - protocol: TCP
+        port: 9443
+
+# BROKEN in Calico IPIP — ipBlock rules for CP host IPs are silently dropped
+ingress:
+  - from:
+      - ipBlock:
+          cidr: 192.168.152.8/32
+    ports:
+      - protocol: TCP
+        port: 9443
+```
+
+**This bug hit this cluster twice** — CNPG webhook (PRs #875/876/878) and prometheus-operator webhook (PR #878, same root cause). Both were fixed by removing ipBlock.
+
 ## Namespace container port reference
 
 Keep this table current whenever a new NetworkPolicy namespace is added.
 
 | Namespace | Container | Container port | Purpose | NetworkPolicy rule |
 |-----------|-----------|---------------|---------|-------------------|
-| `cnpg-system` | `manager` (cnpg-cloudnative-pg) | 9443 | webhook-server | allow-webhook-ingress ingress |
+| `cnpg-system` | `manager` (cnpg-cloudnative-pg) | 9443 | webhook-server | allow-webhook-ingress ingress (open source) |
 | `cnpg-system` | `manager` (cnpg-cloudnative-pg) | 8080 | metrics | allow-monitoring-scrape ingress |
 | `cnpg-system` | n/a (egress target) | 8000 | CNPG instance status API (all namespaces) | allow-instance-status-egress egress |
 | `cnpg-system` | n/a (egress target) | 5432 | PostgreSQL (all namespaces) | *(not needed — operator doesn't connect directly)* |
 | `flux-system` | `source-controller` | 9090 | artifact serving | allow-source-controller-ingress ingress |
+| `monitoring` | `kube-prometheus-stack-operator` | 10250 | prometheus-operator admission webhook | allow-webhook-ingress ingress (open source) |
+| `authentik` | n/a (ingress target) | 8000 | CNPG instance status API | allow-cnpg-operator ingress |
+| `harbor` | n/a (ingress target) | 8000 | CNPG instance status API | allow-cnpg-operator ingress |
 
 Add a row here when writing a new NetworkPolicy with a port restriction. This is the source of
 truth — do not rely on service port numbers.
@@ -53,10 +85,12 @@ truth — do not rely on service port numbers.
 - [ ] For every `port:` field, verify containerPort with `kubectl get pod ... ports` — not guessed, not from service YAML alone
 - [ ] For ingress rules: the port is reachable from the allowed source (test with `kubectl exec ... nc -zv <pod-ip> <port>` if uncertain)
 - [ ] For egress rules: the destination pod's containerPort is confirmed, not the service port
+- [ ] If source is a CP/host IP (webhook, kubelet): use `from: []` not `ipBlock` — see ipBlock section above
 - [ ] Default-deny policy exists in the namespace before allow rules are added (never add only allow rules without a deny)
 - [ ] DNS egress (UDP/TCP 53 to kube-dns) included if pods do any DNS lookups
 - [ ] Kube-apiserver egress (TCP 6443) included if the workload is a controller/operator watching CRDs
 - [ ] Monitoring ingress (from `monitoring` namespace) included for any pods with metrics endpoints
+- [ ] Any namespace with CNPG databases: `allow-cnpg-operator` must include both port 5432 AND port 8000
 
 ## When adding a new namespace with default-deny
 

--- a/clusters/vollminlab-cluster/authentik/networkpolicies/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/authentik/networkpolicies/networkpolicy.yaml
@@ -92,7 +92,9 @@ spec:
         - protocol: TCP
           port: 9443
 ---
-# Allow CNPG operator (cnpg-system) to manage authentik-db
+# Allow CNPG operator (cnpg-system) to manage authentik-db.
+# Port 5432: PostgreSQL connections. Port 8000: instance manager status API
+# (CNPG operator polls /pg/status on each database pod for health/fencing decisions).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -114,6 +116,8 @@ spec:
       ports:
         - protocol: TCP
           port: 5432
+        - protocol: TCP
+          port: 8000
 ---
 # Allow Prometheus scraping from monitoring namespace
 apiVersion: networking.k8s.io/v1

--- a/clusters/vollminlab-cluster/cnpg-system/networkpolicies/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/cnpg-system/networkpolicies/networkpolicy.yaml
@@ -44,6 +44,13 @@ spec:
 # Allow kube-apiserver (CP nodes) to call CNPG admission webhook.
 # Service port is 443 but container (webhook-server) listens on 9443 — NetworkPolicy
 # is evaluated post-DNAT at the pod interface, so container port must be used.
+#
+# ipBlock is NOT used here even though only CP nodes call the webhook. Calico IPIP
+# encapsulation causes the kernel to evaluate rp_filter on the tunl0 interface before
+# nftables chains run; strict RPF (rp_filter=2) drops the decapsulated inner packet
+# when the source IP's return route uses the physical NIC rather than tunl0. This
+# silently kills all host→pod ipBlock rules for cross-node traffic. Open from: [] is
+# safe because the webhook is TLS-authenticated and kube-apiserver is the only caller.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -58,14 +65,7 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    - from:
-        - ipBlock:
-            cidr: 192.168.152.8/32
-        - ipBlock:
-            cidr: 192.168.152.9/32
-        - ipBlock:
-            cidr: 192.168.152.10/32
-      ports:
+    - ports:
         - protocol: TCP
           port: 9443
 ---

--- a/clusters/vollminlab-cluster/harbor/networkpolicies/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/harbor/networkpolicies/networkpolicy.yaml
@@ -90,7 +90,9 @@ spec:
         - protocol: TCP
           port: 8443
 ---
-# Allow CNPG operator (cnpg-system) to manage harbor-db
+# Allow CNPG operator (cnpg-system) to manage harbor-db.
+# Port 5432: PostgreSQL connections. Port 8000: instance manager status API
+# (CNPG operator polls /pg/status on each database pod for health/fencing decisions).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -112,6 +114,8 @@ spec:
       ports:
         - protocol: TCP
           port: 5432
+        - protocol: TCP
+          port: 8000
 ---
 # Allow Prometheus scraping from monitoring namespace
 apiVersion: networking.k8s.io/v1

--- a/clusters/vollminlab-cluster/monitoring/networkpolicies/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/monitoring/networkpolicies/networkpolicy.yaml
@@ -118,7 +118,12 @@ spec:
         - protocol: TCP
           port: 9090
 ---
-# Allow kube-apiserver (CP nodes) to call prometheus-operator admission webhook (port 443)
+# Allow kube-apiserver (CP nodes) to call prometheus-operator admission webhook.
+# Container port is 10250 (named "https"); service maps 443→10250. Port 443 is NOT
+# a container port and must not appear here.
+#
+# ipBlock is NOT used — see cnpg-system allow-webhook-ingress for the explanation.
+# Calico IPIP + rp_filter=2 silently drops host→pod ipBlock rules for cross-node traffic.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -133,16 +138,7 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    - from:
-        - ipBlock:
-            cidr: 192.168.152.8/32
-        - ipBlock:
-            cidr: 192.168.152.9/32
-        - ipBlock:
-            cidr: 192.168.152.10/32
-      ports:
-        - protocol: TCP
-          port: 443
+    - ports:
         - protocol: TCP
           port: 10250
 ---


### PR DESCRIPTION
## Summary

- **Root cause of 4 failing kustomizations (authentik/harbor/mediastack/shlink):** `allow-webhook-ingress` in `cnpg-system` used `ipBlock` to restrict webhook callers to CP node IPs (192.168.152.8-10). On this cluster (Calico IPIP, Ubuntu 24.04, `rp_filter=2` on `tunl0`), the kernel evaluates RPF on the `tunl0` interface before nftables/Calico chains run. Strict RPF drops IPIP-decapsulated packets from CP host IPs because their expected return route is the physical NIC, not `tunl0`. Result: 0 packets ever matched the nftables ipBlock rule; kube-apiserver webhook calls silently timed out. Fix: open `from: []` with port-only restriction — TLS on the admission webhook is the authentication boundary.
- **Same fix applied to `monitoring/allow-webhook-ingress`** (prometheus-operator webhook) — same ipBlock pattern, same latent bug. Dead port `443` also removed (container listens on `10250`; service maps `443 → https → 10250`).
- **Port 8000 added to `allow-cnpg-operator`** in `authentik` and `harbor` — CNPG operator polls `/pg/status` (port 8000) on every database pod for health/fencing; the existing rules only allowed port 5432.
- **`.claude/rules/networkpolicy.md` updated** with the ipBlock+IPIP anti-pattern, a BROKEN/CORRECT example, updated container port reference table, and two new checklist items.

## Files changed

| File | Change |
|------|--------|
| `cnpg-system/networkpolicies/networkpolicy.yaml` | `allow-webhook-ingress`: remove ipBlock, open `from: []` on port 9443 |
| `monitoring/networkpolicies/networkpolicy.yaml` | `allow-webhook-ingress`: remove ipBlock, remove dead port 443, open `from: []` on port 10250 |
| `authentik/networkpolicies/networkpolicy.yaml` | `allow-cnpg-operator`: add port 8000 |
| `harbor/networkpolicies/networkpolicy.yaml` | `allow-cnpg-operator`: add port 8000 |
| `.claude/rules/networkpolicy.md` | Document ipBlock+IPIP limitation with example; update port table; add checklist items |

🤖 Generated with [Claude Code](https://claude.com/claude-code)