### PR TITLE
fix(monitoring): add resources + relax liveness probe for kube-state-metrics

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -214,3 +214,23 @@ data:
         app: kube-state-metrics
         env: production
         category: observability
+      # Kyverno requires CPU+memory requests and limits on every pod. The subchart
+      # ships with resources: {} (none), so KSM ran unbounded. Sized from observed
+      # usage: ~43Mi steady, ~127Mi 24h peak — 256Mi limit gives ~2x headroom.
+      resources:
+        requests:
+          cpu: 25m
+          memory: 96Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi
+      # Relax the liveness probe so a brief kube-apiserver blip does not crash-loop
+      # KSM. /livez makes a live API call; the default 5s timeout / 3 failures (~30s)
+      # is too tight on this cluster, which sees occasional shared-storage etcd
+      # latency spikes that briefly stall the apiserver. 10s timeout / 5 failures
+      # (~50s) rides out a transient stall without restarting. Readiness is left at
+      # default — a brief readiness failure only drops KSM from its Service (a short
+      # metrics gap), it does not restart the pod.
+      livenessProbe:
+        failureThreshold: 5
+        timeoutSeconds: 10


### PR DESCRIPTION
## What

Hardens `kube-state-metrics` (kube-prometheus-stack subchart) against transient kube-apiserver blips, via values-only changes in the existing `kube-prometheus-stack/app/configmap.yaml`.

- **Relax the liveness probe** to `failureThreshold: 5` / `timeoutSeconds: 10` (~50s of sustained unreachability before restart, vs the chart default ~30s). KSM's `/livez` makes a *live* API call, so a slow apiserver fails the probe. Readiness is left at default — a readiness failure only drops KSM from its Service (a short metrics gap), it does not restart the pod.
- **Add `resources` requests/limits** — the subchart ships `resources: {}` (unbounded). Sized from observed usage (~43Mi steady, ~127Mi 24h peak → `256Mi` limit, ~2× headroom). Also satisfies the Kyverno resource-limits enforce policy, which KSM was previously slipping past.

## Why

During the **2026-06-16 17:25–17:30 UTC** incident, all three CP etcd members spiked simultaneously (WAL fsync p99 ~1.7s, backend commit p99 ~3.1s — shared pool_1 / `ds-k8s-cp-ssd` contention, **not** a single node's disk). That briefly stalled the kube-apiserver and KSM crash-looped on its `/livez` probe (`PodCrashLooping` ×10, `AlertmanagerFailedToSendAlerts`). KSM then restarted **again at 19:24 with zero etcd involvement** — purely the aggressive probe tripping on a transient apiserver moment — confirming the probe is too tight for this cluster's storage profile.

## Scope / what this does NOT fix

This does **not** address the root cause — the recurring shared-storage etcd-latency spikes are an infra/TrueNAS-layer concern (candidate triggers: Minecraft world snapshots, TrueNAS scrub/replication, or a noisy co-tenant VM on `ds-k8s-cp-ssd`). This PR only stops KSM from amplifying a brief, self-healing apiserver blip into a crash-loop and alert noise.

## Verification

Subchart (kube-state-metrics 7.4.0) rendered locally with the override: confirms `resources` applied (all four request/limit fields) and the probe merges to `failureThreshold: 5, timeoutSeconds: 10` while preserving the template's `path: /livez` / `port: http`. Live reconciliation is async via Flux.