### PR TITLE
feat(kube-system): longhorn-mount-healer — auto-clear Longhorn stale-mount crashloops (Layer 1)

### DIFF
--- a/clusters/vollminlab-cluster/kube-system/kustomization.yaml
+++ b/clusters/vollminlab-cluster/kube-system/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
   - ./etcd-defrag/app
   - ./kubeadm-cert-monitor/app
   - ./kubeadm-cert-renew/app
+  - ./longhorn-mount-healer/app
   - ./metrics-server/app
   - ./smb-csi-driver/app

--- a/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/cronjob.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: longhorn-mount-healer
+  namespace: kube-system
+  labels:
+    app: longhorn-mount-healer
+    env: production
+    category: storage
+spec:
+  schedule: "*/10 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 3600
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: longhorn-mount-healer
+            env: production
+            category: storage
+        spec:
+          serviceAccountName: longhorn-mount-healer
+          restartPolicy: Never
+          containers:
+            - name: longhorn-mount-healer
+              image: docker.io/alpine/kubectl:1.33.4
+              command: ["/bin/sh", "/scripts/heal.sh"]
+              env:
+                - name: HEAL_NAMESPACES
+                  value: "mediastack monitoring harbor"
+                - name: RESTART_THRESHOLD
+                  value: "5"
+                - name: COOLDOWN_SECONDS
+                  value: "21600"
+                - name: DETACH_TIMEOUT_SECONDS
+                  value: "180"
+                - name: POLL_INTERVAL_SECONDS
+                  value: "5"
+                - name: DRY_RUN
+                  value: "false"
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+                  readOnly: true
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+          volumes:
+            - name: script
+              configMap:
+                name: longhorn-mount-healer-script

--- a/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh
+++ b/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh
@@ -40,6 +40,44 @@ in_cooldown() {
   [ "$delta" -lt "$cd" ]
 }
 
+# pod_crashloop_restarts: echo summed restartCount IF a container/init is in
+# CrashLoopBackOff, else echo 0. $1=ns $2=pod
+pod_crashloop_restarts() {
+  ns="$1"; pod="$2"
+  reasons=$(kc get pod "$pod" -n "$ns" -o jsonpath='{.status.containerStatuses[*].state.waiting.reason}{.status.initContainerStatuses[*].state.waiting.reason}')
+  case "$reasons" in
+    *CrashLoopBackOff*) ;;
+    *) echo 0; return 0 ;;
+  esac
+  restarts=$(kc get pod "$pod" -n "$ns" -o jsonpath='{.status.containerStatuses[*].restartCount} {.status.initContainerStatuses[*].restartCount}')
+  sum_ints $restarts
+}
+
+# longhorn_rwo_volume: echo the PV name of the first longhorn RWO PVC the pod
+# mounts, else empty. $1=ns $2=pod
+longhorn_rwo_volume() {
+  ns="$1"; pod="$2"
+  claims=$(kc get pod "$pod" -n "$ns" -o jsonpath='{.spec.volumes[*].persistentVolumeClaim.claimName}')
+  for claim in $claims; do
+    [ -n "$claim" ] || continue
+    sc=$(kc get pvc "$claim" -n "$ns" -o jsonpath='{.spec.storageClassName}')
+    case "$sc" in longhorn*) ;; *) continue ;; esac
+    modes=$(kc get pvc "$claim" -n "$ns" -o jsonpath='{.spec.accessModes[*]}')
+    case " $modes " in *" ReadWriteOnce "*) ;; *) continue ;; esac
+    pv=$(kc get pvc "$claim" -n "$ns" -o jsonpath='{.spec.volumeName}')
+    [ -n "$pv" ] && { echo "$pv"; return 0; }
+  done
+}
+
+# owner_deployment: echo the Deployment that owns the pod (via its ReplicaSet),
+# else empty. $1=ns $2=pod
+owner_deployment() {
+  ns="$1"; pod="$2"
+  rs=$(kc get pod "$pod" -n "$ns" -o jsonpath='{.metadata.ownerReferences[?(@.kind=="ReplicaSet")].name}')
+  [ -n "$rs" ] || return 0
+  kc get rs "$rs" -n "$ns" -o jsonpath='{.metadata.ownerReferences[?(@.kind=="Deployment")].name}'
+}
+
 main() {
   log "longhorn-mount-healer placeholder main"
 }

--- a/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh
+++ b/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh
@@ -78,6 +78,76 @@ owner_deployment() {
   kc get rs "$rs" -n "$ns" -o jsonpath='{.metadata.ownerReferences[?(@.kind=="Deployment")].name}'
 }
 
+# wait_detached: poll the Longhorn volume until state=detached or timeout.
+# $1=vol $2=timeout_seconds $3=interval_seconds. exit 0 if detached.
+wait_detached() {
+  vol="$1"; timeout="$2"; interval="$3"; elapsed=0
+  while [ "$elapsed" -lt "$timeout" ]; do
+    state=$(kc get volumes.longhorn.io "$vol" -n longhorn-system -o jsonpath='{.status.state}' 2>/dev/null)
+    [ "$state" = "detached" ] && return 0
+    sleep "$interval"
+    elapsed=$((elapsed + interval))
+  done
+  return 1
+}
+
+# emit_event: best-effort core/v1 Event on the Deployment. Never fails the run.
+# $1=ns $2=deploy $3=reason $4=type(Normal|Warning) $5=message
+emit_event() {
+  ens="$1"; edep="$2"; ereason="$3"; etype="$4"; emsg="$5"
+  euid=$(kc get deploy "$edep" -n "$ens" -o jsonpath='{.metadata.uid}' 2>/dev/null)
+  ets=$(date -u +%FT%TZ)
+  ename="${edep}.$(date -u +%s)"
+  kc create -f - >/dev/null 2>&1 <<EOF || log "WARN: event emit failed for $ens/$edep"
+apiVersion: v1
+kind: Event
+metadata:
+  name: ${ename}
+  namespace: ${ens}
+involvedObject:
+  apiVersion: apps/v1
+  kind: Deployment
+  name: ${edep}
+  namespace: ${ens}
+  uid: ${euid}
+reason: ${ereason}
+message: "${emsg}"
+type: ${etype}
+source:
+  component: longhorn-mount-healer
+firstTimestamp: ${ets}
+lastTimestamp: ${ets}
+count: 1
+EOF
+}
+
+# heal_workload: the runbook. $1=ns $2=deploy $3=vol
+heal_workload() {
+  ns="$1"; dep="$2"; vol="$3"
+  replicas=$(kc get deploy "$dep" -n "$ns" -o jsonpath='{.spec.replicas}')
+  if [ -z "$replicas" ] || [ "$replicas" -le 0 ] 2>/dev/null; then
+    log "skip $ns/$dep: replicas=$replicas (nothing to heal)"; return 0
+  fi
+  if [ "$DRY_RUN" = "true" ]; then
+    log "DRY_RUN: would heal $ns/$dep (vol=$vol): scale 0 -> wait-detached -> $replicas"; return 0
+  fi
+  log "healing $ns/$dep (vol=$vol, replicas=$replicas)"
+  kc annotate deploy "$dep" -n "$ns" "$ANN_ORIG=$replicas" --overwrite
+  kc scale deploy "$dep" -n "$ns" --replicas=0
+  if wait_detached "$vol" "$DETACH_TIMEOUT_SECONDS" "$POLL_INTERVAL_SECONDS"; then
+    kc scale deploy "$dep" -n "$ns" --replicas="$replicas"
+    log "healed $ns/$dep (restored to $replicas)"
+    emit_event "$ns" "$dep" HealedStaleMount Normal "Cleared stale Longhorn mount on $vol via scale-0/wait-detached/scale-$replicas"
+  else
+    kc scale deploy "$dep" -n "$ns" --replicas="$replicas"
+    log "WARN: $vol did not detach within ${DETACH_TIMEOUT_SECONDS}s; restored $ns/$dep to $replicas anyway"
+    emit_event "$ns" "$dep" HealedStaleMountTimeout Warning "Volume $vol did not detach within ${DETACH_TIMEOUT_SECONDS}s; restored replicas to $replicas, manual check needed"
+  fi
+  # clear the original-replicas marker (restore done) and stamp cooldown
+  kc annotate deploy "$dep" -n "$ns" "${ANN_ORIG}-" >/dev/null 2>&1 || true
+  kc annotate deploy "$dep" -n "$ns" "$ANN_LAST=$(date -u +%s)" --overwrite
+}
+
 main() {
   log "longhorn-mount-healer placeholder main"
 }

--- a/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh
+++ b/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# longhorn-mount-healer — placeholder, implemented in later tasks
+echo "healer not yet implemented"

--- a/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh
+++ b/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh
@@ -1,3 +1,47 @@
 #!/bin/sh
-# longhorn-mount-healer — placeholder, implemented in later tasks
-echo "healer not yet implemented"
+# longhorn-mount-healer: auto-clear storage-induced crashloops by codifying
+# the proven scale-0 -> wait-detached -> scale-back runbook.
+set -u
+
+# --- tunables (overridable via env in the CronJob) ---
+HEAL_NAMESPACES="${HEAL_NAMESPACES:-mediastack monitoring harbor}"
+RESTART_THRESHOLD="${RESTART_THRESHOLD:-5}"
+COOLDOWN_SECONDS="${COOLDOWN_SECONDS:-21600}"
+DETACH_TIMEOUT_SECONDS="${DETACH_TIMEOUT_SECONDS:-180}"
+POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-5}"
+DRY_RUN="${DRY_RUN:-false}"
+
+ANN_ORIG="mount-healer.vollminlab.com/original-replicas"
+ANN_LAST="mount-healer.vollminlab.com/last-healed"
+# jsonpath-escaped annotation keys (dots escaped)
+JP_ORIG='mount-healer\.vollminlab\.com/original-replicas'
+JP_LAST='mount-healer\.vollminlab\.com/last-healed'
+
+# Single kubectl entry point so tests can stub it.
+kc() { kubectl "$@"; }
+
+log() { echo "[$(date -u +%FT%TZ)] $*"; }
+
+# sum_ints: echo the sum of all integer args (empty args ignored).
+sum_ints() {
+  total=0
+  for n in "$@"; do
+    [ -n "$n" ] || continue
+    total=$((total + n))
+  done
+  echo "$total"
+}
+
+# in_cooldown: exit 0 if (now - last) < cooldown. $1=last(may be empty) $2=now $3=cooldown
+in_cooldown() {
+  last="$1"; now="$2"; cd="$3"
+  [ -n "$last" ] || return 1
+  delta=$((now - last))
+  [ "$delta" -lt "$cd" ]
+}
+
+main() {
+  log "longhorn-mount-healer placeholder main"
+}
+
+[ -n "${HEAL_TEST:-}" ] || main "$@"

--- a/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh
+++ b/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh
@@ -148,8 +148,77 @@ heal_workload() {
   kc annotate deploy "$dep" -n "$ns" "$ANN_LAST=$(date -u +%s)" --overwrite
 }
 
+# restore_orphans: repair any Deployment a prior interrupted heal left at 0.
+# Runs FIRST every invocation so a dead healer pod can't park a workload down.
+restore_orphans() {
+  for ns in $HEAL_NAMESPACES; do
+    deps=$(kc get deploy -n "$ns" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)
+    for dep in $deps; do
+      [ -n "$dep" ] || continue
+      orig=$(kc get deploy "$dep" -n "$ns" -o jsonpath="{.metadata.annotations.$JP_ORIG}" 2>/dev/null)
+      [ -n "$orig" ] || continue
+      cur=$(kc get deploy "$dep" -n "$ns" -o jsonpath='{.spec.replicas}')
+      if [ "$cur" = "0" ] && [ "$orig" != "0" ]; then
+        log "orphan-restore $ns/$dep -> $orig"
+        [ "$DRY_RUN" = "true" ] && continue
+        kc scale deploy "$dep" -n "$ns" --replicas="$orig"
+        kc annotate deploy "$dep" -n "$ns" "${ANN_ORIG}-" >/dev/null 2>&1 || true
+        kc annotate deploy "$dep" -n "$ns" "$ANN_LAST=$(date -u +%s)" --overwrite
+        emit_event "$ns" "$dep" RestoredAfterInterrupt Warning "Restored replicas to $orig after an interrupted heal"
+      fi
+    done
+  done
+}
+
+# pod_mount_wedged: exit 0 if pod is Pending with a FailedMount 'busy' event
+# (the post-scale reattach race). $1=ns $2=pod
+pod_mount_wedged() {
+  ns="$1"; pod="$2"
+  phase=$(kc get pod "$pod" -n "$ns" -o jsonpath='{.status.phase}')
+  [ "$phase" = "Pending" ] || return 1
+  msgs=$(kc get events -n "$ns" --field-selector "involvedObject.name=$pod,reason=FailedMount" -o jsonpath='{.items[*].message}' 2>/dev/null)
+  case "$msgs" in
+    *"already mounted or mount point busy"*) return 0 ;;
+    *"volume is already exclusively attached"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# find_and_heal_one: heal at most ONE stuck workload, gated by cooldown.
+find_and_heal_one() {
+  now=$(date -u +%s)
+  for ns in $HEAL_NAMESPACES; do
+    pods=$(kc get pods -n "$ns" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)
+    for pod in $pods; do
+      [ -n "$pod" ] || continue
+      restarts=$(pod_crashloop_restarts "$ns" "$pod")
+      if [ "$restarts" -gt "$RESTART_THRESHOLD" ]; then
+        :
+      elif pod_mount_wedged "$ns" "$pod"; then
+        :
+      else
+        continue
+      fi
+      vol=$(longhorn_rwo_volume "$ns" "$pod")
+      [ -n "$vol" ] || continue
+      dep=$(owner_deployment "$ns" "$pod")
+      [ -n "$dep" ] || { log "skip $ns/$pod: no Deployment owner"; continue; }
+      last=$(kc get deploy "$dep" -n "$ns" -o jsonpath="{.metadata.annotations.$JP_LAST}" 2>/dev/null)
+      if in_cooldown "$last" "$now" "$COOLDOWN_SECONDS"; then
+        log "skip $ns/$dep: in cooldown (last-healed=$last)"; continue
+      fi
+      heal_workload "$ns" "$dep" "$vol"
+      return 0
+    done
+  done
+  log "no stuck workloads found"
+}
+
 main() {
-  log "longhorn-mount-healer placeholder main"
+  log "longhorn-mount-healer start (ns='$HEAL_NAMESPACES' threshold=$RESTART_THRESHOLD dry_run=$DRY_RUN)"
+  restore_orphans
+  find_and_heal_one
+  log "longhorn-mount-healer done"
 }
 
 [ -n "${HEAL_TEST:-}" ] || main "$@"

--- a/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh
+++ b/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh
@@ -62,5 +62,19 @@ assert_eq "$(longhorn_rwo_volume mediastack radarr-x)" "pvc-abc123" "longhorn RW
 assert_eq "$(longhorn_rwo_volume mediastack prowlarr-y)" "" "smb pod -> no volume"
 assert_eq "$(owner_deployment mediastack radarr-x)" "radarr" "pod -> owning Deployment"
 
+# --- wait_detached: stub kc to report 'detached' immediately ---
+kc() {
+  case "$*" in
+    "get volumes.longhorn.io pvc-abc123 -n longhorn-system -o jsonpath={.status.state}")
+      echo "detached" ;;
+    *) echo "" ;;
+  esac
+}
+wait_detached pvc-abc123 10 1; assert_rc "$?" "0" "wait_detached returns 0 when state=detached"
+
+# stub kc to never detach -> times out fast (timeout 1s, interval 1s)
+kc() { echo "attached"; }
+wait_detached pvc-stuck 1 1; assert_rc "$?" "1" "wait_detached returns 1 on timeout"
+
 printf '\n%s failures\n' "$FAILS"
 [ "$FAILS" = "0" ]

--- a/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh
+++ b/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh
@@ -25,5 +25,42 @@ in_cooldown "100" "150" "60"; assert_rc "$?" "0" "in_cooldown true when delta<co
 in_cooldown "100" "200" "60"; assert_rc "$?" "1" "in_cooldown false when delta>cooldown"
 in_cooldown "" "200" "60";    assert_rc "$?" "1" "in_cooldown false when no last-healed"
 
+# --- detection helpers: stub kc as a dispatcher over fixtures ---
+# A crashlooping radarr pod on a longhorn RWO PVC.
+kc() {
+  case "$*" in
+    "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].state.waiting.reason}{.status.initContainerStatuses[*].state.waiting.reason}")
+      echo "CrashLoopBackOff" ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].restartCount} {.status.initContainerStatuses[*].restartCount}")
+      echo "37 " ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.spec.volumes[*].persistentVolumeClaim.claimName}")
+      echo "radarr-config" ;;
+    "get pvc radarr-config -n mediastack -o jsonpath={.spec.storageClassName}")
+      echo "longhorn" ;;
+    "get pvc radarr-config -n mediastack -o jsonpath={.spec.accessModes[*]}")
+      echo "ReadWriteOnce" ;;
+    "get pvc radarr-config -n mediastack -o jsonpath={.spec.volumeName}")
+      echo "pvc-abc123" ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.metadata.ownerReferences[?(@.kind==\"ReplicaSet\")].name}")
+      echo "radarr-5d9" ;;
+    "get rs radarr-5d9 -n mediastack -o jsonpath={.metadata.ownerReferences[?(@.kind==\"Deployment\")].name}")
+      echo "radarr" ;;
+    # a healthy pod (no waiting reason) on an smb PVC
+    "get pod prowlarr-y -n mediastack -o jsonpath={.status.containerStatuses[*].state.waiting.reason}{.status.initContainerStatuses[*].state.waiting.reason}")
+      echo "" ;;
+    "get pod prowlarr-y -n mediastack -o jsonpath={.spec.volumes[*].persistentVolumeClaim.claimName}")
+      echo "media-share" ;;
+    "get pvc media-share -n mediastack -o jsonpath={.spec.storageClassName}")
+      echo "smb" ;;
+    *) echo "" ;;
+  esac
+}
+
+assert_eq "$(pod_crashloop_restarts mediastack radarr-x)" "37" "crashlooping pod -> summed restarts"
+assert_eq "$(pod_crashloop_restarts mediastack prowlarr-y)" "0" "healthy pod -> 0 restarts"
+assert_eq "$(longhorn_rwo_volume mediastack radarr-x)" "pvc-abc123" "longhorn RWO pod -> PV name"
+assert_eq "$(longhorn_rwo_volume mediastack prowlarr-y)" "" "smb pod -> no volume"
+assert_eq "$(owner_deployment mediastack radarr-x)" "radarr" "pod -> owning Deployment"
+
 printf '\n%s failures\n' "$FAILS"
 [ "$FAILS" = "0" ]

--- a/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh
+++ b/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Unit tests for heal.sh. Run: sh heal_test.sh
+# Sources heal.sh with HEAL_TEST=1 so main() does not run, then stubs kc per-test.
+set -u
+HERE=$(dirname "$0")
+HEAL_TEST=1 . "$HERE/heal.sh"
+
+FAILS=0
+assert_eq() { # $1=actual $2=expected $3=msg
+  if [ "$1" = "$2" ]; then printf 'ok   - %s\n' "$3"
+  else printf 'FAIL - %s (got [%s] want [%s])\n' "$3" "$1" "$2"; FAILS=$((FAILS+1)); fi
+}
+assert_rc() { # $1=actual_rc $2=expected_rc $3=msg
+  if [ "$1" = "$2" ]; then printf 'ok   - %s\n' "$3"
+  else printf 'FAIL - %s (rc got [%s] want [%s])\n' "$3" "$1" "$2"; FAILS=$((FAILS+1)); fi
+}
+
+# --- sum_ints ---
+assert_eq "$(sum_ints 3 0 5)" "8" "sum_ints adds three ints"
+assert_eq "$(sum_ints)" "0" "sum_ints of nothing is 0"
+assert_eq "$(sum_ints 7)" "7" "sum_ints of one int"
+
+# --- in_cooldown ---
+in_cooldown "100" "150" "60"; assert_rc "$?" "0" "in_cooldown true when delta<cooldown"
+in_cooldown "100" "200" "60"; assert_rc "$?" "1" "in_cooldown false when delta>cooldown"
+in_cooldown "" "200" "60";    assert_rc "$?" "1" "in_cooldown false when no last-healed"
+
+printf '\n%s failures\n' "$FAILS"
+[ "$FAILS" = "0" ]

--- a/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh
+++ b/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh
@@ -76,5 +76,70 @@ wait_detached pvc-abc123 10 1; assert_rc "$?" "0" "wait_detached returns 0 when 
 kc() { echo "attached"; }
 wait_detached pvc-stuck 1 1; assert_rc "$?" "1" "wait_detached returns 1 on timeout"
 
+# --- find_and_heal_one: healthy cluster -> no heal ---
+# Single namespace with one healthy pod; stub heal_workload to record calls.
+HEAL_NAMESPACES="mediastack"
+HEALED=""
+heal_workload() { HEALED="$1/$2 vol=$3"; }
+kc() {
+  case "$*" in
+    "get pods -n mediastack -o jsonpath={.items[*].metadata.name}") echo "prowlarr-y" ;;
+    "get pod prowlarr-y -n mediastack -o jsonpath={.status.containerStatuses[*].state.waiting.reason}{.status.initContainerStatuses[*].state.waiting.reason}") echo "" ;;
+    "get pod prowlarr-y -n mediastack -o jsonpath={.status.phase}") echo "Running" ;;
+    *) echo "" ;;
+  esac
+}
+out=$(find_and_heal_one)
+assert_eq "$HEALED" "" "healthy cluster -> nothing healed"
+case "$out" in *"no stuck workloads found"*) assert_rc 0 0 "logs no-stuck message" ;; *) assert_rc 1 0 "logs no-stuck message" ;; esac
+
+# --- find_and_heal_one: one stuck radarr -> heal exactly once ---
+HEALED=""
+HEAL_COUNT=0
+heal_workload() { HEAL_COUNT=$((HEAL_COUNT+1)); HEALED="$1/$2 vol=$3"; }
+kc() {
+  case "$*" in
+    "get pods -n mediastack -o jsonpath={.items[*].metadata.name}") echo "radarr-x sonarr-z" ;;
+    # radarr: crashlooping over threshold, longhorn RWO
+    "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].state.waiting.reason}{.status.initContainerStatuses[*].state.waiting.reason}") echo "CrashLoopBackOff" ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].restartCount} {.status.initContainerStatuses[*].restartCount}") echo "37 " ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.spec.volumes[*].persistentVolumeClaim.claimName}") echo "radarr-config" ;;
+    "get pvc radarr-config -n mediastack -o jsonpath={.spec.storageClassName}") echo "longhorn" ;;
+    "get pvc radarr-config -n mediastack -o jsonpath={.spec.accessModes[*]}") echo "ReadWriteOnce" ;;
+    "get pvc radarr-config -n mediastack -o jsonpath={.spec.volumeName}") echo "pvc-abc123" ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.metadata.ownerReferences[?(@.kind==\"ReplicaSet\")].name}") echo "radarr-5d9" ;;
+    "get rs radarr-5d9 -n mediastack -o jsonpath={.metadata.ownerReferences[?(@.kind==\"Deployment\")].name}") echo "radarr" ;;
+    "get deploy radarr -n mediastack -o jsonpath={.metadata.annotations.mount-healer\\.vollminlab\\.com/last-healed}") echo "" ;;
+    # sonarr would also be stuck, but we must stop after the first heal
+    *) echo "" ;;
+  esac
+}
+find_and_heal_one >/dev/null
+assert_eq "$HEAL_COUNT" "1" "exactly one workload healed per run"
+assert_eq "$HEALED" "mediastack/radarr vol=pvc-abc123" "healed the stuck radarr"
+
+# --- cooldown suppresses re-heal ---
+HEAL_COUNT=0
+kc_inner() { :; }
+# same as above but last-healed is 'now' -> in cooldown
+NOWEPOCH=$(date -u +%s)
+kc() {
+  case "$*" in
+    "get pods -n mediastack -o jsonpath={.items[*].metadata.name}") echo "radarr-x" ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].state.waiting.reason}{.status.initContainerStatuses[*].state.waiting.reason}") echo "CrashLoopBackOff" ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].restartCount} {.status.initContainerStatuses[*].restartCount}") echo "37 " ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.spec.volumes[*].persistentVolumeClaim.claimName}") echo "radarr-config" ;;
+    "get pvc radarr-config -n mediastack -o jsonpath={.spec.storageClassName}") echo "longhorn" ;;
+    "get pvc radarr-config -n mediastack -o jsonpath={.spec.accessModes[*]}") echo "ReadWriteOnce" ;;
+    "get pvc radarr-config -n mediastack -o jsonpath={.spec.volumeName}") echo "pvc-abc123" ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.metadata.ownerReferences[?(@.kind==\"ReplicaSet\")].name}") echo "radarr-5d9" ;;
+    "get rs radarr-5d9 -n mediastack -o jsonpath={.metadata.ownerReferences[?(@.kind==\"Deployment\")].name}") echo "radarr" ;;
+    "get deploy radarr -n mediastack -o jsonpath={.metadata.annotations.mount-healer\\.vollminlab\\.com/last-healed}") echo "$NOWEPOCH" ;;
+    *) echo "" ;;
+  esac
+}
+find_and_heal_one >/dev/null
+assert_eq "$HEAL_COUNT" "0" "cooldown suppresses re-heal"
+
 printf '\n%s failures\n' "$FAILS"
 [ "$FAILS" = "0" ]

--- a/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh
+++ b/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh
@@ -141,5 +141,49 @@ kc() {
 find_and_heal_one >/dev/null
 assert_eq "$HEAL_COUNT" "0" "cooldown suppresses re-heal"
 
+# --- restore_orphans ---
+
+# Test A: parked-at-0 orphan is restored
+HEAL_NAMESPACES="mediastack"
+DRY_RUN="false"
+RESTORED=""
+CLEARED=""
+kc() {
+  case "$*" in
+    "get deploy -n mediastack -o jsonpath={.items[*].metadata.name}")
+      echo "radarr" ;;
+    "get deploy radarr -n mediastack -o jsonpath={.metadata.annotations.mount-healer\\.vollminlab\\.com/original-replicas}")
+      echo "2" ;;
+    "get deploy radarr -n mediastack -o jsonpath={.spec.replicas}")
+      echo "0" ;;
+    "scale deploy radarr -n mediastack --replicas=2")
+      RESTORED="radarr->2" ;;
+    "annotate deploy radarr -n mediastack mount-healer.vollminlab.com/original-replicas-")
+      CLEARED="yes" ;;
+    *) : ;;
+  esac
+}
+restore_orphans >/dev/null
+assert_eq "$RESTORED" "radarr->2" "restore_orphans rescales parked deployment"
+assert_eq "$CLEARED" "yes" "restore_orphans clears original-replicas annotation"
+
+# Test B: deployment already running is not restored
+RESTORED2=""
+kc() {
+  case "$*" in
+    "get deploy -n mediastack -o jsonpath={.items[*].metadata.name}")
+      echo "radarr" ;;
+    "get deploy radarr -n mediastack -o jsonpath={.metadata.annotations.mount-healer\\.vollminlab\\.com/original-replicas}")
+      echo "2" ;;
+    "get deploy radarr -n mediastack -o jsonpath={.spec.replicas}")
+      echo "2" ;;
+    "scale deploy radarr -n mediastack --replicas=2")
+      RESTORED2="radarr->2" ;;
+    *) : ;;
+  esac
+}
+restore_orphans >/dev/null
+assert_eq "$RESTORED2" "" "restore_orphans skips an already-running deployment"
+
 printf '\n%s failures\n' "$FAILS"
 [ "$FAILS" = "0" ]

--- a/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 metadata:
   name: longhorn-mount-healer
-namespace: kube-system
 resources:
   - rbac.yaml
   - cronjob.yaml

--- a/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: longhorn-mount-healer
+namespace: kube-system
+resources:
+  - rbac.yaml
+  - cronjob.yaml
+configMapGenerator:
+  - name: longhorn-mount-healer-script
+    files:
+      - heal.sh
+generatorOptions:
+  disableNameSuffixHash: true
+  labels:
+    app: longhorn-mount-healer
+    env: production
+    category: storage

--- a/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/rbac.yaml
+++ b/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/rbac.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-mount-healer
+  namespace: kube-system
+  labels:
+    app: longhorn-mount-healer
+    env: production
+    category: storage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: longhorn-mount-healer
+  labels:
+    app: longhorn-mount-healer
+    env: production
+    category: storage
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "persistentvolumeclaims"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "create"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "list", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["longhorn.io"]
+    resources: ["volumes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: longhorn-mount-healer
+  labels:
+    app: longhorn-mount-healer
+    env: production
+    category: storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: longhorn-mount-healer
+subjects:
+  - kind: ServiceAccount
+    name: longhorn-mount-healer
+    namespace: kube-system

--- a/docs/superpowers/plans/longhorn-mount-healer.md
+++ b/docs/superpowers/plans/longhorn-mount-healer.md
@@ -1,0 +1,876 @@
+# Longhorn Mount Healer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a `longhorn-mount-healer` CronJob that auto-clears storage-induced crashloops by codifying the proven `scale 0 → wait until the Longhorn volume detaches → scale back` runbook.
+
+**Architecture:** A raw-manifest app in `kube-system` (modeled on the existing `etcd-defrag` CronJob): a ServiceAccount + ClusterRole/Binding, a POSIX-sh script (`heal.sh`) delivered via a kustomize `configMapGenerator`, and a CronJob running `alpine/kubectl` every 10 minutes. The script is dependency-free (pure `kubectl -o jsonpath`, no `jq`/`apk`) so each helper is unit-testable with a stubbed `kubectl`. Safety is enforced by a namespace allowlist, a one-heal-per-run cap, a per-Deployment cooldown, and a crash-safe orphan-restore that runs first every invocation.
+
+**Tech Stack:** Kubernetes CronJob, `docker.io/alpine/kubectl:1.33.4`, POSIX `sh`, kustomize `configMapGenerator`, Flux CD, Longhorn `volumes.longhorn.io` CRs.
+
+**Scope:** This plan is **PR 1 — Layer 1 (the cure) only**, per the design spec (`docs/superpowers/specs/storage-crashloop-resiliency-design.md`). Layer 2 (`default-data-locality`) and Layer 3 (symptom `PrometheusRule`) are a separate follow-up plan.
+
+---
+
+## File Structure
+
+All paths relative to repo root.
+
+| File | Responsibility |
+|------|----------------|
+| `clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh` | The healer logic (POSIX sh). Single source of truth — mounted into the CronJob *and* sourced by the test. |
+| `clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh` | Unit tests. Stubs `kubectl`, sources `heal.sh`, asserts helper behavior. Not deployed (not referenced by kustomization). |
+| `clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/rbac.yaml` | ServiceAccount (kube-system) + ClusterRole + ClusterRoleBinding. |
+| `clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/cronjob.yaml` | CronJob (`*/10`), mounts the generated script ConfigMap, sets tunables via env. |
+| `clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/kustomization.yaml` | Aggregates `rbac.yaml` + `cronjob.yaml`, generates the script ConfigMap from `heal.sh`. |
+| `clusters/vollminlab-cluster/kube-system/kustomization.yaml` (MODIFY) | Add `./longhorn-mount-healer/app` to the `resources` list so Flux reconciles it. |
+
+**Design constants (used throughout):**
+- App/category labels: `app: longhorn-mount-healer`, `env: production`, `category: storage`
+- Allowlist namespaces (env `HEAL_NAMESPACES`): `mediastack monitoring harbor`
+- Annotations on the Deployment:
+  - `mount-healer.vollminlab.com/original-replicas` — replica count captured before scaling to 0
+  - `mount-healer.vollminlab.com/last-healed` — Unix epoch of the last heal (drives cooldown)
+
+---
+
+## Task 1: Scaffold the app directory and Flux wiring
+
+**Files:**
+- Create: `clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/kustomization.yaml`
+- Create: `clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh` (placeholder, fleshed out in Tasks 3–6)
+- Modify: `clusters/vollminlab-cluster/kube-system/kustomization.yaml`
+
+- [ ] **Step 1: Create a minimal `heal.sh` placeholder so `configMapGenerator` has a file**
+
+```sh
+#!/bin/sh
+# longhorn-mount-healer — placeholder, implemented in later tasks
+echo "healer not yet implemented"
+```
+
+- [ ] **Step 2: Create the app `kustomization.yaml` with the script generator**
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: longhorn-mount-healer
+resources:
+  - rbac.yaml
+  - cronjob.yaml
+configMapGenerator:
+  - name: longhorn-mount-healer-script
+    files:
+      - heal.sh
+generatorOptions:
+  disableNameSuffixHash: true
+  labels:
+    app: longhorn-mount-healer
+    env: production
+    category: storage
+```
+
+Note: `rbac.yaml` and `cronjob.yaml` don't exist yet — `kustomize build` will fail until Tasks 2 and 7. That's expected; this step only lays down the file.
+
+- [ ] **Step 3: Wire the app into the kube-system aggregation**
+
+Modify `clusters/vollminlab-cluster/kube-system/kustomization.yaml` — add the new app to `resources` in alphabetical position (after `kubeadm-cert-renew`, before `metrics-server`):
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: kube-system
+resources:
+  - namespace.yaml
+  - ./descheduler/app
+  - ./etcd-defrag/app
+  - ./kubeadm-cert-monitor/app
+  - ./kubeadm-cert-renew/app
+  - ./longhorn-mount-healer/app
+  - ./metrics-server/app
+  - ./smb-csi-driver/app
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/kustomization.yaml \
+        clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh \
+        clusters/vollminlab-cluster/kube-system/kustomization.yaml
+git commit -m "feat(kube-system): scaffold longhorn-mount-healer app + Flux wiring"
+```
+
+---
+
+## Task 2: RBAC (ServiceAccount + ClusterRole + ClusterRoleBinding)
+
+The healer reads pods/PVCs and patches Deployment scale across the allowlist namespaces, reads Longhorn `Volume` CRs in `longhorn-system`, and creates Events — so it needs a **ClusterRole** (cross-namespace), unlike `etcd-defrag`'s namespaced Role.
+
+**Files:**
+- Create: `clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/rbac.yaml`
+
+- [ ] **Step 1: Write the RBAC manifest**
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-mount-healer
+  namespace: kube-system
+  labels:
+    app: longhorn-mount-healer
+    env: production
+    category: storage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: longhorn-mount-healer
+  labels:
+    app: longhorn-mount-healer
+    env: production
+    category: storage
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "persistentvolumeclaims"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "create"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "list", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["longhorn.io"]
+    resources: ["volumes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: longhorn-mount-healer
+  labels:
+    app: longhorn-mount-healer
+    env: production
+    category: storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: longhorn-mount-healer
+subjects:
+  - kind: ServiceAccount
+    name: longhorn-mount-healer
+    namespace: kube-system
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/rbac.yaml
+git commit -m "feat(kube-system): longhorn-mount-healer RBAC (ClusterRole + binding)"
+```
+
+---
+
+## Task 3: Script foundation + pure helpers (`sum_ints`, `in_cooldown`) with tests
+
+Establish the test harness and the `kc` wrapper, then the two pure helpers that need no Kubernetes.
+
+**Files:**
+- Modify: `clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh`
+- Create: `clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh`
+
+- [ ] **Step 1: Write the failing test harness + first tests**
+
+Create `heal_test.sh`:
+
+```sh
+#!/bin/sh
+# Unit tests for heal.sh. Run: sh heal_test.sh
+# Sources heal.sh with HEAL_TEST=1 so main() does not run, then stubs kc per-test.
+set -u
+HERE=$(dirname "$0")
+HEAL_TEST=1 . "$HERE/heal.sh"
+
+FAILS=0
+assert_eq() { # $1=actual $2=expected $3=msg
+  if [ "$1" = "$2" ]; then printf 'ok   - %s\n' "$3"
+  else printf 'FAIL - %s (got [%s] want [%s])\n' "$3" "$1" "$2"; FAILS=$((FAILS+1)); fi
+}
+assert_rc() { # $1=actual_rc $2=expected_rc $3=msg
+  if [ "$1" = "$2" ]; then printf 'ok   - %s\n' "$3"
+  else printf 'FAIL - %s (rc got [%s] want [%s])\n' "$3" "$1" "$2"; FAILS=$((FAILS+1)); fi
+}
+
+# --- sum_ints ---
+assert_eq "$(sum_ints 3 0 5)" "8" "sum_ints adds three ints"
+assert_eq "$(sum_ints)" "0" "sum_ints of nothing is 0"
+assert_eq "$(sum_ints 7)" "7" "sum_ints of one int"
+
+# --- in_cooldown ---
+in_cooldown "100" "150" "60"; assert_rc "$?" "0" "in_cooldown true when delta<cooldown"
+in_cooldown "100" "200" "60"; assert_rc "$?" "1" "in_cooldown false when delta>cooldown"
+in_cooldown "" "200" "60";    assert_rc "$?" "1" "in_cooldown false when no last-healed"
+
+printf '\n%s failures\n' "$FAILS"
+[ "$FAILS" = "0" ]
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `sh clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh`
+Expected: FAIL — `heal.sh` is still the placeholder, so `sum_ints`/`in_cooldown` are undefined (`sum_ints: not found`).
+
+- [ ] **Step 3: Replace `heal.sh` with the foundation + the two helpers**
+
+Overwrite `heal.sh`:
+
+```sh
+#!/bin/sh
+# longhorn-mount-healer: auto-clear storage-induced crashloops by codifying
+# the proven scale-0 -> wait-detached -> scale-back runbook.
+set -u
+
+# --- tunables (overridable via env in the CronJob) ---
+HEAL_NAMESPACES="${HEAL_NAMESPACES:-mediastack monitoring harbor}"
+RESTART_THRESHOLD="${RESTART_THRESHOLD:-5}"
+COOLDOWN_SECONDS="${COOLDOWN_SECONDS:-21600}"
+DETACH_TIMEOUT_SECONDS="${DETACH_TIMEOUT_SECONDS:-180}"
+POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-5}"
+DRY_RUN="${DRY_RUN:-false}"
+
+ANN_ORIG="mount-healer.vollminlab.com/original-replicas"
+ANN_LAST="mount-healer.vollminlab.com/last-healed"
+# jsonpath-escaped annotation keys (dots escaped)
+JP_ORIG='mount-healer\.vollminlab\.com/original-replicas'
+JP_LAST='mount-healer\.vollminlab\.com/last-healed'
+
+# Single kubectl entry point so tests can stub it.
+kc() { kubectl "$@"; }
+
+log() { echo "[$(date -u +%FT%TZ)] $*"; }
+
+# sum_ints: echo the sum of all integer args (empty args ignored).
+sum_ints() {
+  total=0
+  for n in "$@"; do
+    [ -n "$n" ] || continue
+    total=$((total + n))
+  done
+  echo "$total"
+}
+
+# in_cooldown: exit 0 if (now - last) < cooldown. $1=last(may be empty) $2=now $3=cooldown
+in_cooldown() {
+  last="$1"; now="$2"; cd="$3"
+  [ -n "$last" ] || return 1
+  delta=$((now - last))
+  [ "$delta" -lt "$cd" ]
+}
+
+main() {
+  log "longhorn-mount-healer placeholder main"
+}
+
+[ -n "${HEAL_TEST:-}" ] || main "$@"
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `sh clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh`
+Expected: PASS — `0 failures`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh \
+        clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh
+git commit -m "feat(healer): script foundation + sum_ints/in_cooldown helpers with tests"
+```
+
+---
+
+## Task 4: Detection helpers (`pod_crashloop_restarts`, `longhorn_rwo_volume`, `owner_deployment`) with tests
+
+These call `kubectl`, so tests stub `kc` with a dispatcher that echoes canned jsonpath output keyed on the arguments.
+
+**Files:**
+- Modify: `clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh`
+- Modify: `clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh`
+
+- [ ] **Step 1: Add failing tests for the detection helpers**
+
+Append to `heal_test.sh` before the final `printf '\n%s failures\n'` line:
+
+```sh
+# --- detection helpers: stub kc as a dispatcher over fixtures ---
+# A crashlooping radarr pod on a longhorn RWO PVC.
+kc() {
+  case "$*" in
+    "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].state.waiting.reason}{.status.initContainerStatuses[*].state.waiting.reason}")
+      echo "CrashLoopBackOff" ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].restartCount} {.status.initContainerStatuses[*].restartCount}")
+      echo "37 " ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.spec.volumes[*].persistentVolumeClaim.claimName}")
+      echo "radarr-config" ;;
+    "get pvc radarr-config -n mediastack -o jsonpath={.spec.storageClassName}")
+      echo "longhorn" ;;
+    "get pvc radarr-config -n mediastack -o jsonpath={.spec.accessModes[*]}")
+      echo "ReadWriteOnce" ;;
+    "get pvc radarr-config -n mediastack -o jsonpath={.spec.volumeName}")
+      echo "pvc-abc123" ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.metadata.ownerReferences[?(@.kind==\"ReplicaSet\")].name}")
+      echo "radarr-5d9" ;;
+    "get rs radarr-5d9 -n mediastack -o jsonpath={.metadata.ownerReferences[?(@.kind==\"Deployment\")].name}")
+      echo "radarr" ;;
+    # a healthy pod (no waiting reason) on an smb PVC
+    "get pod prowlarr-y -n mediastack -o jsonpath={.status.containerStatuses[*].state.waiting.reason}{.status.initContainerStatuses[*].state.waiting.reason}")
+      echo "" ;;
+    "get pod prowlarr-y -n mediastack -o jsonpath={.spec.volumes[*].persistentVolumeClaim.claimName}")
+      echo "media-share" ;;
+    "get pvc media-share -n mediastack -o jsonpath={.spec.storageClassName}")
+      echo "smb" ;;
+    *) echo "" ;;
+  esac
+}
+
+assert_eq "$(pod_crashloop_restarts mediastack radarr-x)" "37" "crashlooping pod -> summed restarts"
+assert_eq "$(pod_crashloop_restarts mediastack prowlarr-y)" "0" "healthy pod -> 0 restarts"
+assert_eq "$(longhorn_rwo_volume mediastack radarr-x)" "pvc-abc123" "longhorn RWO pod -> PV name"
+assert_eq "$(longhorn_rwo_volume mediastack prowlarr-y)" "" "smb pod -> no volume"
+assert_eq "$(owner_deployment mediastack radarr-x)" "radarr" "pod -> owning Deployment"
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `sh clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh`
+Expected: FAIL on the five new assertions (`pod_crashloop_restarts: not found`, etc.); the Task 3 assertions still pass.
+
+- [ ] **Step 3: Add the detection helpers to `heal.sh`**
+
+Insert these functions immediately above the `main()` definition:
+
+```sh
+# pod_crashloop_restarts: echo summed restartCount IF a container/init is in
+# CrashLoopBackOff, else echo 0. $1=ns $2=pod
+pod_crashloop_restarts() {
+  ns="$1"; pod="$2"
+  reasons=$(kc get pod "$pod" -n "$ns" -o jsonpath='{.status.containerStatuses[*].state.waiting.reason}{.status.initContainerStatuses[*].state.waiting.reason}')
+  case "$reasons" in
+    *CrashLoopBackOff*) ;;
+    *) echo 0; return 0 ;;
+  esac
+  restarts=$(kc get pod "$pod" -n "$ns" -o jsonpath='{.status.containerStatuses[*].restartCount} {.status.initContainerStatuses[*].restartCount}')
+  sum_ints $restarts
+}
+
+# longhorn_rwo_volume: echo the PV name of the first longhorn RWO PVC the pod
+# mounts, else empty. $1=ns $2=pod
+longhorn_rwo_volume() {
+  ns="$1"; pod="$2"
+  claims=$(kc get pod "$pod" -n "$ns" -o jsonpath='{.spec.volumes[*].persistentVolumeClaim.claimName}')
+  for claim in $claims; do
+    [ -n "$claim" ] || continue
+    sc=$(kc get pvc "$claim" -n "$ns" -o jsonpath='{.spec.storageClassName}')
+    case "$sc" in longhorn*) ;; *) continue ;; esac
+    modes=$(kc get pvc "$claim" -n "$ns" -o jsonpath='{.spec.accessModes[*]}')
+    case " $modes " in *" ReadWriteOnce "*) ;; *) continue ;; esac
+    pv=$(kc get pvc "$claim" -n "$ns" -o jsonpath='{.spec.volumeName}')
+    [ -n "$pv" ] && { echo "$pv"; return 0; }
+  done
+}
+
+# owner_deployment: echo the Deployment that owns the pod (via its ReplicaSet),
+# else empty. $1=ns $2=pod
+owner_deployment() {
+  ns="$1"; pod="$2"
+  rs=$(kc get pod "$pod" -n "$ns" -o jsonpath='{.metadata.ownerReferences[?(@.kind=="ReplicaSet")].name}')
+  [ -n "$rs" ] || return 0
+  kc get rs "$rs" -n "$ns" -o jsonpath='{.metadata.ownerReferences[?(@.kind=="Deployment")].name}'
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `sh clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh`
+Expected: PASS — `0 failures`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh \
+        clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh
+git commit -m "feat(healer): detection helpers (crashloop, longhorn-rwo, owner) with tests"
+```
+
+---
+
+## Task 5: Action helpers (`wait_detached`, `emit_event`, `heal_workload`)
+
+These perform side effects (scale, annotate, poll). `wait_detached` is testable; `heal_workload` is verified end-to-end in Task 6's orchestration test and the controlled live test (Verification).
+
+**Files:**
+- Modify: `clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh`
+- Modify: `clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh`
+
+- [ ] **Step 1: Add a failing test for `wait_detached`**
+
+Append to `heal_test.sh` before the final summary line:
+
+```sh
+# --- wait_detached: stub kc to report 'detached' immediately ---
+kc() {
+  case "$*" in
+    "get volumes.longhorn.io pvc-abc123 -n longhorn-system -o jsonpath={.status.state}")
+      echo "detached" ;;
+    *) echo "" ;;
+  esac
+}
+wait_detached pvc-abc123 10 1; assert_rc "$?" "0" "wait_detached returns 0 when state=detached"
+
+# stub kc to never detach -> times out fast (timeout 1s, interval 1s)
+kc() { echo "attached"; }
+wait_detached pvc-stuck 1 1; assert_rc "$?" "1" "wait_detached returns 1 on timeout"
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `sh clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh`
+Expected: FAIL — `wait_detached: not found`.
+
+- [ ] **Step 3: Add the action helpers to `heal.sh`**
+
+Insert above `main()`:
+
+```sh
+# wait_detached: poll the Longhorn volume until state=detached or timeout.
+# $1=vol $2=timeout_seconds $3=interval_seconds. exit 0 if detached.
+wait_detached() {
+  vol="$1"; timeout="$2"; interval="$3"; elapsed=0
+  while [ "$elapsed" -lt "$timeout" ]; do
+    state=$(kc get volumes.longhorn.io "$vol" -n longhorn-system -o jsonpath='{.status.state}' 2>/dev/null)
+    [ "$state" = "detached" ] && return 0
+    sleep "$interval"
+    elapsed=$((elapsed + interval))
+  done
+  return 1
+}
+
+# emit_event: best-effort core/v1 Event on the Deployment. Never fails the run.
+# $1=ns $2=deploy $3=reason $4=type(Normal|Warning) $5=message
+emit_event() {
+  ens="$1"; edep="$2"; ereason="$3"; etype="$4"; emsg="$5"
+  euid=$(kc get deploy "$edep" -n "$ens" -o jsonpath='{.metadata.uid}' 2>/dev/null)
+  ets=$(date -u +%FT%TZ)
+  ename="${edep}.$(date -u +%s)"
+  kc create -f - >/dev/null 2>&1 <<EOF || log "WARN: event emit failed for $ens/$edep"
+apiVersion: v1
+kind: Event
+metadata:
+  name: ${ename}
+  namespace: ${ens}
+involvedObject:
+  apiVersion: apps/v1
+  kind: Deployment
+  name: ${edep}
+  namespace: ${ens}
+  uid: ${euid}
+reason: ${ereason}
+message: "${emsg}"
+type: ${etype}
+source:
+  component: longhorn-mount-healer
+firstTimestamp: ${ets}
+lastTimestamp: ${ets}
+count: 1
+EOF
+}
+
+# heal_workload: the runbook. $1=ns $2=deploy $3=vol
+heal_workload() {
+  ns="$1"; dep="$2"; vol="$3"
+  replicas=$(kc get deploy "$dep" -n "$ns" -o jsonpath='{.spec.replicas}')
+  if [ -z "$replicas" ] || [ "$replicas" -le 0 ] 2>/dev/null; then
+    log "skip $ns/$dep: replicas=$replicas (nothing to heal)"; return 0
+  fi
+  if [ "$DRY_RUN" = "true" ]; then
+    log "DRY_RUN: would heal $ns/$dep (vol=$vol): scale 0 -> wait-detached -> $replicas"; return 0
+  fi
+  log "healing $ns/$dep (vol=$vol, replicas=$replicas)"
+  kc annotate deploy "$dep" -n "$ns" "$ANN_ORIG=$replicas" --overwrite
+  kc scale deploy "$dep" -n "$ns" --replicas=0
+  if wait_detached "$vol" "$DETACH_TIMEOUT_SECONDS" "$POLL_INTERVAL_SECONDS"; then
+    kc scale deploy "$dep" -n "$ns" --replicas="$replicas"
+    log "healed $ns/$dep (restored to $replicas)"
+    emit_event "$ns" "$dep" HealedStaleMount Normal "Cleared stale Longhorn mount on $vol via scale-0/wait-detached/scale-$replicas"
+  else
+    kc scale deploy "$dep" -n "$ns" --replicas="$replicas"
+    log "WARN: $vol did not detach within ${DETACH_TIMEOUT_SECONDS}s; restored $ns/$dep to $replicas anyway"
+    emit_event "$ns" "$dep" HealedStaleMountTimeout Warning "Volume $vol did not detach within ${DETACH_TIMEOUT_SECONDS}s; restored replicas to $replicas, manual check needed"
+  fi
+  # clear the original-replicas marker (restore done) and stamp cooldown
+  kc annotate deploy "$dep" -n "$ns" "${ANN_ORIG}-" >/dev/null 2>&1 || true
+  kc annotate deploy "$dep" -n "$ns" "$ANN_LAST=$(date -u +%s)" --overwrite
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `sh clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh`
+Expected: PASS — `0 failures`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh \
+        clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh
+git commit -m "feat(healer): action helpers wait_detached/emit_event/heal_workload"
+```
+
+---
+
+## Task 6: Orchestration (`restore_orphans`, `find_and_heal_one`, `main`) with an end-to-end stub test
+
+Ties detection + actions together with the safety invariants: orphan-restore runs first, then at most one workload is healed per run, gated by the cooldown.
+
+**Files:**
+- Modify: `clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh`
+- Modify: `clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh`
+
+- [ ] **Step 1: Add failing orchestration tests**
+
+Append to `heal_test.sh` before the final summary line:
+
+```sh
+# --- find_and_heal_one: healthy cluster -> no heal ---
+# Single namespace with one healthy pod; stub heal_workload to record calls.
+HEAL_NAMESPACES="mediastack"
+HEALED=""
+heal_workload() { HEALED="$1/$2 vol=$3"; }
+kc() {
+  case "$*" in
+    "get pods -n mediastack -o jsonpath={.items[*].metadata.name}") echo "prowlarr-y" ;;
+    "get pod prowlarr-y -n mediastack -o jsonpath={.status.containerStatuses[*].state.waiting.reason}{.status.initContainerStatuses[*].state.waiting.reason}") echo "" ;;
+    "get pod prowlarr-y -n mediastack -o jsonpath={.status.phase}") echo "Running" ;;
+    *) echo "" ;;
+  esac
+}
+out=$(find_and_heal_one)
+assert_eq "$HEALED" "" "healthy cluster -> nothing healed"
+case "$out" in *"no stuck workloads found"*) assert_rc 0 0 "logs no-stuck message" ;; *) assert_rc 1 0 "logs no-stuck message" ;; esac
+
+# --- find_and_heal_one: one stuck radarr -> heal exactly once ---
+HEALED=""
+HEAL_COUNT=0
+heal_workload() { HEAL_COUNT=$((HEAL_COUNT+1)); HEALED="$1/$2 vol=$3"; }
+kc() {
+  case "$*" in
+    "get pods -n mediastack -o jsonpath={.items[*].metadata.name}") echo "radarr-x sonarr-z" ;;
+    # radarr: crashlooping over threshold, longhorn RWO
+    "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].state.waiting.reason}{.status.initContainerStatuses[*].state.waiting.reason}") echo "CrashLoopBackOff" ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].restartCount} {.status.initContainerStatuses[*].restartCount}") echo "37 " ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.spec.volumes[*].persistentVolumeClaim.claimName}") echo "radarr-config" ;;
+    "get pvc radarr-config -n mediastack -o jsonpath={.spec.storageClassName}") echo "longhorn" ;;
+    "get pvc radarr-config -n mediastack -o jsonpath={.spec.accessModes[*]}") echo "ReadWriteOnce" ;;
+    "get pvc radarr-config -n mediastack -o jsonpath={.spec.volumeName}") echo "pvc-abc123" ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.metadata.ownerReferences[?(@.kind==\"ReplicaSet\")].name}") echo "radarr-5d9" ;;
+    "get rs radarr-5d9 -n mediastack -o jsonpath={.metadata.ownerReferences[?(@.kind==\"Deployment\")].name}") echo "radarr" ;;
+    "get deploy radarr -n mediastack -o jsonpath={.metadata.annotations.mount-healer\\.vollminlab\\.com/last-healed}") echo "" ;;
+    # sonarr would also be stuck, but we must stop after the first heal
+    *) echo "" ;;
+  esac
+}
+find_and_heal_one >/dev/null
+assert_eq "$HEAL_COUNT" "1" "exactly one workload healed per run"
+assert_eq "$HEALED" "mediastack/radarr vol=pvc-abc123" "healed the stuck radarr"
+
+# --- cooldown suppresses re-heal ---
+HEAL_COUNT=0
+kc_inner() { :; }
+# same as above but last-healed is 'now' -> in cooldown
+NOWEPOCH=$(date -u +%s)
+kc() {
+  case "$*" in
+    "get pods -n mediastack -o jsonpath={.items[*].metadata.name}") echo "radarr-x" ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].state.waiting.reason}{.status.initContainerStatuses[*].state.waiting.reason}") echo "CrashLoopBackOff" ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].restartCount} {.status.initContainerStatuses[*].restartCount}") echo "37 " ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.spec.volumes[*].persistentVolumeClaim.claimName}") echo "radarr-config" ;;
+    "get pvc radarr-config -n mediastack -o jsonpath={.spec.storageClassName}") echo "longhorn" ;;
+    "get pvc radarr-config -n mediastack -o jsonpath={.spec.accessModes[*]}") echo "ReadWriteOnce" ;;
+    "get pvc radarr-config -n mediastack -o jsonpath={.spec.volumeName}") echo "pvc-abc123" ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.metadata.ownerReferences[?(@.kind==\"ReplicaSet\")].name}") echo "radarr-5d9" ;;
+    "get rs radarr-5d9 -n mediastack -o jsonpath={.metadata.ownerReferences[?(@.kind==\"Deployment\")].name}") echo "radarr" ;;
+    "get deploy radarr -n mediastack -o jsonpath={.metadata.annotations.mount-healer\\.vollminlab\\.com/last-healed}") echo "$NOWEPOCH" ;;
+    *) echo "" ;;
+  esac
+}
+find_and_heal_one >/dev/null
+assert_eq "$HEAL_COUNT" "0" "cooldown suppresses re-heal"
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `sh clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh`
+Expected: FAIL — `find_and_heal_one: not found`.
+
+- [ ] **Step 3: Add orchestration to `heal.sh` and replace `main()`**
+
+Replace the placeholder `main()` with the orchestration (and add `restore_orphans` + `find_and_heal_one` above it):
+
+```sh
+# restore_orphans: repair any Deployment a prior interrupted heal left at 0.
+# Runs FIRST every invocation so a dead healer pod can't park a workload down.
+restore_orphans() {
+  for ns in $HEAL_NAMESPACES; do
+    deps=$(kc get deploy -n "$ns" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)
+    for dep in $deps; do
+      [ -n "$dep" ] || continue
+      orig=$(kc get deploy "$dep" -n "$ns" -o jsonpath="{.metadata.annotations.$JP_ORIG}" 2>/dev/null)
+      [ -n "$orig" ] || continue
+      cur=$(kc get deploy "$dep" -n "$ns" -o jsonpath='{.spec.replicas}')
+      if [ "$cur" = "0" ] && [ "$orig" != "0" ]; then
+        log "orphan-restore $ns/$dep -> $orig"
+        [ "$DRY_RUN" = "true" ] && continue
+        kc scale deploy "$dep" -n "$ns" --replicas="$orig"
+        kc annotate deploy "$dep" -n "$ns" "${ANN_ORIG}-" >/dev/null 2>&1 || true
+        kc annotate deploy "$dep" -n "$ns" "$ANN_LAST=$(date -u +%s)" --overwrite
+        emit_event "$ns" "$dep" RestoredAfterInterrupt Warning "Restored replicas to $orig after an interrupted heal"
+      fi
+    done
+  done
+}
+
+# pod_mount_wedged: exit 0 if pod is Pending with a FailedMount 'busy' event
+# (the post-scale reattach race). $1=ns $2=pod
+pod_mount_wedged() {
+  ns="$1"; pod="$2"
+  phase=$(kc get pod "$pod" -n "$ns" -o jsonpath='{.status.phase}')
+  [ "$phase" = "Pending" ] || return 1
+  msgs=$(kc get events -n "$ns" --field-selector "involvedObject.name=$pod,reason=FailedMount" -o jsonpath='{.items[*].message}' 2>/dev/null)
+  case "$msgs" in
+    *"already mounted or mount point busy"*) return 0 ;;
+    *"volume is already exclusively attached"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# find_and_heal_one: heal at most ONE stuck workload, gated by cooldown.
+find_and_heal_one() {
+  now=$(date -u +%s)
+  for ns in $HEAL_NAMESPACES; do
+    pods=$(kc get pods -n "$ns" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)
+    for pod in $pods; do
+      [ -n "$pod" ] || continue
+      restarts=$(pod_crashloop_restarts "$ns" "$pod")
+      if [ "$restarts" -gt "$RESTART_THRESHOLD" ]; then
+        :
+      elif pod_mount_wedged "$ns" "$pod"; then
+        :
+      else
+        continue
+      fi
+      vol=$(longhorn_rwo_volume "$ns" "$pod")
+      [ -n "$vol" ] || continue
+      dep=$(owner_deployment "$ns" "$pod")
+      [ -n "$dep" ] || { log "skip $ns/$pod: no Deployment owner"; continue; }
+      last=$(kc get deploy "$dep" -n "$ns" -o jsonpath="{.metadata.annotations.$JP_LAST}" 2>/dev/null)
+      if in_cooldown "$last" "$now" "$COOLDOWN_SECONDS"; then
+        log "skip $ns/$dep: in cooldown (last-healed=$last)"; continue
+      fi
+      heal_workload "$ns" "$dep" "$vol"
+      return 0
+    done
+  done
+  log "no stuck workloads found"
+}
+
+main() {
+  log "longhorn-mount-healer start (ns='$HEAL_NAMESPACES' threshold=$RESTART_THRESHOLD dry_run=$DRY_RUN)"
+  restore_orphans
+  find_and_heal_one
+  log "longhorn-mount-healer done"
+}
+
+[ -n "${HEAL_TEST:-}" ] || main "$@"
+```
+
+Note: delete the old placeholder `main()` and the trailing `[ -n "${HEAL_TEST:-}" ] || main "$@"` line from Task 3 so there is exactly one of each.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `sh clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh`
+Expected: PASS — `0 failures`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh \
+        clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh
+git commit -m "feat(healer): orchestration (orphan-restore, one-per-run, cooldown) with e2e stub tests"
+```
+
+---
+
+## Task 7: CronJob manifest
+
+**Files:**
+- Create: `clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/cronjob.yaml`
+
+- [ ] **Step 1: Write the CronJob**
+
+Modeled on `etcd-defrag/app/cronjob.yaml` (same image, resource shape, `concurrencyPolicy: Forbid`). Mounts the generated script ConfigMap read-only and runs it.
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: longhorn-mount-healer
+  namespace: kube-system
+  labels:
+    app: longhorn-mount-healer
+    env: production
+    category: storage
+spec:
+  schedule: "*/10 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 3600
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: longhorn-mount-healer
+            env: production
+            category: storage
+        spec:
+          serviceAccountName: longhorn-mount-healer
+          restartPolicy: Never
+          containers:
+            - name: longhorn-mount-healer
+              image: docker.io/alpine/kubectl:1.33.4
+              command: ["/bin/sh", "/scripts/heal.sh"]
+              env:
+                - name: HEAL_NAMESPACES
+                  value: "mediastack monitoring harbor"
+                - name: RESTART_THRESHOLD
+                  value: "5"
+                - name: COOLDOWN_SECONDS
+                  value: "21600"
+                - name: DETACH_TIMEOUT_SECONDS
+                  value: "180"
+                - name: POLL_INTERVAL_SECONDS
+                  value: "5"
+                - name: DRY_RUN
+                  value: "false"
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+                  readOnly: true
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+          volumes:
+            - name: script
+              configMap:
+                name: longhorn-mount-healer-script
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/cronjob.yaml
+git commit -m "feat(kube-system): longhorn-mount-healer CronJob (*/10)"
+```
+
+---
+
+## Task 8: Validate, run the full test suite, and open the PR
+
+**Files:** none (validation + PR).
+
+- [ ] **Step 1: Run the unit test suite one final time**
+
+Run: `sh clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh`
+Expected: PASS — `0 failures`.
+
+- [ ] **Step 2: Validate the manifests build**
+
+Run: `kubectl kustomize clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app`
+Expected: clean YAML output containing the ServiceAccount, ClusterRole, ClusterRoleBinding, CronJob, and a `ConfigMap` named exactly `longhorn-mount-healer-script` (no hash suffix) carrying the `app/env/category` labels and the `heal.sh` key.
+
+Then build the whole namespace to confirm the aggregation edit is valid:
+Run: `kubectl kustomize clusters/vollminlab-cluster/kube-system`
+Expected: builds without error and includes the healer resources.
+
+- [ ] **Step 3: Sanity-check Kyverno-relevant fields**
+
+Confirm by inspection of the build output:
+- CronJob pod template has `app`, `env`, `category` labels and CPU+memory requests+limits (resource-limits + required-labels policies).
+- Image is pinned `docker.io/alpine/kubectl:1.33.4` (no `:latest`).
+- No `privileged`, no `hostPath`, not in `default` namespace.
+- Generated ConfigMap carries the three labels (required-labels on ConfigMaps).
+
+- [ ] **Step 4: Push the branch and open the PR**
+
+```bash
+git push -u origin feat/storage-crashloop-resiliency
+gh pr create --title "feat(kube-system): longhorn-mount-healer — auto-clear storage-induced crashloops" \
+  --body "Implements Layer 1 of docs/superpowers/specs/storage-crashloop-resiliency-design.md.
+
+CronJob in kube-system that codifies the proven scale-0 -> wait-detached -> scale-back
+runbook for pods stuck in CrashLoopBackOff (or wedged Pending) on a Longhorn RWO volume.
+Safety: namespace allowlist (mediastack/monitoring/harbor), one heal per run, per-Deployment
+6h cooldown, and a crash-safe orphan-restore that runs first every invocation.
+
+Layers 2 (data-locality nudge) and 3 (symptom alert) follow in a separate PR.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+Do not merge — wait for explicit approval and green CI (Kyverno test + gitleaks).
+
+---
+
+## Post-merge controlled verification (operational, not part of the PR)
+
+After Flux reconciles the merged PR:
+
+1. `kubectl get cronjob longhorn-mount-healer -n kube-system` → schedule `*/10`, recently scheduled.
+2. Inspect a steady-state job log: `kubectl logs -n kube-system job/<latest-healer-job>` → ends with `no stuck workloads found` and `done`; nothing scaled.
+3. RBAC spot-check:
+   `kubectl auth can-i patch deployments/scale -n mediastack --as=system:serviceaccount:kube-system:longhorn-mount-healer` → `yes`;
+   `kubectl auth can-i get volumes.longhorn.io -n longhorn-system --as=system:serviceaccount:kube-system:longhorn-mount-healer` → `yes`.
+4. **DRY_RUN rehearsal (optional):** temporarily set `DRY_RUN=true` (env edit on the CronJob, not committed) and induce a crashloop on a throwaway allowlisted Deployment past 5 restarts; confirm the next job logs `DRY_RUN: would heal ...` and does **not** scale it. Revert.
+5. **Live heal:** with `DRY_RUN=false`, replay against a genuinely stuck workload (or the next real incident); confirm the job scales it to 0, waits for `detached`, scales it back, and emits a `HealedStaleMount` Event (`kubectl get events -n <ns> --field-selector reason=HealedStaleMount`).
+6. **Crash-safe restore:** while a heal is mid-flight (workload at 0 with the `original-replicas` annotation), delete the running job pod; confirm the next `*/10` run logs `orphan-restore` and brings the workload back.
+
+---
+
+## Self-Review
+
+**Spec coverage** (against `storage-crashloop-resiliency-design.md`, Layer 1 only — Layers 2/3 are out of scope for this plan):
+- Detection: CrashLoopBackOff>threshold → `pod_crashloop_restarts` (Task 4); wedged Pending/FailedMount → `pod_mount_wedged` (Task 6); Longhorn RWO backing → `longhorn_rwo_volume` (Task 4). ✓
+- Action runbook (record replicas → scale 0 → poll until detached → scale back → Event): `heal_workload` (Task 5). ✓
+- Namespace allowlist: `HEAL_NAMESPACES` env + loop (Tasks 6/7). ✓
+- One-per-run: `find_and_heal_one` returns after first heal (Task 6, tested). ✓
+- Per-workload cooldown: `in_cooldown` + `ANN_LAST` (Tasks 3/6, tested). ✓
+- Crash-safe restore: `restore_orphans` runs first in `main` (Task 6). ✓
+- Detach-timeout fallback (restore anyway + Warning event): `heal_workload` else-branch (Task 5). ✓
+- Deployments-only: owner resolution stops at Deployment; StatefulSets never matched (Task 4). ✓
+- RBAC least-privilege: ClusterRole scoped to the exact verbs/resources (Task 2). ✓
+- Flux wiring (single index — no HelmRepository): kube-system aggregation edit (Task 1). ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; commands have expected output. ✓
+
+**Type/name consistency:** `kc`, `log`, `sum_ints`, `in_cooldown`, `pod_crashloop_restarts`, `longhorn_rwo_volume`, `owner_deployment`, `wait_detached`, `emit_event`, `heal_workload`, `restore_orphans`, `pod_mount_wedged`, `find_and_heal_one`, `main` — names used in tests match definitions. ConfigMap name `longhorn-mount-healer-script` matches between `kustomization.yaml` (generator) and `cronjob.yaml` (volume). Annotation keys `ANN_ORIG`/`ANN_LAST` and their jsonpath-escaped twins `JP_ORIG`/`JP_LAST` are consistent. ✓

--- a/docs/superpowers/specs/storage-crashloop-resiliency-design.md
+++ b/docs/superpowers/specs/storage-crashloop-resiliency-design.md
@@ -1,6 +1,6 @@
 # Storage-Induced Crashloop Resiliency — Design
 
-**Status:** Draft for review
+**Status:** Draft for review (revised after adversarial evaluation)
 **Created:** 2026-06-20
 **Author:** Scott Vollmin (with Claude)
 **Related incident:** Longhorn stale-mount EIO recurrence 2026-06-20 (radarr w03, sonarr w04 crashlooping 2+ days; grafana datasource landmine detonated by the same w04 blip)
@@ -17,9 +17,18 @@ mount, and crashes again — **CrashLoopBackOff**.
 
 **The trap that makes this self-perpetuating:** a CrashLoopBackOff pod never triggers a Longhorn
 volume detach. The pod stays scheduled on the same node, the volume stays attached, the stale mount
-is never cleared. The only thing that clears it is a full detach/reattach cycle — which requires the
-pod object to be *deleted and rescheduled* (`scale 0 → wait detached → scale 1`, or an eviction).
-Kubernetes' built-in restart loop deletes the *container*, never the *pod*, so it can never escape.
+is never cleared. Kubernetes' built-in restart loop deletes the *container*, never the *pod*, so it
+can never escape. The only thing that clears it is a full **detach/reattach** cycle.
+
+**Why the detach is the hard part (the crux):** the proven manual cure is
+`scale 0 → wait until the Longhorn volume reports detached → scale 1`. The load-bearing step is the
+**wait**. An errored ext4 filesystem cannot unmount cleanly — the kernel reports the mount `busy`
+(`exit status 32: already mounted or mount point busy`), and the detach takes time to complete. Any
+remediation that deletes/recreates the pod *without waiting for the volume to fully detach* races the
+new pod against the still-attaching volume and re-wedges it in `ContainerCreating`. Kubernetes'
+6-minute force-detach (kubernetes#65392) only fires when the **node is unreachable**, not on a hung
+unmount on a *healthy* node — and these nodes are healthy. So nothing in the stock system performs
+the wait.
 
 On 2026-06-20 this left radarr and sonarr crashlooping for **2+ days** (36–38 restarts each) until a
 human ran the manual scale-0→1 recovery. That manual step is the gap this design closes.
@@ -29,16 +38,42 @@ is *a* trigger, but the resiliency requirement is that the cluster heals itself 
 **regardless of which app, which node, or what triggered the stale mount**. The cure must be
 app-agnostic and node-agnostic.
 
+## Why not the descheduler (rejected approach)
+
+The obvious low-effort option is to reuse the **descheduler** already running in `kube-system`
+(CronJob, chart 0.36.0 / descheduler **v0.36**) and add its `RemovePodsHavingTooManyRestarts`
+plugin to evict stuck pods. This was the original draft of this design. Adversarial evaluation
+killed it:
+
+- **Eviction does not perform the wait.** Eviction is a graceful pod-delete followed by an immediate
+  reschedule (the Deployment's `Recreate` strategy starts the replacement as soon as the old pod is
+  gone). There is no knob to make the descheduler block until the Longhorn volume reports `detached`.
+  On the *errored/busy-mount* subset — which is precisely the 2-day incident — the replacement pod
+  races the still-attaching volume and wedges in `ContainerCreating`, re-triggered every cycle. It
+  heals only the *clean-restart* subset and turns the errored subset from a loud CrashLoopBackOff
+  into a quieter hang.
+- **Its metrics are unobservable here.** The descheduler runs as a CronJob; its job pods live ~4s and
+  the chart only renders a Service/ServiceMonitor in `kind: Deployment` mode. The intended
+  Layer-3 alert on `descheduler_pods_evicted_total` is therefore unscrapeable without restructuring
+  the descheduler itself.
+- **No eviction rate caps in the current config** — adding the plugin without
+  `maxNoOfPodsToEvictTotal`/per-node/per-namespace caps risks a thundering-herd eviction.
+
+A remediation step that *always* performs the full detach-with-wait strictly dominates: it heals both
+the clean and errored subsets. That is what this design builds. The descheduler is left untouched,
+continuing to run only its `LowNodeUtilization` balance profile.
+
 ## Goal
 
 Make the cluster self-heal from storage-induced crashloops with no human intervention, and make that
 self-healing observable. Concretely:
 
-1. **Resiliency (primary):** any pod stuck in CrashLoopBackOff past a threshold is automatically
-   evicted, which forces the Longhorn detach/reattach that clears the stale mount. This is the cure
-   and it heals *every* variant of the problem — every app, every node, every trigger.
-2. **Visibility:** when the self-healing fires, an alert tells us it happened, so a recurring
-   storage problem can't hide behind a system that silently papers over it.
+1. **Resiliency (primary):** any workload whose pod is stuck on a stale Longhorn mount past a
+   threshold is automatically returned to health by codifying the proven runbook
+   (`scale 0 → wait detached → scale to original`). This is the cure and it heals *every* variant —
+   every app, every node, every trigger.
+2. **Visibility:** when the self-healing fires, an alert surfaces it, so a recurring storage problem
+   can't hide behind a system that silently papers over it.
 
 Frequency reduction (making the stale mount happen less often) is explicitly **secondary** and kept
 to a zero-risk declarative nudge — see Layer 2. The node RAM rework tracked separately
@@ -48,54 +83,77 @@ to a zero-risk declarative nudge — see Layer 2. The node RAM rework tracked se
 
 - Fixing the node memory/IO pressure that triggers the blips (separate RAM-rework effort).
 - Patching `dataLocality` on existing volumes (triggers background replica rebuilds; deferred to a
-  controlled operational step, not part of this change).
+  controlled operational step gated on a Longhorn capacity check).
+- Healing StatefulSet-backed workloads (v1 targets Deployments only — the arr/monitoring pattern;
+  see Open questions).
 - Any app-specific or node-specific remediation.
 
 ## Approach
 
-Reuse the **descheduler** already deployed in `kube-system` (CronJob, chart 0.36.0 /
-descheduler v0.33). It already runs every 30 minutes with a `DefaultEvictor` + `LowNodeUtilization`
-balance profile. We add one deschedule plugin — `RemovePodsHavingTooManyRestarts` — that evicts
-pods stuck restarting. Eviction deletes the pod object, which is exactly the trigger Longhorn needs
-to detach and reattach the volume on reschedule, clearing the stale mount.
+A small **`longhorn-mount-healer` CronJob** in `kube-system` (same home as the descheduler) that runs
+the known-good runbook on a schedule. It is a kubectl/bash job — no operator framework, no watch
+loop — because the failure is a *sustained stuck state*, not a fast transient, so periodic polling is
+sufficient and far simpler to reason about and roll back.
 
-This was chosen over a custom controller or per-app liveness-probe hacks because the mechanism
-already exists, is maintained upstream, is app/node-agnostic by construction, and needs only a
-configmap change.
+### Layer 1 — `longhorn-mount-healer` (the cure) — PRIMARY
 
-### Layer 1 — Self-healing eviction (the cure) — PRIMARY
+New raw-manifest app at `clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/`:
+`cronjob.yaml`, `rbac.yaml`, `configmap.yaml` (the script), `kustomization.yaml`. Image
+`alpine/kubectl:1.33.4` (cluster convention; `apk add jq` in-script if needed). Schedule `*/10`.
 
-Edit `clusters/vollminlab-cluster/kube-system/descheduler/app/configmap.yaml`:
+**Detection — a workload is "stuck on storage" this run if BOTH hold:**
 
-- Add a `RemovePodsHavingTooManyRestarts` plugin to the `default` profile:
-  - `podRestartThreshold: 10` — a pod that has restarted 10+ times is unambiguously stuck, not
-    transiently flapping. At ~5 min max CrashLoopBackOff backoff, 10 restarts ≈ under an hour of
-    crashing before the cluster heals it — versus the 2+ days it took by hand.
-  - `includingInitContainers: true` — count init-container restarts too.
-  - **`states: ["CrashLoopBackOff"]`** — only evict pods whose container is *currently* in
-    CrashLoopBackOff. This is the critical safety scope: without it the plugin evicts any pod whose
-    *cumulative* restart count exceeds the threshold, including a pod that crashed 11 times last week
-    and has run healthy since. Scoping to the live CrashLoopBackOff state means we only ever evict a
-    pod that is *right now* stuck. (Supported on descheduler v0.29+; this cluster is on v0.33.)
-- Enable it under `plugins.deschedule.enabled`.
-- Tighten the CronJob `schedule` from `*/30 * * * *` to `*/15 * * * *` so a stuck pod is healed
-  within ~15 minutes of crossing the threshold instead of up to 30.
+1. Its pod is in one of:
+   - **CrashLoopBackOff** with summed `restartCount > 5` (the radarr exit-134 / sonarr exit-139
+     case). Threshold 5 ≈ a few minutes of backoff — long enough to exclude a transient startup
+     crash, far short of the 36–38 we hit by hand.
+   - **Pending/ContainerCreating** carrying a `FailedMount` event matching
+     `already mounted or mount point busy` (or Longhorn attach errors) — the wedged-reattach case.
+2. The pod mounts a **Longhorn `ReadWriteOnce` PVC**. Mapping: pod → mounted PVC (pod namespace) →
+   `PVC.spec.volumeName` (= PV name) → Longhorn `Volume` CR of the same name in `longhorn-system`.
 
-**Why eviction heals the mount:** the existing `DefaultEvictor` already has
-`nodeFit: true` and `podProtections.defaultDisabled: ["PodsWithLocalStorage"]`. `nodeFit` only
-evicts a pod that can be scheduled elsewhere; Longhorn RWO volumes can attach to any node, so this
-always passes. Eviction → pod deleted → Longhorn detaches the volume → pod reschedules → volume
-reattaches with a clean mount (fsck runs on attach). This is the same detach/reattach the manual
-`scale 0 → 1` recovery performs, done automatically.
+**Action — the proven runbook, per stuck workload:**
 
-**Safety properties:**
-- `DefaultEvictor` protects DaemonSet pods, static/mirror pods, and pods with
-  `system-cluster-critical`/`system-node-critical` priority by default — so the descheduler can't
-  evict its way into a cluster outage.
-- `states: ["CrashLoopBackOff"]` means healthy pods are never touched, no matter their history.
-- Worst case for a *legitimately* crashlooping app (bad config, not a stale mount): the descheduler
-  evicts it, it reschedules, and it crashloops again — i.e. eviction is a no-op for non-storage
-  crashloops, not a harm. It neither fixes nor worsens a genuine application bug.
+1. Resolve the owning controller (Deployment) from the pod's ownerReferences.
+2. Record the controller's current `spec.replicas` in an annotation
+   (`mount-healer.vollminlab.com/original-replicas`) **before** scaling.
+3. Scale the Deployment to **0**.
+4. **Poll** `kubectl get volumes.longhorn.io <vol> -n longhorn-system -o jsonpath='{.status.state}'`
+   until it reads `detached`, up to a bounded timeout (e.g. 3 min).
+5. Scale the Deployment back to the recorded original replica count.
+6. Emit a Kubernetes `Event` (`reason: HealedStaleMount`) on the Deployment and a healer log line.
+
+**Safety properties (load-bearing):**
+
+- **Namespace allowlist** — only acts in the namespaces that actually hold Longhorn RWO app volumes
+  (`mediastack`, `monitoring`, `harbor`). Never touches arbitrary workloads. The allowlist is an
+  explicit script constant, reviewed in PR.
+- **One workload per run** — at most one Deployment is healed per invocation; any other stuck
+  workloads wait for the next tick. This is the thundering-herd brake the descheduler approach
+  lacked.
+- **Per-workload cooldown** — an annotation timestamp (`mount-healer.vollminlab.com/last-healed`)
+  suppresses re-healing the same Deployment within a cooldown window (e.g. 6h). A workload that
+  crashloops *again* after a heal is a genuine application bug, not a stale mount: the healer leaves
+  it alone and Layer 3 pages a human.
+- **Crash-safe restore (idempotency)** — at the **start** of every run, before any detection, the
+  healer first scans the allowlist for any Deployment carrying
+  `mount-healer.vollminlab.com/original-replicas` while sitting at `spec.replicas: 0`, and restores
+  it. So a healer job pod that dies between step 3 and step 5 cannot leave a workload parked at zero;
+  the next tick repairs it.
+- **Detach-timeout fallback** — if the volume never reaches `detached` within the timeout, the
+  healer **still restores** the original replicas (never silently parks a workload at 0) and emits a
+  `HealedStaleMountTimeout` Event so the alert fires. Down-and-alerting beats down-and-silent.
+- **Deployments only** — targets the arr/monitoring pattern (RWO + `strategy: Recreate`, replicas 1).
+  StatefulSets are explicitly skipped in v1.
+
+**RBAC** (ServiceAccount in `kube-system` + ClusterRole + ClusterRoleBinding):
+`get`/`list` on `pods`, `persistentvolumeclaims`, `persistentvolumes`, `events`;
+`get`/`list`/`patch` on `apps/deployments` and `apps/deployments/scale`;
+`create` on `events`; `get`/`list` on `volumes.longhorn.io`.
+
+**Why this heals where eviction can't:** every code path performs the explicit *poll-until-detached*
+wait before bringing the workload back. That wait is the one ingredient the manual runbook has and
+eviction lacks, and it is what clears the errored/busy mount.
 
 ### Layer 2 — Data-locality nudge (frequency reduction) — DECLARATIVE ONLY, zero churn
 
@@ -105,70 +163,88 @@ less likely to be the replica the pod is actively reading, shrinking the most co
 stale mount.
 
 **Scope is deliberately limited to declarative-only:**
-- Change the global default and/or the StorageClass `dataLocality` parameter so volumes created
-  going forward get a local replica.
-- **Do not** patch `dataLocality` on existing volumes in this change. That triggers background
-  replica rebuilds and must be gated behind a Longhorn capacity check (per `storage.md`). It's a
-  deferred operational step, not part of this PR.
 
-This layer is kept intentionally small so it never competes with or complicates Layer 1. If review
-prefers to drop Layer 2 entirely and rely solely on Layer 1's cure, that is acceptable — Layer 1
-heals the problem regardless of frequency.
+- Change the global default and/or the StorageClass `dataLocality` parameter so volumes created going
+  forward get a local replica.
+- **Do not** patch `dataLocality` on existing volumes in this change. That triggers background replica
+  rebuilds and must be gated behind a Longhorn capacity check (per `storage.md`). It's a deferred
+  operational step, not part of this work.
 
-### Layer 3 — Visibility (so self-healing isn't silent)
+### Layer 3 — Visibility (symptom-based) — so self-healing isn't silent
 
-Add a `PrometheusRule` that alerts when the descheduler evicts pods, so automated healing surfaces a
-recurring storage problem instead of masking it.
+Add a `PrometheusRule` (in `monitoring`) that alerts on the **symptom**, using the already-scraped
+kube-state-metrics series — no dependency on the descheduler's unscrapeable CronJob metrics:
 
-- Alert on the descheduler's evicted-pods metric (`descheduler_pods_evicted`) showing eviction
-  activity over a window — info/warning severity, routed like other cluster alerts.
-- Intent: "the cluster healed itself N times today" is a signal worth seeing. A spike means a node
-  or volume is misbehaving and the underlying trigger (node pressure) needs attention even though
-  users saw no outage.
-- Verify the descheduler CronJob's metrics are actually scraped by Prometheus; if the CronJob job
-  pods aren't currently a ServiceMonitor/scrape target, wire that up as part of this layer (else the
-  metric won't exist). Confirm metric name and exposure during implementation.
+- Alert on `kube_pod_container_status_restarts_total` increasing rapidly over a window (a pod
+  sustaining restarts), at warning severity, routed like other cluster alerts.
+- Combined with the healer's `HealedStaleMount` / `HealedStaleMountTimeout` Events, this gives both
+  signals: *something got stuck* (the alert) and *it got healed* (the Event). If the alert keeps
+  firing despite the healer running, the healer isn't coping (e.g. cooldown suppressed a genuine bug,
+  or detach is timing out) → a human investigates the underlying node pressure.
 
 ## Components changed
 
-| Component | File | Change |
-|-----------|------|--------|
-| Descheduler policy | `kube-system/descheduler/app/configmap.yaml` | Add `RemovePodsHavingTooManyRestarts` (threshold 10, `states: [CrashLoopBackOff]`, init containers); enable under `plugins.deschedule`; schedule `*/30`→`*/15` |
+| Component | File(s) | Change |
+|-----------|---------|--------|
+| Healer app | new `kube-system/longhorn-mount-healer/app/{cronjob,rbac,configmap,kustomization}.yaml` | CronJob (`*/10`), ServiceAccount + ClusterRole/Binding, script ConfigMap, kustomization |
+| Flux wiring | `flux-system/flux-kustomizations/{longhorn-mount-healer-kustomization.yaml, kustomization.yaml}` | New Flux Kustomization CR + add to the resources index. **No HelmRepository** — it is not a chart, so the second (repositories) index does not apply |
 | Longhorn settings | `longhorn-system/longhorn/app/configmap.yaml` | Set `default-data-locality: best-effort` (new/recreated volumes only) |
 | StorageClass(es) | `clusterwide/storageclass-longhorn*.yaml` | Add/confirm `dataLocality: best-effort` parameter where appropriate |
-| Alerting | new `PrometheusRule` (monitoring) + scrape wiring if needed | Alert on `descheduler_pods_evicted`; ensure descheduler metrics are scraped |
+| Alerting | new `PrometheusRule` (monitoring) | Alert on `kube_pod_container_status_restarts_total` |
+
+## PR scoping
+
+Layer 1 (the cure) is its own concern and stands alone. Per the one-concern-per-PR rule, the proposed
+split is:
+
+1. **PR 1 — Layer 1 healer** (primary; lands the cure).
+2. **PR 2 — Layers 2 + 3** (frequency nudge + symptom alert), as a follow-up.
+
+(If review prefers a single PR for all three, that is acceptable — they are one coherent resiliency
+concern — but the default is to land the cure first.)
 
 ## Verification
 
-After Flux reconciles:
-- Descheduler runs on the 15-min schedule; `kubectl get cronjob descheduler -n kube-system` shows
-  the new schedule and recent successful jobs.
-- Inspect a descheduler job log to confirm the `RemovePodsHavingTooManyRestarts` plugin loaded and
-  that, in steady state with no stuck pods, it evicts nothing.
-- Confirm no autogen/eviction of healthy or system-critical pods (descheduler logs list every
-  eviction with a reason).
-- `default-data-locality` reads `best-effort` in Longhorn settings; existing volumes are
-  **unchanged** (no rebuilds kicked off).
-- New `PrometheusRule` is loaded (`kubectl get prometheusrule -n monitoring`); the
-  `descheduler_pods_evicted` metric resolves in Prometheus.
+After Flux reconciles **PR 1**:
 
-**End-to-end (optional, controlled):** intentionally induce a crashloop on a throwaway pod past the
-threshold and confirm the descheduler evicts it within ~15 min and it reschedules clean. Not
-required for merge; Flux reconciliation verification is async.
+- `kubectl get cronjob longhorn-mount-healer -n kube-system` shows the `*/10` schedule and recent
+  successful jobs.
+- A healer job log in steady state (no stuck pods) reports "no stuck workloads" and scales nothing.
+- RBAC: the ServiceAccount can `get` Longhorn volumes and `patch` deployment scale
+  (`kubectl auth can-i --as=system:serviceaccount:kube-system:longhorn-mount-healer ...`).
+- **End-to-end (controlled):** induce a stale-mount-like crashloop on a throwaway allowlisted
+  Deployment (or replay against radarr in a maintenance window), confirm the healer scales it to 0,
+  waits for `detached`, scales it back, and emits `HealedStaleMount`. Confirm the crash-safe-restore
+  path by killing a healer job mid-run and verifying the next tick restores replicas.
+
+After **PR 2**:
+
+- `default-data-locality` reads `best-effort` in Longhorn settings; existing volumes are
+  **unchanged** (no rebuilds kicked off — confirm via Longhorn UI/volume list).
+- New `PrometheusRule` is loaded (`kubectl get prometheusrule -n monitoring`); the
+  `kube_pod_container_status_restarts_total` expression resolves in Prometheus/VictoriaMetrics.
 
 ## Rollout & rollback
 
-- Single PR, all four changes (they're one coherent concern: self-healing + its visibility +
-  the zero-risk frequency nudge). Kyverno CI runs the same policies as in-cluster.
-- Rollback is a config revert: removing the plugin / restoring `*/30` reverts Layer 1; the
-  `default-data-locality` change only affects future volumes so reverting it is also harmless.
-- No data risk at any point — eviction performs the same safe detach/reattach as the manual
+- Rollback of Layer 1 is deleting the app dir + its Flux Kustomization (the healer simply stops
+  running; nothing it changed persists beyond annotations, which are inert).
+- A healer mid-run at rollback time is covered by the crash-safe-restore invariant only while the
+  CronJob still exists — so rollback should confirm no Deployment is parked at 0 with the
+  `original-replicas` annotation before deleting the app.
+- Layer 2's `default-data-locality` change only affects future volumes, so reverting it is harmless.
+- No data risk at any point — the healer performs the same safe detach/reattach as the manual
   recovery, and Layer 2 never touches existing volumes.
 
 ## Open questions / to confirm during implementation
 
-1. Exact descheduler metric name and whether its CronJob pods are already a Prometheus scrape
-   target (Layer 3 depends on this).
-2. Whether `default-data-locality` belongs at the global Longhorn setting, the StorageClass
-   parameter, or both — confirm against current `longhorn` configmap and StorageClass definitions.
-3. Whether to keep Layer 2 in this PR or split it out — reviewer's call; Layer 1 stands alone.
+1. **Pod → Deployment resolution** for the wedged-`ContainerCreating` case: a pod stuck pre-start
+   still has ownerReferences (ReplicaSet → Deployment), so resolution holds; confirm against a live
+   wedged pod.
+2. **jq availability** in `alpine/kubectl:1.33.4` — if absent, either `apk add jq` in-script or rely
+   on `kubectl -o jsonpath`/`-o go-template` only.
+3. **StatefulSet coverage** — none of the motivating apps are StatefulSets, but Longhorn-backed
+   StatefulSets exist elsewhere (e.g. CNPG). Out of scope for v1; revisit if a StatefulSet ever
+   exhibits the same stale-mount pattern.
+4. **Whether `default-data-locality` belongs at the global Longhorn setting, the StorageClass
+   parameter, or both** — confirm against the current `longhorn` configmap and StorageClass
+   definitions when building PR 2.

--- a/docs/superpowers/specs/storage-crashloop-resiliency-design.md
+++ b/docs/superpowers/specs/storage-crashloop-resiliency-design.md
@@ -1,0 +1,174 @@
+# Storage-Induced Crashloop Resiliency — Design
+
+**Status:** Draft for review
+**Created:** 2026-06-20
+**Author:** Scott Vollmin (with Claude)
+**Related incident:** Longhorn stale-mount EIO recurrence 2026-06-20 (radarr w03, sonarr w04 crashlooping 2+ days; grafana datasource landmine detonated by the same w04 blip)
+
+## Problem
+
+A Longhorn replica blip — usually triggered by node memory/IO pressure on a worker — can flip a
+pod's in-pod ext4 mount into an EIO (errored, read-only) state while Longhorn still reports the
+volume healthy and attached. The data layer is fine; only the in-pod mount is stale.
+
+The app reacts by crashing: radarr exits 134 on `I/O error: /config/config.xml`, sonarr segfaults
+exit 139 on the SQLite load. Kubernetes restarts the container in place, it hits the same stale
+mount, and crashes again — **CrashLoopBackOff**.
+
+**The trap that makes this self-perpetuating:** a CrashLoopBackOff pod never triggers a Longhorn
+volume detach. The pod stays scheduled on the same node, the volume stays attached, the stale mount
+is never cleared. The only thing that clears it is a full detach/reattach cycle — which requires the
+pod object to be *deleted and rescheduled* (`scale 0 → wait detached → scale 1`, or an eviction).
+Kubernetes' built-in restart loop deletes the *container*, never the *pod*, so it can never escape.
+
+On 2026-06-20 this left radarr and sonarr crashlooping for **2+ days** (36–38 restarts each) until a
+human ran the manual scale-0→1 recovery. That manual step is the gap this design closes.
+
+This is **not** a node-specific problem and the fix must not be node-specific. Node memory pressure
+is *a* trigger, but the resiliency requirement is that the cluster heals itself from a stuck pod
+**regardless of which app, which node, or what triggered the stale mount**. The cure must be
+app-agnostic and node-agnostic.
+
+## Goal
+
+Make the cluster self-heal from storage-induced crashloops with no human intervention, and make that
+self-healing observable. Concretely:
+
+1. **Resiliency (primary):** any pod stuck in CrashLoopBackOff past a threshold is automatically
+   evicted, which forces the Longhorn detach/reattach that clears the stale mount. This is the cure
+   and it heals *every* variant of the problem — every app, every node, every trigger.
+2. **Visibility:** when the self-healing fires, an alert tells us it happened, so a recurring
+   storage problem can't hide behind a system that silently papers over it.
+
+Frequency reduction (making the stale mount happen less often) is explicitly **secondary** and kept
+to a zero-risk declarative nudge — see Layer 2. The node RAM rework tracked separately
+(`project_worker02_memory_pressure`) remains the real frequency fix and is out of scope here.
+
+## Non-goals
+
+- Fixing the node memory/IO pressure that triggers the blips (separate RAM-rework effort).
+- Patching `dataLocality` on existing volumes (triggers background replica rebuilds; deferred to a
+  controlled operational step, not part of this change).
+- Any app-specific or node-specific remediation.
+
+## Approach
+
+Reuse the **descheduler** already deployed in `kube-system` (CronJob, chart 0.36.0 /
+descheduler v0.33). It already runs every 30 minutes with a `DefaultEvictor` + `LowNodeUtilization`
+balance profile. We add one deschedule plugin — `RemovePodsHavingTooManyRestarts` — that evicts
+pods stuck restarting. Eviction deletes the pod object, which is exactly the trigger Longhorn needs
+to detach and reattach the volume on reschedule, clearing the stale mount.
+
+This was chosen over a custom controller or per-app liveness-probe hacks because the mechanism
+already exists, is maintained upstream, is app/node-agnostic by construction, and needs only a
+configmap change.
+
+### Layer 1 — Self-healing eviction (the cure) — PRIMARY
+
+Edit `clusters/vollminlab-cluster/kube-system/descheduler/app/configmap.yaml`:
+
+- Add a `RemovePodsHavingTooManyRestarts` plugin to the `default` profile:
+  - `podRestartThreshold: 10` — a pod that has restarted 10+ times is unambiguously stuck, not
+    transiently flapping. At ~5 min max CrashLoopBackOff backoff, 10 restarts ≈ under an hour of
+    crashing before the cluster heals it — versus the 2+ days it took by hand.
+  - `includingInitContainers: true` — count init-container restarts too.
+  - **`states: ["CrashLoopBackOff"]`** — only evict pods whose container is *currently* in
+    CrashLoopBackOff. This is the critical safety scope: without it the plugin evicts any pod whose
+    *cumulative* restart count exceeds the threshold, including a pod that crashed 11 times last week
+    and has run healthy since. Scoping to the live CrashLoopBackOff state means we only ever evict a
+    pod that is *right now* stuck. (Supported on descheduler v0.29+; this cluster is on v0.33.)
+- Enable it under `plugins.deschedule.enabled`.
+- Tighten the CronJob `schedule` from `*/30 * * * *` to `*/15 * * * *` so a stuck pod is healed
+  within ~15 minutes of crossing the threshold instead of up to 30.
+
+**Why eviction heals the mount:** the existing `DefaultEvictor` already has
+`nodeFit: true` and `podProtections.defaultDisabled: ["PodsWithLocalStorage"]`. `nodeFit` only
+evicts a pod that can be scheduled elsewhere; Longhorn RWO volumes can attach to any node, so this
+always passes. Eviction → pod deleted → Longhorn detaches the volume → pod reschedules → volume
+reattaches with a clean mount (fsck runs on attach). This is the same detach/reattach the manual
+`scale 0 → 1` recovery performs, done automatically.
+
+**Safety properties:**
+- `DefaultEvictor` protects DaemonSet pods, static/mirror pods, and pods with
+  `system-cluster-critical`/`system-node-critical` priority by default — so the descheduler can't
+  evict its way into a cluster outage.
+- `states: ["CrashLoopBackOff"]` means healthy pods are never touched, no matter their history.
+- Worst case for a *legitimately* crashlooping app (bad config, not a stale mount): the descheduler
+  evicts it, it reschedules, and it crashloops again — i.e. eviction is a no-op for non-storage
+  crashloops, not a harm. It neither fixes nor worsens a genuine application bug.
+
+### Layer 2 — Data-locality nudge (frequency reduction) — DECLARATIVE ONLY, zero churn
+
+Set Longhorn's `default-data-locality` to `best-effort` so **new and recreated** volumes keep a
+replica co-located with the pod that mounts them. A local replica means a remote-node blip is far
+less likely to be the replica the pod is actively reading, shrinking the most common trigger for the
+stale mount.
+
+**Scope is deliberately limited to declarative-only:**
+- Change the global default and/or the StorageClass `dataLocality` parameter so volumes created
+  going forward get a local replica.
+- **Do not** patch `dataLocality` on existing volumes in this change. That triggers background
+  replica rebuilds and must be gated behind a Longhorn capacity check (per `storage.md`). It's a
+  deferred operational step, not part of this PR.
+
+This layer is kept intentionally small so it never competes with or complicates Layer 1. If review
+prefers to drop Layer 2 entirely and rely solely on Layer 1's cure, that is acceptable — Layer 1
+heals the problem regardless of frequency.
+
+### Layer 3 — Visibility (so self-healing isn't silent)
+
+Add a `PrometheusRule` that alerts when the descheduler evicts pods, so automated healing surfaces a
+recurring storage problem instead of masking it.
+
+- Alert on the descheduler's evicted-pods metric (`descheduler_pods_evicted`) showing eviction
+  activity over a window — info/warning severity, routed like other cluster alerts.
+- Intent: "the cluster healed itself N times today" is a signal worth seeing. A spike means a node
+  or volume is misbehaving and the underlying trigger (node pressure) needs attention even though
+  users saw no outage.
+- Verify the descheduler CronJob's metrics are actually scraped by Prometheus; if the CronJob job
+  pods aren't currently a ServiceMonitor/scrape target, wire that up as part of this layer (else the
+  metric won't exist). Confirm metric name and exposure during implementation.
+
+## Components changed
+
+| Component | File | Change |
+|-----------|------|--------|
+| Descheduler policy | `kube-system/descheduler/app/configmap.yaml` | Add `RemovePodsHavingTooManyRestarts` (threshold 10, `states: [CrashLoopBackOff]`, init containers); enable under `plugins.deschedule`; schedule `*/30`→`*/15` |
+| Longhorn settings | `longhorn-system/longhorn/app/configmap.yaml` | Set `default-data-locality: best-effort` (new/recreated volumes only) |
+| StorageClass(es) | `clusterwide/storageclass-longhorn*.yaml` | Add/confirm `dataLocality: best-effort` parameter where appropriate |
+| Alerting | new `PrometheusRule` (monitoring) + scrape wiring if needed | Alert on `descheduler_pods_evicted`; ensure descheduler metrics are scraped |
+
+## Verification
+
+After Flux reconciles:
+- Descheduler runs on the 15-min schedule; `kubectl get cronjob descheduler -n kube-system` shows
+  the new schedule and recent successful jobs.
+- Inspect a descheduler job log to confirm the `RemovePodsHavingTooManyRestarts` plugin loaded and
+  that, in steady state with no stuck pods, it evicts nothing.
+- Confirm no autogen/eviction of healthy or system-critical pods (descheduler logs list every
+  eviction with a reason).
+- `default-data-locality` reads `best-effort` in Longhorn settings; existing volumes are
+  **unchanged** (no rebuilds kicked off).
+- New `PrometheusRule` is loaded (`kubectl get prometheusrule -n monitoring`); the
+  `descheduler_pods_evicted` metric resolves in Prometheus.
+
+**End-to-end (optional, controlled):** intentionally induce a crashloop on a throwaway pod past the
+threshold and confirm the descheduler evicts it within ~15 min and it reschedules clean. Not
+required for merge; Flux reconciliation verification is async.
+
+## Rollout & rollback
+
+- Single PR, all four changes (they're one coherent concern: self-healing + its visibility +
+  the zero-risk frequency nudge). Kyverno CI runs the same policies as in-cluster.
+- Rollback is a config revert: removing the plugin / restoring `*/30` reverts Layer 1; the
+  `default-data-locality` change only affects future volumes so reverting it is also harmless.
+- No data risk at any point — eviction performs the same safe detach/reattach as the manual
+  recovery, and Layer 2 never touches existing volumes.
+
+## Open questions / to confirm during implementation
+
+1. Exact descheduler metric name and whether its CronJob pods are already a Prometheus scrape
+   target (Layer 3 depends on this).
+2. Whether `default-data-locality` belongs at the global Longhorn setting, the StorageClass
+   parameter, or both — confirm against current `longhorn` configmap and StorageClass definitions.
+3. Whether to keep Layer 2 in this PR or split it out — reviewer's call; Layer 1 stands alone.


### PR DESCRIPTION
## What

Adds **Layer 1** of storage-crashloop self-healing: a `kube-system` CronJob (`*/10`) that codifies the proven manual runbook for Longhorn stale-mount EIO crashloops — `scale Deployment to 0 → poll the Longhorn Volume CR until state=detached → scale back to original replicas`.

## Why

When a Longhorn replica blips, a pod's in-pod ext4 mount can flip to read-only/EIO while Longhorn still reports the volume healthy + attached. A `CrashLoopBackOff` pod never triggers a volume detach, so the workload is stuck until someone runs the runbook by hand. This happened to radarr/sonarr and left them crashlooping for 2+ days. The healer detects the condition and performs the same recovery automatically.

## How it works

A pure-POSIX `sh` script (`heal.sh`, no `jq`/`apk` — hermetic and unit-tested) run by the CronJob with safety rails:

- **Namespace allowlist** (`mediastack monitoring harbor`, env-overridable) — never touches the whole cluster.
- **Crash-safe orphan-restore runs FIRST** every invocation: if a prior healer pod died mid-heal leaving a Deployment at 0 with an `original-replicas` annotation, it is restored before anything else.
- **One heal per run**, gated by a **per-Deployment 6h cooldown** (`last-healed` annotation).
- Only targets Deployments owning a crashlooping (restartCount > threshold) **or** mount-wedged pod that mounts a **Longhorn RWO** volume.
- Replicas are restored in **both** the detached and the timeout branch — a workload is never left at 0.
- `DRY_RUN` support; best-effort Event emission that never fails the run.

Least-privilege `ClusterRole` (cross-namespace) grants exactly the verbs the script calls. Wired into the `kube-system` aggregating Kustomization; the script ships as a stable-named ConfigMap (`configMapGenerator` + `disableNameSuffixHash`).

Layers 2 (Longhorn `default-data-locality: best-effort`) and 3 (PrometheusRule symptom alert) follow in a separate PR.

## Tests

`heal_test.sh` — 21 POSIX-sh unit assertions (pure helpers, detection, `wait_detached`, one-per-run, cooldown suppression, and crash-safe orphan-restore). All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeJTNxa3qhvqjrCdJY9cP5