### PR TITLE
feat(homepage): add Vollminlab Org link + retitle repo link to Cluster Repo

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -364,7 +364,11 @@ data:
                 icon: shlink.png
                 namespace: shlink
                 app: shlink-web
-            - Homelab Repo:
+            - Vollminlab Org:
+                description: All Vollminlab repositories
+                href: https://github.com/vollminlab
+                icon: github.png
+            - Cluster Repo:
                 description: This Kubernetes cluster repo
                 href: https://github.com/vollminlab/k8s-vollminlab-cluster
                 icon: github.png


### PR DESCRIPTION
## Summary

Adds a **Vollminlab Org** bookmark to the homepage Vollminlab group, pointing at the GitHub org landing page (`https://github.com/vollminlab`). Retitles the existing repo link from **Homelab Repo** → **Cluster Repo** to disambiguate it from the new org link.

## Why these two and not all 12 repos

The org landing page already indexes every repo, so a single "Vollminlab Org" tile gives one-click access to all repos and scales for free as the org grows — no per-repo maintenance churn on the dashboard. "Cluster Repo" stays as the one repo touched daily. These are the two highest-value GitHub jumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)