### PR TITLE
fix(authentik): allow cloudflared egress to Cloudflare edge on port 7844

### DIFF
--- a/.claude/rules/networkpolicy.md
+++ b/.claude/rules/networkpolicy.md
@@ -75,6 +75,7 @@ Keep this table current whenever a new NetworkPolicy namespace is added.
 | `flux-system` | `source-controller` | 9090 | artifact serving | allow-source-controller-ingress ingress |
 | `monitoring` | `kube-prometheus-stack-operator` | 10250 | prometheus-operator admission webhook | allow-webhook-ingress ingress (open source) |
 | `authentik` | n/a (ingress target) | 8000 | CNPG instance status API | allow-cnpg-operator ingress |
+| `authentik` | n/a (egress target) | 7844 | Cloudflare tunnel edge (QUIC UDP + http2 TCP) | allow-external-egress egress |
 | `harbor` | n/a (ingress target) | 8000 | CNPG instance status API | allow-cnpg-operator ingress |
 
 Add a row here when writing a new NetworkPolicy with a port restriction. This is the source of

--- a/clusters/vollminlab-cluster/authentik/cloudflared-authentik/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/authentik/cloudflared-authentik/app/deployment.yaml
@@ -25,10 +25,10 @@ spec:
           args:
             - tunnel
             - --no-autoupdate
-            # Force http2 (TCP) transport. The default `auto` protocol left this
-            # pod stuck retrying QUIC with "timeout: no recent network activity"
-            # on 3 of 4 edge connections (Cloudflare reported the tunnel degraded).
-            # http2 avoids UDP/7844 entirely and is sufficient for HTTP forward-auth.
+            # Pin http2 (TCP) transport. The real cause of the degraded tunnel
+            # was the authentik egress NetworkPolicy blocking port 7844 (fixed in
+            # allow-external-egress); http2 keeps the edge connections on TCP and
+            # is sufficient for HTTP forward-auth — no UDP/QUIC path needed.
             - --protocol
             - http2
             - run

--- a/clusters/vollminlab-cluster/authentik/networkpolicies/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/authentik/networkpolicies/networkpolicy.yaml
@@ -181,7 +181,8 @@ spec:
         - protocol: TCP
           port: 9000
 ---
-# Allow external egress: Cloudflare tunnel (443), SMTP (587/465), OIDC providers
+# Allow external egress: Cloudflare tunnel (7844 QUIC/http2 + 443 fallback),
+# SMTP (587/465), OIDC providers (443)
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -199,6 +200,14 @@ spec:
     - ports:
         - protocol: TCP
           port: 443
+    # cloudflared connects to the Cloudflare edge on 7844 (QUIC over UDP,
+    # http2 over TCP). Without this, the tunnel falls back to a single
+    # TCP-443 connection and Cloudflare reports it degraded (1/4 HA conns).
+    - ports:
+        - protocol: TCP
+          port: 7844
+        - protocol: UDP
+          port: 7844
     - ports:
         - protocol: TCP
           port: 587


### PR DESCRIPTION
## Problem

The `cloudflared-authentik` SSO tunnel has been reporting **degraded** in the Cloudflare dashboard — only 1 of 4 HA edge connections healthy (`cloudflared_tunnel_ha_connections 1`).

Root cause: the authentik namespace egress NetworkPolicy `allow-external-egress` only permitted TCP **443/587/465**. cloudflared connects to the Cloudflare edge on port **7844** (QUIC over UDP, http2 over TCP). That port was silently dropped by the default-deny egress policy, so the tunnel survived only on a single TCP-443 fallback connection.

This is why the mediastack and ingress-nginx tunnels stayed healthy — those namespaces have **no** NetworkPolicies, so 7844 was never blocked.

## Why #888 didn't fix it

PR #888 added `--protocol http2`, on the theory that QUIC/UDP path quality was the issue. After merge, verification showed http2 **also** timed out (`dial tcp 198.41.192.167:7844: i/o timeout`) — because http2 dials the same port 7844, just over TCP, which the egress policy blocked identically. The protocol was never the problem; the egress filter was.

## Fix

- Add **TCP + UDP 7844** to `allow-external-egress` so cloudflared can establish all 4 edge connections.
- Keep `--protocol http2` — it pins the edge connections to TCP (no UDP/QUIC needed for HTTP forward-auth) and the comment is corrected to name the real root cause.
- Record the 7844 egress rule in the `networkpolicy.md` port reference table.

## Verification (after merge + Flux reconcile)

- `cloudflared_tunnel_ha_connections` reaches **4**
- pod logs show clean edge registrations with no `7844 i/o timeout`
- Cloudflare dashboard shows the tunnel **healthy**

🤖 Generated with [Claude Code](https://claude.com/claude-code)