### PR TITLE
feat(monitoring): forward-looking VictoriaMetrics PVC fill alerts

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - prometheusrule-custom.yaml
   - prometheusrule-eso.yaml
   - prometheusrule-gitops.yaml
+  - prometheusrule-victoria-metrics.yaml
   - nodes-dashboard-configmap.yaml
   - longhorn-dashboard-configmap.yaml
   - minio-dashboard-configmap.yaml

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-victoria-metrics.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-victoria-metrics.yaml
@@ -1,0 +1,94 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: vollminlab-victoria-metrics-rules
+  namespace: monitoring
+  labels:
+    app: kube-prometheus-stack
+    env: production
+    category: observability
+    release: kube-prometheus-stack
+spec:
+  groups:
+    # Slow-fill early-warning for the VictoriaMetrics data PVC.
+    #
+    # The stock KubePersistentVolumeFillingUp alert only looks ~4 days ahead. This group
+    # projects weeks ahead so a creeping fill (e.g. cardinality growth outrunning retention)
+    # surfaces with enough lead time to act, rather than 4 days before the wall.
+    #
+    # Why the available-ratio gate on the alerts:
+    #   A retention-bounded TSDB *legitimately* fills during its initial ramp (before the
+    #   retention horizon is reached, nothing is deleted yet) and then plateaus once deletion
+    #   matches ingestion. During that ramp days-to-full reads low even though the volume is
+    #   healthy. At steady state, free space is flat so days-to-full goes to +inf and the alert
+    #   stays silent on its own. The ratio gate suppresses the (known, healthy) ramp by only
+    #   firing once free space has fallen *below the expected steady-state plateau*.
+    #
+    #   Expected plateau at 60Gi / 30d retention (~1.63 GB/day): ~13 GB free ≈ 21% free.
+    #   Gates are set below that (warn <10%, crit <6%) so the normal ramp/plateau never trips
+    #   them; only a genuine drift below plateau does.
+    #   >>> Revisit these gate fractions if the PVC size or retentionPeriod changes. <<<
+    #
+    # Series are pre-aggregated (max without volatile labels) so deriv() stays continuous if the
+    # VM pod is rescheduled to a different node (the instance/node labels would otherwise change).
+    - name: victoria-metrics-storage
+      interval: 5m
+      rules:
+        - record: victoriametrics:pvc_available_bytes
+          expr: |
+            max without (endpoint, instance, job, metrics_path, node, prometheus, prometheus_replica, service) (
+              kubelet_volume_stats_available_bytes{namespace="monitoring", persistentvolumeclaim="server-volume-victoria-metrics-single-server-0"}
+            )
+
+        - record: victoriametrics:pvc_capacity_bytes
+          expr: |
+            max without (endpoint, instance, job, metrics_path, node, prometheus, prometheus_replica, service) (
+              kubelet_volume_stats_capacity_bytes{namespace="monitoring", persistentvolumeclaim="server-volume-victoria-metrics-single-server-0"}
+            )
+
+        - record: victoriametrics:pvc_available_ratio
+          expr: |
+            victoriametrics:pvc_available_bytes / victoriametrics:pvc_capacity_bytes
+
+        # Days until the PVC fills at the current 12h net-consumption rate.
+        # clamp_min keeps the result finite (and the alerts silent) whenever free space is
+        # flat or growing, i.e. -deriv <= 0. Needs ~12h of history after deploy to evaluate.
+        - record: victoriametrics:pvc_days_to_full
+          expr: |
+            victoriametrics:pvc_available_bytes
+              /
+            clamp_min(- deriv(victoriametrics:pvc_available_bytes[12h]), 1)
+              / 86400
+
+        - alert: VictoriaMetricsPVCProjectedFull
+          expr: |
+            victoriametrics:pvc_days_to_full < 45
+              and
+            victoriametrics:pvc_available_ratio < 0.10
+          for: 6h
+          labels:
+            severity: warning
+          annotations:
+            summary: "VictoriaMetrics PVC projected to fill within {{ $value | printf \"%.0f\" }} days"
+            description: >-
+              server-volume-victoria-metrics-single-server-0 is below 10% free and
+              trending to full in {{ $value | printf "%.0f" }} days at the current 12h
+              rate. Free space has dropped below the expected retention plateau — check
+              active-series cardinality and retentionPeriod before it reaches the
+              KubePersistentVolumeFillingUp horizon.
+
+        - alert: VictoriaMetricsPVCFillingSoon
+          expr: |
+            victoriametrics:pvc_days_to_full < 7
+              and
+            victoriametrics:pvc_available_ratio < 0.06
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: "VictoriaMetrics PVC will fill in < 7 days"
+            description: >-
+              server-volume-victoria-metrics-single-server-0 is below 6% free and
+              trending to full in {{ $value | printf "%.0f" }} days. Expand the PVC
+              (Longhorn online resize) or cut retentionPeriod now — a full data dir
+              takes VictoriaMetrics read-only and drops new samples.


### PR DESCRIPTION
## Why

The VictoriaMetrics data PVC tripped `KubePersistentVolumeFillingUp` recently. That stock alert only projects **~4 days** ahead — too short a runway to react to a slow creeping fill (cardinality growth outrunning retention, a retention bump, etc.). This adds a projection guardrail that warns **weeks** ahead.

This is the **projection-alert** half of the VM-retention work, kept as its own PR. The PVC resize + retention change is PR #901 (separate).

## What

A new `PrometheusRule` (`vollminlab-victoria-metrics-rules`) wired into `kube-prometheus-stack/app/kustomization.yaml`.

**Recording rules**
- `victoriametrics:pvc_available_bytes` / `:pvc_capacity_bytes` — PVC free/total, pre-aggregated with `max without (...)` so the series (and `deriv()`) stays continuous across VM pod reschedules to other nodes.
- `victoriametrics:pvc_available_ratio` — fraction free.
- `victoriametrics:pvc_days_to_full` — projected days at the current 12h net-consumption rate; `clamp_min` keeps it finite (and the alerts silent) whenever free space is flat or growing.

**Alerts** — gated on `available_ratio` so the *healthy* retention ramp/plateau never trips them; they fire only when free space drifts **below** the expected steady-state plateau (~21% free at 60Gi/30d):
- `VictoriaMetricsPVCProjectedFull` (warning) — `days_to_full < 45` **and** `free < 10%`, `for: 6h`.
- `VictoriaMetricsPVCFillingSoon` (critical) — `days_to_full < 7` **and** `free < 6%`, `for: 1h`.

## Design note

The gate fractions (10% / 6%) are tuned to the **60Gi / 30d** plateau. The rule file carries an inline comment: revisit the fractions if PVC size or `retentionPeriod` changes.

## Validation (local)
- `yamllint` (CI config: line-length 200, no document-start) — clean
- `promtool check rules` — 6 rules OK
- `kustomize build` — renders 17 resources (was 16; confirms wiring)
- `kubeconform` — 0 invalid

🤖 Generated with [Claude Code](https://claude.com/claude-code)