### PR TITLE
fix(velero): trim daily-full local TTL 168h→ 96h + add wedged-backup escalation alert

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -100,6 +100,22 @@ spec:
             summary: "Velero daily-full backup partially failed"
             description: "A daily-full backup has PartiallyFailed in the last 26 hours. Check velero backup describe."
 
+        # Escalation guard. VeleroBackupNotAttempted/PartiallyFailed are warnings that can be
+        # tolerated for days — on 2026-07-02 a wedged InProgress backup left daily-full
+        # PartiallyFailed for 4 days, silently pinning kopia blocks (maintenance can't GC an
+        # in-use snapshot) until MinIO hit 100%. This fires critical when NO fully-successful
+        # daily-full has completed in 72h, forcing action before a stuck/degraded backup fills
+        # the volume. Reuses the restart-immune velero_backup_last_successful_timestamp gauge.
+        - alert: VeleroBackupPersistentlyFailing
+          expr: |
+            time() - velero_backup_last_successful_timestamp{schedule="velero-daily-full"} > 72 * 3600
+          for: 30m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Velero daily-full has had no successful backup in 72 hours"
+            description: "Last fully-successful daily-full backup was {{ $value | humanizeDuration }} ago — a backup may be wedged InProgress or repeatedly PartiallyFailed. A stuck backup blocks kopia GC and will fill MinIO. Check 'velero backup get' and repo maintenance."
+
         - alert: KubeJobFailed
           expr: |
             (kube_job_failed{namespace!="velero"} > 0)

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -114,7 +114,11 @@ spec:
             severity: critical
           annotations:
             summary: "Velero daily-full has had no successful backup in 72 hours"
-            description: "Last fully-successful daily-full backup was {{ $value | humanizeDuration }} ago — a backup may be wedged InProgress or repeatedly PartiallyFailed. A stuck backup blocks kopia GC and will fill MinIO. Check 'velero backup get' and repo maintenance."
+            description: >-
+              Last fully-successful daily-full backup was {{ $value | humanizeDuration }}
+              ago — a backup may be wedged InProgress or repeatedly PartiallyFailed. A
+              stuck backup blocks kopia GC and will fill MinIO. Check 'velero backup get'
+              and repo maintenance.
 
         - alert: KubeJobFailed
           expr: |

--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -146,7 +146,12 @@ data:
         schedule: "0 3 * * *"
         useOwnerReferencesInBackup: false
         template:
-          ttl: 168h
+          # Local MinIO copy is a fast-restore CACHE, not the retention tier: the same
+          # data lands in B2 daily (daily-b2, 90d) and monthly (monthly-b2, 365d), only
+          # ~1h behind. 96h (4 days) covers a long-weekend "noticed it Monday" restore at
+          # LAN speed while keeping steady-state headroom on the 100Gi MinIO volume.
+          # Anything older is rare and served from B2. (Was 168h; trimmed 2026-07-02.)
+          ttl: 96h
           storageLocation: minio
           defaultVolumesToFsBackup: true
           excludedNamespaces:


### PR DESCRIPTION
## Incident

On 2026-07-02 a wedged `abs-fsck-verify-20260702` backup sat `InProgress` for ~4 days, leaving daily-full `PartiallyFailed`. Because kopia full maintenance cannot GC blocks belonging to an in-use snapshot, ~27.5GB of orphaned content blocks accumulated in the `mediastack` kopia repo and drove the MinIO backup volume to ~100% full, firing `KubePersistentVolumeFillingUp`.

Space was reclaimed operationally by forcing a full kopia maintenance run (8744 unused contents / 27.5GB deleted; MinIO 98% → 72%). This PR addresses the **recurrence**, not the one-time cleanup.

## Changes

**1. Trim daily-full local TTL 168h → 96h** (`velero/velero/app/configmap.yaml`)

The local MinIO copy is a fast-restore *cache*, not the retention tier — the same data lands in B2 daily (90d) and monthly (365d), only ~1h behind. 96h (4 days) still covers a "noticed it Monday" long-weekend restore at LAN speed while keeping steady-state headroom on the 100Gi MinIO volume. Anything older is rare and served from B2.

**2. Add `VeleroBackupPersistentlyFailing` critical alert** (`monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml`)

`VeleroBackupNotAttempted`/`PartiallyFailed` are warnings that can be tolerated for days — which is exactly how a wedged backup silently pinned kopia blocks until the volume filled. This new rule fires **critical** when no fully-successful daily-full has completed in 72h, forcing action before a stuck/degraded backup fills the volume. Reuses the restart-immune `velero_backup_last_successful_timestamp` gauge.

## Root cause / prevention

The real recurrence guard is (a) ensuring full maintenance can actually run (not blocked by a wedged snapshot) and (b) surfacing a persistently-failing backup loudly before it fills storage. The TTL cut is secondary headroom; the escalation alert is the durable fix.
