### PR TITLE
fix(longhorn-system): bump longhorn-rebalancing-controller to v0.1.1

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/longhorn-rebalancing-controller-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/longhorn-rebalancing-controller-ocirepository.yaml
@@ -11,6 +11,6 @@ spec:
   interval: 1h
   url: oci://harbor.vollminlab.com/vollminlab/charts/longhorn-rebalancing-controller
   ref:
-    tag: "0.1.0"
+    tag: "0.1.1"
   secretRef:
     name: harbor-vollminlab-pull


### PR DESCRIPTION
## Summary

- Bumps OCIRepository tag `0.1.0` → `0.1.1`

**What changed in v0.1.1:**
- Fixed CRD kind mismatch: `s.AddKnownTypes` registered Go struct names (`LonghornNode`) instead of actual CRD kinds (`Node`/`Replica`/`Volume`), causing the controller to crash-loop with `no matches for kind "LonghornNode" in version "longhorn.io/v1beta2"`
- Fixed missing RBAC: ClusterRole lacked `configmaps` `get`/`list`/`watch`, so every reconcile loop failed with a forbidden error when reading the config ConfigMap
- Fixed CI: Docker Hub rate limit on the `golang` base image — now pulled through Harbor's `dockerhub-proxy` project

🤖 Generated with [Claude Code](https://claude.com/claude-code)