### PR TITLE
fix(security): add PSS-restricted securityContext to renovate + kyverno-webhook-patch cronjobs

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/patches/webhooks-postrender-patch.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/patches/webhooks-postrender-patch.yaml
@@ -21,6 +21,14 @@ spec:
           restartPolicy: OnFailure
           serviceAccountName: kyverno-webhook-patch
           terminationGracePeriodSeconds: 10
+          # Pod-level security context — required to satisfy PSS "restricted"
+          # enforced on the kyverno namespace. alpine/kubectl defaults to root,
+          # so pin a non-root uid explicitly.
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
           tolerations:
             - key: node-role.kubernetes.io/control-plane
               operator: Exists
@@ -31,6 +39,18 @@ spec:
             - name: kubectl
               image: docker.io/alpine/kubectl:1.33.4
               imagePullPolicy: Always
+              # Container-level security context — PSS "restricted" requires
+              # allowPrivilegeEscalation: false and all capabilities dropped.
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              env:
+                # kubectl writes its discovery cache under $HOME; /root is not
+                # writable as uid 1000, so redirect to a writable path.
+                - name: HOME
+                  value: /tmp
               resources:
                 requests:
                   cpu: 10m

--- a/clusters/vollminlab-cluster/renovate/renovate/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/renovate/renovate/app/configmap.yaml
@@ -20,6 +20,13 @@ data:
         env: production
         category: apps
 
+    # Pod-level security context — required to satisfy PSS "restricted" enforced
+    # on the renovate namespace (runAsNonRoot + RuntimeDefault seccomp).
+    securityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+
     resources:
       requests:
         cpu: 200m
@@ -33,6 +40,16 @@ data:
           name: renovate-token
 
     renovate:
+      # Container-level security context — PSS "restricted" requires
+      # allowPrivilegeEscalation: false and all capabilities dropped.
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       config: |
         {
           "platform": "github",


### PR DESCRIPTION
## Summary

Two CronJob-backed workloads run in namespaces enforcing PodSecurity **restricted** but set no `securityContext`, so every scheduled pod was rejected at admission (`allowPrivilegeEscalation != false`, unrestricted capabilities).

- **renovate** — silently produced **zero runs since 2026-06-04** (succeeded 06-01→06-03, then 14 straight failures). No dependency PRs for two weeks.
- **patch-kyverno-webhooks** — failing every 5 minutes with the same violation, plus `TooManyMissedTimes`.

## Changes

**renovate** (`renovate/renovate/app/configmap.yaml`)
- Top-level `securityContext` (pod): `runAsNonRoot: true`, `seccompProfile: RuntimeDefault`
- `renovate.securityContext` (container): `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `runAsNonRoot`, `RuntimeDefault`
- Verified with `helm template` (chart `renovate` 46.100.3) that both contexts land on the rendered pod/container. The renovate image runs as uid 1000, so `runAsNonRoot` is satisfiable without pinning a uid.

**patch-kyverno-webhooks** (`kyverno/kyverno/patches/webhooks-postrender-patch.yaml`)
- Pod `securityContext`: `runAsNonRoot`, `runAsUser: 1000` (alpine/kubectl defaults to root), `RuntimeDefault`
- Container `securityContext`: `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`
- `HOME=/tmp` so kubectl's discovery cache stays writable under uid 1000

Both satisfy PSS `restricted`: runAsNonRoot ✅ · allowPrivilegeEscalation false ✅ · drop ALL ✅ · RuntimeDefault seccomp ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)