### PR TITLE
fix(authentik): force cloudflared http2 transport to clear degraded tunnel

### DIFF
--- a/clusters/vollminlab-cluster/authentik/cloudflared-authentik/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/authentik/cloudflared-authentik/app/deployment.yaml
@@ -25,6 +25,12 @@ spec:
           args:
             - tunnel
             - --no-autoupdate
+            # Force http2 (TCP) transport. The default `auto` protocol left this
+            # pod stuck retrying QUIC with "timeout: no recent network activity"
+            # on 3 of 4 edge connections (Cloudflare reported the tunnel degraded).
+            # http2 avoids UDP/7844 entirely and is sufficient for HTTP forward-auth.
+            - --protocol
+            - http2
             - run
           env:
             - name: TUNNEL_TOKEN


### PR DESCRIPTION
## Problem

The Authentik SSO Cloudflare tunnel (`cloudflared-authentik`) shows **degraded** in the Cloudflare dashboard. Its `cloudflared` pod runs with the default `auto` protocol and is stuck endlessly retrying QUIC:

```
WRN Failed to dial a quic connection error="failed to dial to edge with quic: timeout: no recent network activity"
```

The tunnel still serves traffic (`authentik.vollminlab.com` returns 302 in <100ms), but only partial edge connectivity is up → "degraded" / no HA.

## Why not just restart

A `rollout restart` was tried first. The fresh pod landed on a **different node** (k8sworker04) and **still** failed QUIC on `connIndex=0` — so the broken UDP/7844 path to the assigned Cloudflare edge IPs is the cause, not the node. The other three cluster tunnels happen to ride healthy QUIC paths; this one does not. Restart alone is not a durable fix.

## Fix

Force `--protocol http2` on this deployment's args. This switches the tunnel to TCP transport, sidestepping QUIC/UDP entirely. `http2` is fully sufficient for HTTP forward-auth (the only traffic this tunnel carries) and is Cloudflare's documented remedy for persistent QUIC "no recent network activity" timeouts.

Scope is limited to the `cloudflared-authentik` deployment — the other tunnels are untouched and keep using QUIC.

## After merge

Flux reconciles → pod restarts with http2 → verify the Cloudflare dashboard shows the tunnel **healthy** and `kubectl logs -n authentik deploy/cloudflared-authentik` shows clean `Registered tunnel connection` with no QUIC retry spam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)