### PR TITLE
fix(victoria-metrics): cut retention 90d→30d, expand PVC 30Gi→60Gi

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/victoria-metrics/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/victoria-metrics/app/configmap.yaml
@@ -13,7 +13,9 @@ data:
     fullnameOverride: victoria-metrics-single
 
     server:
-      retentionPeriod: 90d
+      # 30d local retention. 90d on longhorn-r2 (2 replicas) projected to ~145GB on-disk —
+      # far past the 30Gi PVC. 30d steady-state (~1.6GB/day → ~48GB) fits the 60Gi PVC below.
+      retentionPeriod: 30d
 
       # mode: statefulSet (not deployment) so the RWO Longhorn volume is handled via a
       # volumeClaimTemplate and there is no rolling-update detach trap.
@@ -24,7 +26,10 @@ data:
         storageClassName: longhorn-r2
         accessModes:
           - ReadWriteOnce
-        size: 30Gi
+        # 60Gi headroom over the ~48GB 30d steady-state. NOTE: volumeClaimTemplate is
+        # immutable — bumping this does NOT resize the live PVC. After merge, online-patch
+        # the PVC + recreate the STS --cascade=orphan so Flux re-templates at 60Gi.
+        size: 60Gi
 
       podLabels:
         app: victoria-metrics


### PR DESCRIPTION
## Problem

The VictoriaMetrics PVC (`server-volume-victoria-metrics-single-server-0`) is filling up and tripping **KubePersistentVolumeFillingUp** — `predict_linear` projects **< 4 days to full**.

This is **normal accumulation, not an anomaly**:
- 90d retention on `longhorn-r2` (2 replicas) at ~1.6GB/day projects to **~145GB on-disk**, far past the original **30Gi** PVC.
- We were only ~17 of 90 days into the retention window, so the PVC had never been pushed to its steady-state size before — the alert is the first time the projection caught up.

## Fix

- **Retention 90d → 30d.** VM is the long-term store, but 90d of full-resolution metrics on tight Longhorn capacity isn't worth the cost. 30d steady-state ≈ **48GB**.
- **PVC 30Gi → 60Gi.** Headroom over the 48GB steady-state. Verified VM replicas land on k8sworker04 (~38GB usable headroom) and k8sworker02 (~89GB), so +30GB/replica fits online; 128Gi would not.

Net result is a **permanent** fix (steady-state < PVC), not a deferred re-fill.

## Follow-up after merge (manual, out-of-band)

The StatefulSet `volumeClaimTemplate` is **immutable**, so this size bump alone won't resize the live PVC. After Flux reconciles the configmap:

1. Online-patch the live PVC to 60Gi (`kubectl patch pvc ... resources.requests.storage=60Gi`) — Longhorn online expansion, relieves the < 4-day pressure immediately.
2. `kubectl delete sts victoria-metrics-single-server -n monitoring --cascade=orphan` so Flux/Helm recreates it with the 60Gi template (pods/PVC untouched).
3. Retention arg applies on the next pod restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)