### PR TITLE
feat(minio): alert on offline drive + drive I/O errors

### DIFF
--- a/clusters/vollminlab-cluster/minio/minio/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/minio/minio/app/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - minio-credentials-externalsecret.yaml
   - minio-oidc-credentials-externalsecret.yaml
   - servicemonitor.yaml
+  - prometheusrule.yaml

--- a/clusters/vollminlab-cluster/minio/minio/app/prometheusrule.yaml
+++ b/clusters/vollminlab-cluster/minio/minio/app/prometheusrule.yaml
@@ -31,7 +31,13 @@ spec:
             severity: critical
           annotations:
             summary: "MinIO has {{ $value }} drive(s) offline — writes are failing silently"
-            description: "minio_cluster_drive_offline_total={{ $value }} for >10m. This is a single-drive deployment, so MinIO is returning 503 to all clients (velero, terraform-state, CNPG backups, loki). Likely a stale Longhorn mount: check `mc admin info` and `ls /export` for I/O errors; recover by scaling minio to 0, waiting for the Longhorn volume to detach, then back to 1."
+            description: >-
+              minio_cluster_drive_offline_total={{ $value }} for >10m. This is a
+              single-drive deployment, so MinIO is returning 503 to all clients
+              (velero, terraform-state, CNPG backups, loki). Likely a stale Longhorn
+              mount: check `mc admin info` and `ls /export` for I/O errors; recover
+              by scaling minio to 0, waiting for the Longhorn volume to detach, then
+              back to 1.
 
         # Complementary failure mode: a drive that is still counted "online" but
         # actively throwing I/O errors (flaky storage, severed handle mid-flight).
@@ -44,4 +50,9 @@ spec:
             severity: warning
           annotations:
             summary: "MinIO drive is logging I/O errors"
-            description: "minio_node_drive_errors_ioerror is incrementing for >10m on {{ $labels.server }}. The underlying drive (Longhorn volume) is throwing I/O errors even if not yet marked offline — investigate the volume mount and Longhorn replica health before it degrades to fully offline."
+            description: >-
+              minio_node_drive_errors_ioerror is incrementing for >10m on
+              {{ $labels.server }}. The underlying drive (Longhorn volume) is
+              throwing I/O errors even if not yet marked offline — investigate the
+              volume mount and Longhorn replica health before it degrades to fully
+              offline.

--- a/clusters/vollminlab-cluster/minio/minio/app/prometheusrule.yaml
+++ b/clusters/vollminlab-cluster/minio/minio/app/prometheusrule.yaml
@@ -1,0 +1,47 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: minio-rules
+  namespace: minio
+  labels:
+    app: minio
+    env: production
+    category: storage
+    # Required for the kube-prometheus-stack Prometheus to select this rule.
+    # ruleSelector matches release=kube-prometheus-stack; ruleNamespaceSelector
+    # is empty (all namespaces), so a rule in the minio namespace is picked up.
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: minio.drives
+      rules:
+        # On 2026-06-16 a Longhorn engine reconnect (triggered by an etcd
+        # storage-latency storm) severed MinIO's mount of /export. MinIO's
+        # process kept running (0 restarts) so nothing crashed or alerted, but
+        # it served 503 SlowDownWrite to every client — velero, terraform-state,
+        # CNPG backups, loki compactor — for ~3h until loki crashlooped and
+        # surfaced it. This is a single-drive (EC:0) deployment, so any offline
+        # drive means MinIO is entirely unwritable. The metric stayed reliable
+        # and the scrape stayed up throughout the outage, so this alert would
+        # have fired at ~17:35 instead of the failure surfacing at 20:40.
+        - alert: MinIODriveOffline
+          expr: minio_cluster_drive_offline_total > 0
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "MinIO has {{ $value }} drive(s) offline — writes are failing silently"
+            description: "minio_cluster_drive_offline_total={{ $value }} for >10m. This is a single-drive deployment, so MinIO is returning 503 to all clients (velero, terraform-state, CNPG backups, loki). Likely a stale Longhorn mount: check `mc admin info` and `ls /export` for I/O errors; recover by scaling minio to 0, waiting for the Longhorn volume to detach, then back to 1."
+
+        # Complementary failure mode: a drive that is still counted "online" but
+        # actively throwing I/O errors (flaky storage, severed handle mid-flight).
+        # During the 2026-06-16 incident this counter climbed from 0 to ~18,480.
+        # rate() handles the counter reset on pod restart.
+        - alert: MinIODriveIOErrors
+          expr: rate(minio_node_drive_errors_ioerror[5m]) > 0
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "MinIO drive is logging I/O errors"
+            description: "minio_node_drive_errors_ioerror is incrementing for >10m on {{ $labels.server }}. The underlying drive (Longhorn volume) is throwing I/O errors even if not yet marked offline — investigate the volume mount and Longhorn replica health before it degrades to fully offline."


### PR DESCRIPTION
## What

Adds a `PrometheusRule` (`minio-rules`) for MinIO with two complementary alerts. MinIO previously had **no health alerting** — only a ServiceMonitor + dashboard.

- **`MinIODriveOffline`** (critical) — `minio_cluster_drive_offline_total > 0` for 10m. This is a single-drive (EC:0) deployment, so any offline drive means MinIO is entirely unwritable.
- **`MinIODriveIOErrors`** (warning) — `rate(minio_node_drive_errors_ioerror[5m]) > 0` for 10m. Catches the complementary failure mode: a drive that's still counted "online" but actively throwing I/O errors.

## Why

On 2026-06-16 a Longhorn engine reconnect — triggered by an etcd storage-latency storm — severed MinIO's mount of `/export`. MinIO's process kept running (**0 restarts**), so nothing crashed or alerted, but `mc admin info` showed `0/1 drives online` and MinIO returned `503 SlowDownWrite` to **every** client (velero, terraform-state, CNPG backups, loki compactor) for **~3 hours**. It only surfaced when loki-0 happened to restart and its compactor's init hit the 503 → CrashLoopBackOff.

Recovery required forcing a full Longhorn detach (scale to 0 → wait `detached` → scale to 1). A liveness probe would **not** have helped — it restarts the container in place, reusing the same stale kubelet mount, so it would just crashloop. Detection is the right repo-side fix; recovery is inherently manual here.

## Validated against historical data

Queried VictoriaMetrics over the incident window (17:00–21:30 UTC):

| Metric | Behavior during outage |
|--------|------------------------|
| `minio_cluster_drive_offline_total` | held at **1** from 17:25 → 20:50, back to 0 after fix |
| `minio_node_drive_errors_ioerror` | climbed **0 → 18,480** |
| `up{namespace="minio"}` | stayed **1** (scrape healthy throughout) |

So `MinIODriveOffline` (`for: 10m`) would have fired at **~17:35** — roughly **3 hours earlier** than the failure actually surfaced.

## Wiring / verification

- Placed in the `minio` namespace, co-located with the app. Verified `ruleNamespaceSelector={}` (all namespaces) + `ruleSelector` matches `release: kube-prometheus-stack` — so the label on the rule is sufficient for the kube-prometheus-stack Prometheus to load it.
- Added to `minio/minio/app/kustomization.yaml`.
- `kubectl kustomize` renders cleanly; both PromQL expressions validated against VictoriaMetrics (`status: success`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)