### PR TITLE
chore(longhorn-system): bump longhorn-rebalancing-controller to v0.1.2

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/longhorn-rebalancing-controller-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/longhorn-rebalancing-controller-ocirepository.yaml
@@ -11,6 +11,6 @@ spec:
   interval: 1h
   url: oci://harbor.vollminlab.com/vollminlab/charts/longhorn-rebalancing-controller
   ref:
-    tag: "0.1.1"
+    tag: "0.1.2"
   secretRef:
     name: harbor-vollminlab-pull


### PR DESCRIPTION
## Summary

- Bumps OCIRepository tag from `0.1.1` → `0.1.2`
- v0.1.2 adds StorageClass-aware eviction gating (prevents DMZ eviction loop), corrects EvictionRequested byte accounting, tightens safety gates, and adds mode hysteresis
- Full changelog: vollminlab/longhorn-rebalancing-controller#4

🤖 Generated with [Claude Code](https://claude.com/claude-code)