### PR TITLE
fix(homepage): allow homepage widgets to reach authentik + grafana

### DIFF
--- a/.claude/rules/networkpolicy.md
+++ b/.claude/rules/networkpolicy.md
@@ -74,6 +74,9 @@ Keep this table current whenever a new NetworkPolicy namespace is added.
 | `cnpg-system` | n/a (egress target) | 5432 | PostgreSQL (all namespaces) | *(not needed — operator doesn't connect directly)* |
 | `flux-system` | `source-controller` | 9090 | artifact serving | allow-source-controller-ingress ingress |
 | `monitoring` | `kube-prometheus-stack-operator` | 10250 | prometheus-operator admission webhook | allow-webhook-ingress ingress (open source) |
+| `monitoring` | `grafana` | 3000 | Grafana HTTP (homepage widget) | allow-homepage-grafana ingress (from homepage) |
+| `monitoring` | `prometheus` | 9090 | Prometheus HTTP (homepage widget) | allow-homepage-prometheus ingress (from homepage) |
+| `authentik` | `server` | 9000 | authentik-server HTTP (homepage widget) | allow-homepage ingress (from homepage) |
 | `authentik` | n/a (ingress target) | 8000 | CNPG instance status API | allow-cnpg-operator ingress |
 | `authentik` | n/a (egress target) | 7844 | Cloudflare tunnel edge (QUIC UDP + http2 TCP) | allow-external-egress egress |
 | `harbor` | n/a (ingress target) | 8000 | CNPG instance status API | allow-cnpg-operator ingress |

--- a/clusters/vollminlab-cluster/authentik/networkpolicies/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/authentik/networkpolicies/networkpolicy.yaml
@@ -92,6 +92,32 @@ spec:
         - protocol: TCP
           port: 9443
 ---
+# Allow the homepage dashboard to reach authentik-server for its status widget.
+# Homepage calls http://authentik-server.authentik.svc.cluster.local (svc port 80),
+# which DNATs to container port 9000. Without this the request is dropped by
+# default-deny and the widget reports "API Error: connect ETIMEDOUT".
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-homepage
+  namespace: authentik
+  labels:
+    app: authentik
+    env: production
+    category: security
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: homepage
+      ports:
+        - protocol: TCP
+          port: 9000
+---
 # Allow CNPG operator (cnpg-system) to manage authentik-db.
 # Port 5432: PostgreSQL connections. Port 8000: instance manager status API
 # (CNPG operator polls /pg/status on each database pod for health/fencing decisions).

--- a/clusters/vollminlab-cluster/monitoring/networkpolicies/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/monitoring/networkpolicies/networkpolicy.yaml
@@ -118,6 +118,32 @@ spec:
         - protocol: TCP
           port: 9090
 ---
+# Allow the homepage dashboard to reach Grafana for its status widget.
+# Homepage calls http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local:80,
+# which DNATs to container port 3000. Without this the request is dropped by
+# default-deny and the widget reports "API Error: connect ETIMEDOUT".
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-homepage-grafana
+  namespace: monitoring
+  labels:
+    app: monitoring
+    env: production
+    category: security
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: homepage
+      ports:
+        - protocol: TCP
+          port: 3000
+---
 # Allow kube-apiserver (CP nodes) to call prometheus-operator admission webhook.
 # Container port is 10250 (named "https"); service maps 443→10250. Port 443 is NOT
 # a container port and must not appear here.


### PR DESCRIPTION
## Problem

The **Authentik** and **Grafana** homepage status widgets were failing with `API Error: connect ETIMEDOUT`.

Both widgets call the backend ClusterIP directly from the `homepage` namespace:

| Widget | Target | Service port → container port |
|--------|--------|------------------------------|
| Authentik | `authentik-server.authentik.svc.cluster.local` | 80 → **9000** |
| Grafana | `kube-prometheus-stack-grafana.monitoring.svc.cluster.local:80` | 80 → **3000** |

Neither namespace had a NetworkPolicy permitting ingress from the `homepage` namespace to those ports, so `default-deny-all` silently dropped the packets → `ETIMEDOUT`. The **Prometheus** widget kept working only because `allow-homepage-prometheus` already opened port 9090 from homepage — that contrast is what localised the fault.

This is not an auth/API-key problem: the `homepage-env-vars` ExternalSecret is `SecretSynced=True`, and the error is a connection timeout, not 401/403.

## Fix

Two **additive** ingress policies (no existing traffic affected). NetworkPolicy is evaluated post-DNAT at the pod, so the rules target the **container ports** (9000 / 3000), verified against the live pod specs — not service port 80.

- `authentik/allow-homepage` — homepage → 9000
- `monitoring/allow-homepage-grafana` — homepage → 3000

Also adds the new port rows to `.claude/rules/networkpolicy.md` (the per-namespace port reference table).

## Verification (post-merge, after Flux reconciles)

Both widgets render data on the homepage dashboard; nginx/backends already healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)