### PR TITLE
fix(arc-runners): allow egress to Harbor MetalLB VIP (192.168.152.245:443)

### DIFF
--- a/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/networkpolicy.yaml
@@ -40,16 +40,24 @@ spec:
       ports:
         - port: 6443
           protocol: TCP
-    # Harbor registry — target harbor namespace pods directly.
-    # Calico evaluates NetworkPolicy after kube-proxy DNAT, so ipBlock on the
-    # LoadBalancer VIP (192.168.152.245) never matches — the destination is already
-    # rewritten to the harbor-nginx pod IP (172.18.x.x) before Calico sees the packet.
+    # Harbor registry — two rules required because MetalLB L2 and ClusterIP have different DNAT timing.
+    # ClusterIP (10.102.38.65): kube-proxy DNAT rewrites 443→8443 locally before Calico evaluates;
+    # Calico sees post-DNAT pod IP → covered by the namespaceSelector rule.
+    # MetalLB VIP (192.168.152.245): ARP routes the packet to the MetalLB speaker node before local
+    # kube-proxy DNAT can fire; Calico sees the pre-DNAT destination (192.168.152.245:443) on the
+    # originating node → must use ipBlock on the VIP with the pre-DNAT service port (443).
     - to:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: harbor
       ports:
         - port: 8443
+          protocol: TCP
+    - to:
+        - ipBlock:
+            cidr: 192.168.152.245/32
+      ports:
+        - port: 443
           protocol: TCP
     # Public internet — GitHub, OCI registries, apt mirrors, etc.
     # All RFC 1918 ranges blocked to prevent accessing internal cluster services.


### PR DESCRIPTION
## Summary

- Adds `ipBlock: 192.168.152.245/32` on port 443 to the `arc-runners-egress` NetworkPolicy alongside the existing `namespaceSelector: harbor:8443` rule
- Both rules are now required due to different DNAT timing between ClusterIP and MetalLB L2 paths

## Root cause

MetalLB L2 uses ARP to route packets to the designated speaker node **before** local kube-proxy PREROUTING DNAT fires. Calico evaluates egress on the originating node and sees the pre-DNAT destination (`192.168.152.245:443`), not the harbor-nginx pod IP. The existing `namespaceSelector: harbor:8443` rule only matches after kube-proxy rewrites the destination — which works for ClusterIP (`10.102.38.65`) but not for the MetalLB VIP.

The public internet rule excludes all of `192.168.0.0/16`, which includes the VIP, so MetalLB VIP connections were silently dropped.

This was confirmed by 3-way connectivity test from an ARC runner pod:
- Direct pod IP → 200 OK ✓
- ClusterIP (`10.102.38.65:443`) → 200 OK ✓  
- MetalLB VIP (`192.168.152.245:443`) → timeout ✗

## Impact

All `Build and Push` CI runs in `longhorn-rebalancing-controller` have been failing with `dial tcp 192.168.152.245:443: i/o timeout` since Harbor's `default-deny-all` NetworkPolicy was added in #875. This PR unblocks those builds.

## Historical context

PR #602 removed the original `ipBlock: 192.168.152.245/32` approach and switched to `namespaceSelector: harbor:8443`, asserting that ipBlock on the VIP "never matches." That assertion was correct for the ClusterIP path — but the namespaceSelector approach relied on Harbor having no ingress NetworkPolicy (it accepted all connections). Now that Harbor has `default-deny-all` + `allow-arc-runners`, both egress paths are load-bearing and both rules are required.