### PR TITLE
fix(harbor): migrate MetalLB annotation to metallb.io domain

### DIFF
--- a/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
@@ -27,7 +27,7 @@ data:
           httpPort: 80
           httpsPort: 443
         annotations:
-          metallb.universe.tf/loadBalancerIPs: "192.168.152.245"
+          metallb.io/loadBalancerIPs: "192.168.152.245"
           external-dns.alpha.kubernetes.io/hostname: harbor.vollminlab.com
         sourceRanges: []
 


### PR DESCRIPTION
## What

Switch the harbor LoadBalancer service annotation from the deprecated
`metallb.universe.tf/loadBalancerIPs` to `metallb.io/loadBalancerIPs`.

## Why

MetalLB **v0.16.1** (running in-cluster) renamed its annotation domain from
`metallb.universe.tf/` to `metallb.io/`. The controller logs a
`deprecatedAnnotation` warning for harbor's service, which Headlamp surfaces
as an event:

```
event=deprecatedAnnotation
annotation=metallb.universe.tf/...
msg="The used annotation is deprecated. Support might get removed in future versions"
```

Proof the new domain is active: MetalLB itself already writes
`metallb.io/ip-allocated-from-pool` on the harbor and ingress-nginx services.

## Scope

- **harbor** — the only MetalLB annotation set from git (`configmap.yaml:30`). Fixed here.
- **ingress-nginx** — its deprecated `metallb.universe.tf/ip-allocated-from-pool` is **not in git** (stale leftover from a 2025-01-20 `kubectl apply`, superseded by the `metallb.io/` annotation MetalLB now sets). Handled as a live-cluster cleanup, out of scope for this PR.

## Risk

None expected. Same requested VIP (`192.168.152.245`); v0.16.1 honors the
`metallb.io/` domain so the IP allocation is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)