### PR TITLE
feat(monitoring): alert on Flux/Terraform reconcile failures + silent CronJob death

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -234,3 +234,147 @@ data:
       livenessProbe:
         failureThreshold: 5
         timeoutSeconds: 10
+      # --- GitOps control-plane readiness metrics ---
+      # Flux v2.8 controllers no longer expose gotk_reconcile_condition (the old
+      # per-resource readiness gauge was removed; controllers only emit
+      # gotk_reconcile_duration_seconds now). The documented replacement is
+      # kube-state-metrics Custom Resource State, which reads the Ready condition
+      # directly off each Flux/tofu CR and emits gotk_resource_info{ready=...}.
+      # Without this, a failed Kustomization/HelmRelease/Terraform reconcile is
+      # invisible to Prometheus — the gap that let 5 tofu workspaces fail silently.
+      # RBAC: KSM's ClusterRole has no access to these CRDs by default; extraRules
+      # grant the list/watch it needs to read them.
+      rbac:
+        extraRules:
+          - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+            resources: ["kustomizations"]
+            verbs: ["list", "watch"]
+          - apiGroups: ["helm.toolkit.fluxcd.io"]
+            resources: ["helmreleases"]
+            verbs: ["list", "watch"]
+          - apiGroups: ["source.toolkit.fluxcd.io"]
+            resources:
+              ["gitrepositories", "ocirepositories", "helmrepositories", "helmcharts", "buckets"]
+            verbs: ["list", "watch"]
+          - apiGroups: ["infra.contrib.fluxcd.io"]
+            resources: ["terraforms"]
+            verbs: ["list", "watch"]
+      customResourceState:
+        enabled: true
+        config:
+          spec:
+            resources:
+              # Each resource emits gotk_resource_info{name, exported_namespace,
+              # customresource_group/kind/version (auto), ready, reason, suspended} = 1.
+              # ready/reason come from the Ready condition; suspended from spec.suspend.
+              - groupVersionKind:
+                  group: kustomize.toolkit.fluxcd.io
+                  version: v1
+                  kind: Kustomization
+                metricNamePrefix: gotk
+                labelsFromPath:
+                  name: [metadata, name]
+                  exported_namespace: [metadata, namespace]
+                metrics:
+                  - name: resource_info
+                    help: "The current readiness of a Flux GitOps Toolkit resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          ready: [status, conditions, "[type=Ready]", status]
+                          reason: [status, conditions, "[type=Ready]", reason]
+                          suspended: [spec, suspend]
+              - groupVersionKind:
+                  group: helm.toolkit.fluxcd.io
+                  version: v2
+                  kind: HelmRelease
+                metricNamePrefix: gotk
+                labelsFromPath:
+                  name: [metadata, name]
+                  exported_namespace: [metadata, namespace]
+                metrics:
+                  - name: resource_info
+                    help: "The current readiness of a Flux GitOps Toolkit resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          ready: [status, conditions, "[type=Ready]", status]
+                          reason: [status, conditions, "[type=Ready]", reason]
+                          suspended: [spec, suspend]
+              - groupVersionKind:
+                  group: source.toolkit.fluxcd.io
+                  version: v1
+                  kind: GitRepository
+                metricNamePrefix: gotk
+                labelsFromPath:
+                  name: [metadata, name]
+                  exported_namespace: [metadata, namespace]
+                metrics:
+                  - name: resource_info
+                    help: "The current readiness of a Flux GitOps Toolkit resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          ready: [status, conditions, "[type=Ready]", status]
+                          reason: [status, conditions, "[type=Ready]", reason]
+                          suspended: [spec, suspend]
+              - groupVersionKind:
+                  group: source.toolkit.fluxcd.io
+                  version: v1
+                  kind: OCIRepository
+                metricNamePrefix: gotk
+                labelsFromPath:
+                  name: [metadata, name]
+                  exported_namespace: [metadata, namespace]
+                metrics:
+                  - name: resource_info
+                    help: "The current readiness of a Flux GitOps Toolkit resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          ready: [status, conditions, "[type=Ready]", status]
+                          reason: [status, conditions, "[type=Ready]", reason]
+                          suspended: [spec, suspend]
+              - groupVersionKind:
+                  group: source.toolkit.fluxcd.io
+                  version: v1
+                  kind: HelmRepository
+                metricNamePrefix: gotk
+                labelsFromPath:
+                  name: [metadata, name]
+                  exported_namespace: [metadata, namespace]
+                metrics:
+                  - name: resource_info
+                    help: "The current readiness of a Flux GitOps Toolkit resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          ready: [status, conditions, "[type=Ready]", status]
+                          reason: [status, conditions, "[type=Ready]", reason]
+                          suspended: [spec, suspend]
+              # tofu-controller Terraform CRs (served v1alpha2). Same Ready-condition
+              # shape; reason carries TerraformAppliedSucceed / TFExecPlanFailed /
+              # DriftDetected — the alert keys on reason to skip intentional drift.
+              - groupVersionKind:
+                  group: infra.contrib.fluxcd.io
+                  version: v1alpha2
+                  kind: Terraform
+                metricNamePrefix: gotk
+                labelsFromPath:
+                  name: [metadata, name]
+                  exported_namespace: [metadata, namespace]
+                metrics:
+                  - name: resource_info
+                    help: "The current readiness of a tofu-controller Terraform resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          ready: [status, conditions, "[type=Ready]", status]
+                          reason: [status, conditions, "[type=Ready]", reason]
+                          suspended: [spec, suspend]

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - grafana-admin-credentials-externalsecret.yaml
   - prometheusrule-custom.yaml
   - prometheusrule-eso.yaml
+  - prometheusrule-gitops.yaml
   - nodes-dashboard-configmap.yaml
   - longhorn-dashboard-configmap.yaml
   - minio-dashboard-configmap.yaml

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-gitops.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-gitops.yaml
@@ -1,0 +1,60 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: gitops-control-plane-alerts
+  namespace: monitoring
+  labels:
+    app: kube-prometheus-stack
+    env: production
+    category: observability
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: gitops-control-plane
+      rules:
+        # Flux GitOps Toolkit resources (Kustomization, HelmRelease, source CRs).
+        # gotk_resource_info is produced by kube-state-metrics Custom Resource State
+        # (configured in the KSM values; Flux v2.8 no longer exposes a per-resource
+        # readiness gauge of its own). ready="False" means the Ready condition is
+        # False; suspended resources are excluded (intentionally paused, not failing).
+        # Terraform CRs are excluded here — they get their own rule below so drift can
+        # be filtered out.
+        - alert: FluxResourceNotReady
+          expr: |
+            gotk_resource_info{customresource_group!="infra.contrib.fluxcd.io", ready="False", suspended!="true"} == 1
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Flux resource not ready"
+            description: "{{ $labels.customresource_kind }} {{ $labels.name }} in namespace {{ $labels.exported_namespace }} has had a failing Ready condition (reason: {{ $labels.reason }}) for 15 minutes. Flux is not reconciling it — check `flux get {{ $labels.customresource_kind | toLower }} -A`."
+        # tofu-controller Terraform resources. DriftDetected is intentionally excluded:
+        # authentik-config and b2-config carry permanent known drift on this cluster
+        # (provider/server version skew) and re-plan every reconcile — that is noise,
+        # not a failure. This catches the real failure modes (plan/apply errors,
+        # missing dependencies) that left 5 tofu workspaces broken with no alert.
+        - alert: TerraformResourceNotReady
+          expr: |
+            gotk_resource_info{customresource_group="infra.contrib.fluxcd.io", ready="False", reason!~"DriftDetected.*", suspended!="true"} == 1
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Terraform workspace failing"
+            description: "Terraform {{ $labels.name }} in namespace {{ $labels.exported_namespace }} has a failing Ready condition (reason: {{ $labels.reason }}) for 30 minutes. This is a real apply/plan failure, not known drift — check `kubectl describe terraform {{ $labels.name }} -n {{ $labels.exported_namespace }}`."
+        # CronJob silent-death detector. The existing KubeJobFailed / KubeJobNotCompleted
+        # alerts key on kube_job_failed / kube_job_status_active, but an admission-rejected
+        # job (e.g. a PSS violation) never creates a pod, so those counters stay 0 and the
+        # alerts are structurally blind — exactly how the renovate and kyverno cronjobs
+        # died silently for weeks. last_successful_time is the only signal that survives
+        # admission rejection. Every cronjob here runs at least daily; 26h > daily period
+        # + grace, so this fires only on genuine missed runs, never on normal scheduling.
+        - alert: CronJobNotSucceededRecently
+          expr: |
+            (time() - kube_cronjob_status_last_successful_time) > 93600
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "CronJob has not succeeded in over 26h"
+            description: "CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} last completed successfully {{ $value | humanizeDuration }} ago. A daily job that has not succeeded in 26h is failing silently — check for admission rejection (PSS/Kyverno) or a stuck Forbid-policy job: `kubectl get jobs -n {{ $labels.namespace }}`."

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-gitops.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-gitops.yaml
@@ -27,7 +27,11 @@ spec:
             severity: warning
           annotations:
             summary: "Flux resource not ready"
-            description: "{{ $labels.customresource_kind }} {{ $labels.name }} in namespace {{ $labels.exported_namespace }} has had a failing Ready condition (reason: {{ $labels.reason }}) for 15 minutes. Flux is not reconciling it — check `flux get {{ $labels.customresource_kind | toLower }} -A`."
+            description: >-
+              {{ $labels.customresource_kind }} {{ $labels.name }} in namespace
+              {{ $labels.exported_namespace }} has had a failing Ready condition
+              (reason: {{ $labels.reason }}) for 15 minutes. Flux is not
+              reconciling it — check `flux get {{ $labels.customresource_kind | toLower }} -A`.
         # tofu-controller Terraform resources. DriftDetected is intentionally excluded:
         # authentik-config and b2-config carry permanent known drift on this cluster
         # (provider/server version skew) and re-plan every reconcile — that is noise,
@@ -41,7 +45,11 @@ spec:
             severity: warning
           annotations:
             summary: "Terraform workspace failing"
-            description: "Terraform {{ $labels.name }} in namespace {{ $labels.exported_namespace }} has a failing Ready condition (reason: {{ $labels.reason }}) for 30 minutes. This is a real apply/plan failure, not known drift — check `kubectl describe terraform {{ $labels.name }} -n {{ $labels.exported_namespace }}`."
+            description: >-
+              Terraform {{ $labels.name }} in namespace {{ $labels.exported_namespace }}
+              has a failing Ready condition (reason: {{ $labels.reason }}) for 30
+              minutes. This is a real apply/plan failure, not known drift — check
+              `kubectl describe terraform {{ $labels.name }} -n {{ $labels.exported_namespace }}`.
         # CronJob silent-death detector. The existing KubeJobFailed / KubeJobNotCompleted
         # alerts key on kube_job_failed / kube_job_status_active, but an admission-rejected
         # job (e.g. a PSS violation) never creates a pod, so those counters stay 0 and the
@@ -57,4 +65,8 @@ spec:
             severity: warning
           annotations:
             summary: "CronJob has not succeeded in over 26h"
-            description: "CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} last completed successfully {{ $value | humanizeDuration }} ago. A daily job that has not succeeded in 26h is failing silently — check for admission rejection (PSS/Kyverno) or a stuck Forbid-policy job: `kubectl get jobs -n {{ $labels.namespace }}`."
+            description: >-
+              CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} last completed
+              successfully {{ $value | humanizeDuration }} ago. A daily job that has
+              not succeeded in 26h is failing silently — check for admission rejection
+              (PSS/Kyverno) or a stuck Forbid-policy job: `kubectl get jobs -n {{ $labels.namespace }}`.


### PR DESCRIPTION
## Why

The renovate and patch-kyverno-webhooks CronJobs, and five tofu-controller workspaces, all failed silently for weeks (fixed in #897/#898). The follow-up question was: **why didn't metrics or alerting catch any of it?** Three structural blind spots:

1. **Flux is unmonitored.** Flux v2.8 removed the per-resource `gotk_reconcile_condition` gauge — controllers now only emit `gotk_reconcile_duration_seconds`. A failing Kustomization / HelmRelease / source was invisible to Prometheus.
2. **tofu-controller is unmonitored.** Terraform CRs were never scraped at all, so 5 broken workspaces produced no signal.
3. **The Job alerts are blind to admission rejection.** Existing `KubeJobFailed` / `KubeJobNotCompleted` key on `kube_job_failed` / `kube_job_status_active`. A job rejected at admission (PSS violation) never creates a pod, so those counters stay `0` — the exact failure mode that killed both cronjobs is structurally invisible to them.

## What

**kube-state-metrics Custom Resource State** (`configmap.yaml`) emits `gotk_resource_info{ready,reason,suspended}` read directly off each CR's Ready condition, for Kustomization, HelmRelease, the source CRs, and Terraform. Adds the required `rbac.extraRules` (KSM has no default CRD access). CRS metrics serve on the existing `8080` `/metrics` port — **already scraped by the KSM ServiceMonitor, so no new ServiceMonitor or NetworkPolicy.**

**New PrometheusRule** (`prometheusrule-gitops.yaml`), three alerts:

| Alert | Expr signal | For | Notes |
|-------|-------------|-----|-------|
| `FluxResourceNotReady` | `gotk_resource_info{group!=tofu, ready="False", suspended!="true"}` | 15m | Any non-Terraform Flux resource stuck not-ready |
| `TerraformResourceNotReady` | same, group=tofu, `reason!~"DriftDetected.*"` | 30m | **Excludes DriftDetected** so the known authentik-config / b2-config drift stays quiet; only real plan/apply failures fire |
| `CronJobNotSucceededRecently` | `time() - kube_cronjob_status_last_successful_time > 93600` | 15m | 26h threshold; the only signal that survives admission rejection. Every cronjob runs ≥ daily, so no false positives |

## Verification

Async via Flux reconciliation. After merge: KSM rolls out with CRS enabled → `gotk_resource_info` series appear in Prometheus → PrometheusRule loads (label `release: kube-prometheus-stack`). No live cluster change can be asserted at PR-open time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)