### PR TITLE
feat(monitoring): extend wedged-backup escalation to daily-b2 schedule

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -120,6 +120,26 @@ spec:
               stuck backup blocks kopia GC and will fill MinIO. Check 'velero backup get'
               and repo maintenance.
 
+        # Same escalation guard for the off-site daily-b2 schedule. daily-b2 shares the
+        # same failure surface (a wedged/PartiallyFailed backup pins kopia blocks the B2
+        # repo's full maintenance can't GC) — it just fills Backblaze instead of MinIO,
+        # and leaves the retention tier stale. daily-b2 has its own 72h guard because a
+        # per-schedule threshold is required: monthly-b2 legitimately runs monthly, so it
+        # can't share this alert (its last-success age exceeds 72h by design).
+        - alert: VeleroB2BackupPersistentlyFailing
+          expr: |
+            time() - velero_backup_last_successful_timestamp{schedule="velero-daily-b2"} > 72 * 3600
+          for: 30m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Velero daily-b2 has had no successful backup in 72 hours"
+            description: >-
+              Last fully-successful daily-b2 (off-site Backblaze) backup was
+              {{ $value | humanizeDuration }} ago — a backup may be wedged InProgress or
+              repeatedly PartiallyFailed, pinning kopia blocks in B2 and leaving the
+              off-site retention tier stale. Check 'velero backup get' and repo maintenance.
+
         - alert: KubeJobFailed
           expr: |
             (kube_job_failed{namespace!="velero"} > 0)


### PR DESCRIPTION
## What

Adds `VeleroB2BackupPersistentlyFailing` — a per-schedule critical escalation alert for the off-site `daily-b2` (Backblaze) schedule, mirroring the `VeleroBackupPersistentlyFailing` alert added for `daily-full` in #918.

## Why

#918 closed the detection gap for `daily-full` → MinIO: a wedged/repeatedly-`PartiallyFailed` backup pins kopia content blocks that full maintenance can't GC, silently filling the store while `velero_backup_last_successful_timestamp` stays stuck (verified empirically — `PartiallyFailed` does **not** advance the gauge).

`daily-b2` shares the exact same failure surface — it just fills Backblaze instead of MinIO and leaves the **off-site retention tier** stale. It had no equivalent guard. This PR closes that gap.

## Details

- `expr`: `time() - velero_backup_last_successful_timestamp{schedule="velero-daily-b2"} > 72 * 3600`, `for: 30m`, `severity: critical`.
- A **per-schedule** threshold is required: `monthly-b2` legitimately runs monthly, so its last-success age exceeds 72h by design and cannot share this alert. Hence a dedicated `daily-b2` rule.

## Validation

- `awk` — no line exceeds the 200-char yamllint CI limit.
- `promtool check rules` — SUCCESS, 23 rules across 8 groups (was 22).

Related: #918