### PR TITLE
fix(harbor): allow pod CIDR in loadbalancer ingress NetworkPolicy for ARC runner VIP traffic

### DIFF
--- a/clusters/vollminlab-cluster/harbor/networkpolicies/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/harbor/networkpolicies/networkpolicy.yaml
@@ -66,6 +66,9 @@ spec:
 # Allow external access via LoadBalancer (192.168.152.245). Harbor has no Ingress resource
 # — all traffic enters through the LoadBalancer. externalTrafficPolicy: Cluster means kube-proxy
 # SNATs external clients to the node IP, so source appears as 192.168.152.0/24 at the pod.
+# Pod-originated VIP traffic (e.g. ARC runners) takes a different path: kube-proxy KUBE-EXT
+# chain DNATs the VIP then masquerades using the tunl0 interface IP (172.18.x.x, Calico IPIP
+# tunnel, pod CIDR 172.18.0.0/16) — NOT the node eth0 IP. The second rule covers this case.
 # Harbor nginx container ports are 8080 (HTTP) and 8443 (HTTPS).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -87,6 +90,12 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
+        - protocol: TCP
+          port: 8443
+    - from:
+        - ipBlock:
+            cidr: 172.18.0.0/16
+      ports:
         - protocol: TCP
           port: 8443
 ---


### PR DESCRIPTION
## Summary

- Adds `172.18.0.0/16` (pod CIDR) to `allow-loadbalancer-ingress` NetworkPolicy for port 8443
- Fixes ARC runner CI builds that time out when pushing images to `harbor.vollminlab.com`
- Updates comment to document the KUBE-EXT masquerade behavior via Calico IPIP tunnel

## Root cause

When ARC runner pods on k8sworker02 connect to `harbor.vollminlab.com` (MetalLB VIP `192.168.152.245`), kube-proxy's **KUBE-EXT chain** handles the traffic:

1. DNATs `192.168.152.245:443` → `172.18.26.78:8443` (Harbor nginx pod on k8sworker04)
2. Marks for masquerade (KUBE-MARK-MASQ) — KUBE-EXT masquerades ALL sources, unlike KUBE-SVC which exempts pod-CIDR
3. nat POSTROUTING masquerade fires using the **`tunl0` interface IP** (`172.18.145.6/32`) because the packet routes via Calico's IPIP tunnel — NOT the node eth0 IP (`192.168.152.12`)

Harbor's `allow-loadbalancer-ingress` only allowed `192.168.152.0/24`. The masqueraded source `172.18.145.6` is in `172.18.0.0/16` (pod CIDR), so **1020 packets hit the default-deny drop** in Harbor's ingress Calico chain (`cali-tw-calid7a5ea11b9e`).

Confirmed with live nft chain inspection:
- `allow-loadbalancer-ingress` chain: **0 packets matched** despite 1020 arriving
- `tunl0` on k8sworker02: `inet 172.18.145.6/32 scope global tunl0`

## Security posture

- Only port 8443 (HTTPS) is opened for `172.18.0.0/16` — the pod CIDR is internal-only (no external exposure)
- Port 8080 (HTTP) is not added for the pod CIDR since CI traffic is HTTPS-only
- The `allow-arc-runners` namespaceSelector policy was added in PR #882 — that policy correctly identifies the runner namespace but only fires on **direct pod-to-pod** paths (ClusterIP/pod-IP); it does NOT fire on VIP paths where KUBE-EXT masquerades the source IP

## Verification

After merge + Flux reconcile (~10 min), re-trigger the `Build and Push` workflow in `k8s-vollminlab-cluster-longhorn-rebalancing-controller` to push chart `v0.1.0` to Harbor, then re-run CI on PR #881.

🤖 Generated with [Claude Code](https://claude.com/claude-code)