### PR TITLE
fix(trivy): use memory cache backend to stop scan-job BackoffLimitExceeded

### DIFF
--- a/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
@@ -25,6 +25,16 @@ data:
 
     trivy:
       ignoreUnfixed: true
+      # Use an in-memory analysis cache for scan jobs. Trivy >=0.66 added a
+      # lock timeout on the filesystem (BoltDB) cache; pods whose containers
+      # share an image (e.g. longhorn-driver-deployer's init + main container
+      # both run longhorn-manager) launch concurrent scans against one shared
+      # cache emptyDir and deadlock on the lock -> BackoffLimitExceeded. The
+      # memory backend has no on-disk lock, so concurrent same-image scans
+      # succeed. Requires trivy >=0.68.1 (chart default is 0.69.3).
+      configFile:
+        cache:
+          backend: memory
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
## Problem

Headlamp showed a continuous loop of `scan-vulnerabilityreport-*` Jobs in `trivy-system` failing with `BackoffLimitExceeded`. The operator logs reveal the real cause:

```
ERROR  Failed to acquire cache or database lock
FATAL  unable to initialize fs cache: cache may be in use by another process: timeout
```

Trivy ≥0.66 ([trivy#9307](https://github.com/aquasecurity/trivy/pull/9307)) added a lock timeout on the filesystem (BoltDB) analysis cache. Trivy-operator runs **one scan-job pod per workload with one scan container per scanned image**, all sharing a single cache `emptyDir`. Two workloads here have an **init container and a main container running the *same* image**:

- `longhorn-driver-deployer` — init `wait-longhorn-manager` + main, both `longhornio/longhorn-manager:v1.12.0`
- `longhorn-rebalancing-controller` — same pattern

The two scan containers start together and deadlock on the shared cache lock → job fails → `BackoffLimitExceeded` → retries forever. Every other longhorn workload scans fine because its containers use distinct images, so cache writes stagger. (These two were the only longhorn workloads missing a `vulnerabilityreport`.)

## Fix

Set `trivy.configFile.cache.backend: memory` so each scan uses an in-memory analysis cache with no on-disk lock. Concurrent same-image scans in one job pod no longer contend.

This is the upstream-recommended fix, confirmed by the trivy-operator maintainer and users in [trivy-operator#2769](https://github.com/aquasecurity/trivy-operator/issues/2769). Requires trivy ≥0.68.1; our chart (0.32.1 / app 0.30.1) defaults to trivy 0.69.3, and v0.30.1 renders `trivy.configFile` into the scan-job trivy config.

## Verification (post-merge, after Flux reconciles)

```
kubectl rollout status deploy/trivy-operator -n trivy-system
# new scan jobs complete instead of BackoffLimitExceeded
kubectl get jobs -n trivy-system
# the two previously-missing reports appear
kubectl get vulnerabilityreports -n longhorn-system | grep -E 'driver-deployer|rebalancing'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeJTNxa3qhvqjrCdJY9cP5