### PR TITLE
chore(longhorn-rebalancing-controller): bump OCIRepository to v0.1.3

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/longhorn-rebalancing-controller-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/longhorn-rebalancing-controller-ocirepository.yaml
@@ -11,6 +11,6 @@ spec:
   interval: 1h
   url: oci://harbor.vollminlab.com/vollminlab/charts/longhorn-rebalancing-controller
   ref:
-    tag: "0.1.2"
+    tag: "0.1.3"
   secretRef:
     name: harbor-vollminlab-pull


### PR DESCRIPTION
## Summary

- Bumps `longhorn-rebalancing-controller` OCIRepository tag from `0.1.2` → `0.1.3`
- v0.1.3 fixes the safety gate that was blocking all evictions overnight — `robustness=unknown` (detached/idle Longhorn volumes) was incorrectly treated as a block condition; now only `degraded` and `faulted` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)