### PR TITLE
fix(kyverno): enforce restrict-image-registries policy (M3)

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-image-registries.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-image-registries.yaml
@@ -12,14 +12,13 @@ metadata:
       ghcr.io, quay.io, registry.k8s.io, docker.io, mirror.gcr.io,
       oci.trueforge.org, reg.kyverno.io, us-docker.pkg.dev. Short names
       without an explicit registry domain (defaulting to docker.io) are
-      also permitted. Running in Audit mode — violations are reported but
-      not blocked.
+      also permitted.
   labels:
     app: kyverno
     env: production
     category: security
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: restrict-image-registries-containers


### PR DESCRIPTION
## Summary

- Flips `restrict-image-registries` ClusterPolicy from `Audit` → `Enforce`
- Removes stale "Running in Audit mode" sentence from the description annotation
- Pre-flight checks confirmed **zero violations** in Audit mode before this change (all cluster images are from approved registries)

Closes #800