### PR TITLE
feat(monitoring): add StorageHealerNotCoping alert (storage resiliency Layer 3)

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -174,7 +174,16 @@ spec:
             severity: critical
           annotations:
             summary: "Self-healer not coping: {{ $labels.namespace }}/{{ $labels.pod }} still crash-looping"
-            description: "Container {{ $labels.container }} in {{ $labels.namespace }}/{{ $labels.pod }} has restarted {{ $value | printf \"%.0f\" }} times in the last hour and is still crash-looping past the longhorn-mount-healer window. The automated scale-0 -> wait-detached -> scale-up cure has not resolved it. Check `kubectl get events -n {{ $labels.namespace }} --field-selector reason=HealedStaleMountTimeout` (the healer emits this in the affected namespace) and the healer CronJob logs (`kubectl logs -n kube-system -l app=longhorn-mount-healer --tail=100`); if it is a stale Longhorn mount, run the manual runbook (scale the Deployment to 0, wait for the Longhorn volume to report detached, scale it back up)."
+            description: >-
+              Container {{ $labels.container }} in {{ $labels.namespace }}/{{ $labels.pod }}
+              has restarted {{ $value | printf "%.0f" }} times in the last hour and is still
+              crash-looping past the longhorn-mount-healer window. The automated scale-0 ->
+              wait-detached -> scale-up cure has not resolved it. Check
+              `kubectl get events -n {{ $labels.namespace }} --field-selector reason=HealedStaleMountTimeout`
+              (the healer emits this in the affected namespace) and the healer CronJob logs
+              (`kubectl logs -n kube-system -l app=longhorn-mount-healer --tail=100`); if it
+              is a stale Longhorn mount, run the manual runbook (scale the Deployment to 0,
+              wait for the Longhorn volume to report detached, scale it back up).
 
         - alert: PodNotReady
           expr: |

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -158,6 +158,24 @@ spec:
             summary: "Pod {{ $labels.namespace }}/{{ $labels.pod }} is crash-looping"
             description: "Container {{ $labels.container }} in {{ $labels.namespace }}/{{ $labels.pod }} has restarted {{ $value | printf \"%.0f\" }} times in the last 30 minutes."
 
+        # Escalated sibling of PodCrashLooping, scoped to the namespaces the longhorn-mount-healer
+        # CronJob (kube-system) covers. The healer runs */10 and clears a stale Longhorn mount via
+        # scale-0 -> wait-detached -> scale-up within ~10-20m; a fresh pod after a heal resets this
+        # counter. A crashloop still accruing restarts an hour later means the automated cure did
+        # not take -- a detach timeout (HealedStaleMountTimeout) or the healer's 6h per-workload
+        # cooldown suppressing what is actually an application bug. Either way a human is needed.
+        # NOTE: keep this namespace regex in sync with the healer's HEAL_NAMESPACES allowlist
+        # (clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh).
+        - alert: StorageHealerNotCoping
+          expr: |
+            increase(kube_pod_container_status_restarts_total{namespace=~"mediastack|monitoring|harbor"}[1h]) > 6
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: "Self-healer not coping: {{ $labels.namespace }}/{{ $labels.pod }} still crash-looping"
+            description: "Container {{ $labels.container }} in {{ $labels.namespace }}/{{ $labels.pod }} has restarted {{ $value | printf \"%.0f\" }} times in the last hour and is still crash-looping past the longhorn-mount-healer window. The automated scale-0 -> wait-detached -> scale-up cure has not resolved it. Check `kubectl get events -n {{ $labels.namespace }} --field-selector reason=HealedStaleMountTimeout` (the healer emits this in the affected namespace) and the healer CronJob logs (`kubectl logs -n kube-system -l app=longhorn-mount-healer --tail=100`); if it is a stale Longhorn mount, run the manual runbook (scale the Deployment to 0, wait for the Longhorn volume to report detached, scale it back up)."
+
         - alert: PodNotReady
           expr: |
             (

--- a/docs/superpowers/specs/storage-crashloop-resiliency-design.md
+++ b/docs/superpowers/specs/storage-crashloop-resiliency-design.md
@@ -197,11 +197,39 @@ kube-state-metrics series — no dependency on the descheduler's unscrapeable Cr
 Layer 1 (the cure) is its own concern and stands alone. Per the one-concern-per-PR rule, the proposed
 split is:
 
-1. **PR 1 — Layer 1 healer** (primary; lands the cure).
+1. **PR 1 — Layer 1 healer** (primary; lands the cure). **MERGED** as PR #916 (commit f9dc891).
 2. **PR 2 — Layers 2 + 3** (frequency nudge + symptom alert), as a follow-up.
 
 (If review prefers a single PR for all three, that is acceptable — they are one coherent resiliency
 concern — but the default is to land the cure first.)
+
+### PR 2 as-built (de-scoped after investigation)
+
+Investigation while building PR 2 found most of the originally-specified scope was **already
+satisfied**, so PR 2 collapsed to a single new alert:
+
+- **Layer 2 — SKIPPED, already in place.** The two explicit StorageClasses that the design would
+  have touched — `clusterwide/storageclass-longhorn-r2.yaml` and `storageclass-longhorn-dmz.yaml` —
+  **already set `dataLocality: best-effort`**. The chart-generated default `longhorn` StorageClass
+  explicitly sets `dataLocality: disabled` (Helm chart default), which *overrides* the global
+  `default-data-locality` setting for any volume created from it — so flipping the global setting
+  would be inert for the default-SC apps, and StorageClass `parameters` are immutable (would require
+  SC recreation). The zero-risk declarative nudge therefore offered no incremental benefit worth the
+  churn; deferred entirely to the tracked node-RAM rework (`project_worker02_memory_pressure`), which
+  is the real frequency fix. (Resolves open question #4: best-effort lives at the StorageClass
+  parameter; the global setting is inert behind explicit per-SC values.)
+- **Layer 3 — REFINED to one alert, `StorageHealerNotCoping`.** The generic symptom alert the design
+  described (`kube_pod_container_status_restarts_total` rising → warning) **already exists** as
+  `PodCrashLooping` in `prometheusrule-custom.yaml`, and healer-CronJob death is already covered by
+  `CronJobNotSucceededRecently` (`prometheusrule-gitops.yaml`). The only non-duplicative, additive
+  signal is the design's "if the alert keeps firing despite the healer running, the healer isn't
+  coping" case. PR 2 adds exactly that as `StorageHealerNotCoping` (added to the existing
+  `pod-health` group in `prometheusrule-custom.yaml`): `critical`, scoped to the healer's
+  `HEAL_NAMESPACES` allowlist (`mediastack|monitoring|harbor`), firing when a pod there is still
+  crash-looping an hour later (`increase(...[1h]) > 6` `for: 1h`). A successful heal recreates the
+  pod with a new name, resetting the per-pod counter series, so the alert only fires when the
+  automated cure failed (detach timeout) or the 6h per-workload cooldown is masking a genuine
+  application bug. No Flux wiring change — the alert lands in an already-indexed file.
 
 ## Verification
 


### PR DESCRIPTION
## Summary

Adds **Layer 3** of the storage-crashloop resiliency design — a single escalation alert, `StorageHealerNotCoping` — and records the PR-2 de-scope decided after investigation. Layer 1 (the `longhorn-mount-healer` CronJob, the cure) shipped in #916.

## What this does

`StorageHealerNotCoping` (`critical`) fires when a pod in the healer's namespaces (`mediastack|monitoring|harbor`) is **still** accruing container restarts an hour after a crashloop began — i.e. the automated `scale-0 → wait-detached → scale-up` cure did not resolve it and a human is needed.

```promql
increase(kube_pod_container_status_restarts_total{namespace=~"mediastack|monitoring|harbor"}[1h]) > 6
```
`for: 1h`, `severity: critical`.

A **successful** heal recreates the pod under a new name, which resets `kube_pod_container_status_restarts_total` — so this alert only fires when the cure *failed* (detach timeout / `HealedStaleMountTimeout`, or the healer's 6h per-workload cooldown masking a genuine application bug). It is an escalated sibling of the existing `PodCrashLooping` (`warning`), matching the established warning→critical pattern already used in this file.

## De-scope recorded in the design spec

- **Layer 2 (global `default-data-locality` nudge) — skipped.** The explicit StorageClasses (`longhorn-r2`, `longhorn-dmz`) already set `dataLocality: best-effort`, and the chart-default `longhorn` SC sets `dataLocality: disabled`, which overrides the global setting for default-SC volumes. SC parameters are immutable, so the global nudge would be inert.
- **Layer 3 — narrowed** to this one non-duplicative alert. Generic crashloop symptoms are already covered by `PodCrashLooping`; silent CronJob death by `CronJobNotSucceededRecently`. The only additive signal is "the healer is not coping."

## Notes

- The alert lands in an already-indexed PrometheusRule file (`prometheusrule-custom.yaml`) — **no Flux wiring change**.
- `promtool check rules` passes (21 rules).
- The alert's namespace regex is kept in sync with the healer's `HEAL_NAMESPACES` allowlist (a `NOTE:` comment in the rule flags this coupling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeJTNxa3qhvqjrCdJY9cP5
