### PR TITLE
feat(longhorn-system): enable longhorn-rebalancing-controller live mode

### DIFF
--- a/clusters/vollminlab-cluster/longhorn-system/longhorn-rebalancing-controller/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn-rebalancing-controller/app/configmap.yaml
@@ -18,7 +18,7 @@ data:
       - name: harbor-vollminlab-pull
 
     config:
-      dryRun: true
+      dryRun: false
 
     resources:
       requests:


### PR DESCRIPTION
## Summary

- Sets `dryRun: false` on the longhorn-rebalancing-controller

**Active safety config (all other values unchanged from defaults):**
- Evictions only during `02:00–05:00 UTC` maintenance window
- Max 2 evictions/day with 30-minute cooldown between each
- Smallest replica evicted first (minimises rebuild time)
- Safety gate blocks all evictions if any volume is unhealthy or any replica is currently rebuilding

**Current state:** k8sworker02 at 83.2% (threshold: 75%) — first live eviction will fire tonight during the maintenance window, moving a small replica off k8sworker02 so Longhorn rebuilds it on k8sworker03 or k8sworker06 (lowest utilisation nodes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)