### PR TITLE
fix(tofu): stop perpetual drift on harbor/b2/portainer

### DIFF
--- a/terraform/authentik/portainer.tf
+++ b/terraform/authentik/portainer.tf
@@ -15,4 +15,12 @@ resource "portainer_settings" "main" {
     oauth_auto_create_users = true
     default_team_id         = 0
   }
+
+  # Portainer's API does not persist hide_internal_auth (it reads back false),
+  # so every reconcile re-sent the value and drifted again 10 minutes later.
+  # That futile re-apply loop was the source of the authentik-config drift
+  # churn (and CNPG WAL bloat). Keep the declared intent but stop the loop.
+  lifecycle {
+    ignore_changes = [oauth_settings[0].hide_internal_auth]
+  }
 }

--- a/terraform/b2/main.tf
+++ b/terraform/b2/main.tf
@@ -1,6 +1,14 @@
 resource "b2_bucket" "velero" {
   bucket_name = "vollminlab-k8s-backups"
   bucket_type = "allPrivate"
+
+  # The bucket has default SSE-B2 encryption enabled at rest. Declaring it
+  # matches live state; omitting the block made every plan try to strip it
+  # (algorithm/mode -> null), causing perpetual drift.
+  default_server_side_encryption {
+    mode      = "SSE-B2"
+    algorithm = "AES256"
+  }
 }
 
 resource "b2_bucket" "volsync" {

--- a/terraform/harbor/config.tf
+++ b/terraform/harbor/config.tf
@@ -7,11 +7,11 @@ resource "harbor_config_auth" "oidc" {
   # Harbor reports the username claim it actually onboarded with
   # (preferred_username). Declaring it here matches live state; omitting it
   # let the provider default (name) plan a perpetual oidc_user_claim -> null.
-  oidc_user_claim    = "preferred_username"
-  oidc_scope         = "openid,profile,email,groups"
-  oidc_groups_claim  = "groups"
-  oidc_admin_group   = "Harbor Admins"
-  oidc_auto_onboard  = true
-  oidc_verify_cert   = true
-  primary_auth_mode  = true
+  oidc_user_claim   = "preferred_username"
+  oidc_scope        = "openid,profile,email,groups"
+  oidc_groups_claim = "groups"
+  oidc_admin_group  = "Harbor Admins"
+  oidc_auto_onboard = true
+  oidc_verify_cert  = true
+  primary_auth_mode = true
 }

--- a/terraform/harbor/config.tf
+++ b/terraform/harbor/config.tf
@@ -4,6 +4,10 @@ resource "harbor_config_auth" "oidc" {
   oidc_endpoint      = "https://authentik.vollminlab.com/application/o/harbor/"
   oidc_client_id     = "61knXoFusnE1LOVJLSSRZkLtnLFak5NylhhOxDBx" # gitleaks:allow
   oidc_client_secret = var.harbor_oidc_client_secret
+  # Harbor reports the username claim it actually onboarded with
+  # (preferred_username). Declaring it here matches live state; omitting it
+  # let the provider default (name) plan a perpetual oidc_user_claim -> null.
+  oidc_user_claim    = "preferred_username"
   oidc_scope         = "openid,profile,email,groups"
   oidc_groups_claim  = "groups"
   oidc_admin_group   = "Harbor Admins"


### PR DESCRIPTION
## Problem

Three tofu-controller workspaces (`harbor-config`, `b2-config`, `authentik-config`) emitted continuous `DriftDetected` events and re-applied the same single-resource change every 10 minutes. None was a real config change — in each case the declared config under-specified the live server state, so every plan diffed against reality and "fixed" it, only to drift again on the next reconcile.

## Root cause & fix (per workspace)

**harbor-config — `harbor_config_auth.oidc`**
Harbor onboards OIDC users with the `preferred_username` claim and reports it back. The config omitted `oidc_user_claim`, so the provider default (`name`) planned `oidc_user_claim -> null` on every run. Declared the actual value.

**b2-config — `b2_bucket.velero`**
The `vollminlab-k8s-backups` bucket has default SSE-B2/AES256 encryption enabled at rest, but the config had no `default_server_side_encryption` block, so every plan tried to strip it (`algorithm`/`mode -> null`). Declared the block — this matches live state and keeps Velero backups encrypted. (`b2_bucket.volsync` is not encrypted and was not drifting; left unchanged.)

**authentik-config — `portainer_settings.main`**
Portainer's API never persists `oauth_settings.hide_internal_auth` (reads back `false`), so each reconcile re-sent `true` and drifted again. This futile re-apply loop was the `authentik-config` churn behind the prior CNPG WAL bloat. Kept the declared intent and added `lifecycle.ignore_changes` on that one attribute to break the loop.

## Why one PR

All three are the same class of bug (round-trip mismatch causing a self-perpetuating apply loop) found together while triaging the Headlamp drift events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeJTNxa3qhvqjrCdJY9cP5