### PR TITLE
fix(monitoring): exclude monthly kubeadm-cert-monitor from CronJob alert

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-gitops.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-gitops.yaml
@@ -55,11 +55,14 @@ spec:
         # job (e.g. a PSS violation) never creates a pod, so those counters stay 0 and the
         # alerts are structurally blind — exactly how the renovate and kyverno cronjobs
         # died silently for weeks. last_successful_time is the only signal that survives
-        # admission rejection. Every cronjob here runs at least daily; 26h > daily period
-        # + grace, so this fires only on genuine missed runs, never on normal scheduling.
+        # admission rejection. The 26h threshold assumes a cronjob runs at least daily
+        # (26h > daily period + grace), so it fires only on genuine missed runs. Jobs
+        # that legitimately run less than daily must be excluded by name, otherwise the
+        # gap between their normal runs trips the threshold — e.g. kube-system's monthly
+        # kubeadm-cert-monitor (`0 9 1 * *`) would false-fire for ~30 days between runs.
         - alert: CronJobNotSucceededRecently
           expr: |
-            (time() - kube_cronjob_status_last_successful_time) > 93600
+            (time() - kube_cronjob_status_last_successful_time{cronjob!="kubeadm-cert-monitor"}) > 93600
           for: 15m
           labels:
             severity: warning


### PR DESCRIPTION
## What

`CronJobNotSucceededRecently` (added in #899) uses a 26h staleness threshold on `kube_cronjob_status_last_successful_time`. That threshold assumes every cronjob runs **at least daily**. `kube-system/kubeadm-cert-monitor` runs **monthly** (`0 9 1 * *`), so the ~30-day gap between its normal, healthy runs trips the threshold — producing a chronic false positive for ~30 days out of every month.

This excludes it by name and documents the daily-cadence assumption in the rule comment, so any future sub-daily cronjob is handled the same way.

```
(time() - kube_cronjob_status_last_successful_time{cronjob!="kubeadm-cert-monitor"}) > 93600
```

## Why now

Verified live after #899 merged: the alert went `pending` on two cronjobs.
- **`renovate/renovate`** — a genuine true positive (jobs go missing daily, `lastSuccessfulTime` stuck at 2026-06-03). Left untouched; this PR does not mask it, and it warrants separate investigation.
- **`kube-system/kubeadm-cert-monitor`** — the false positive fixed here (monthly job, last succeeded 2026-06-01, next run 2026-07-01).

## Validation

- `yamllint` (CI config, line-length max 200) — clean, longest line 144.
- `promtool check rules` — SUCCESS, 3 rules found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)