### PR TITLE
feat(monitoring): VictoriaMetrics cold tier (395d, off-Longhorn on pool_0)

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -17,7 +17,17 @@ data:
         scrapeInterval: 30s
         retention: 24h
         remoteWrite:
+          # #1 hot tier (30d, SSD) — the default Grafana datasource.
           - url: http://victoria-metrics-single-server.monitoring.svc.cluster.local:8428/api/v1/write
+          # #2 cold tier (395d, pool_0 spinning disk). Its own queue isolates the
+          # slow endpoint: if pool_0 falls behind, only the LT shard queue backs up
+          # — the hot write and scraping are unaffected.
+          - url: http://victoria-metrics-lt-server.monitoring.svc.cluster.local:8428/api/v1/write
+            name: vm-lt
+            queueConfig:
+              capacity: 10000
+              maxShards: 10
+              maxSamplesPerSend: 2000
         serviceMonitorSelectorNilUsesHelmValues: false
         serviceMonitorSelector: {}
         serviceMonitorNamespaceSelector: {}
@@ -106,6 +116,14 @@ data:
           uid: prometheus-live
           access: proxy
           url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+          isDefault: false
+          jsonData:
+            timeInterval: 30s
+        - name: VictoriaMetrics (long-term)
+          type: prometheus
+          uid: victoriametrics-lt
+          access: proxy
+          url: http://victoria-metrics-lt-server.monitoring.svc.cluster.local:8428
           isDefault: false
           jsonData:
             timeInterval: 30s

--- a/clusters/vollminlab-cluster/monitoring/kustomization.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   - loki/app
   - promtail/app
   - victoria-metrics/app
+  - victoria-metrics-lt/app

--- a/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/configmap.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: victoria-metrics-lt-values
+  namespace: monitoring
+  labels:
+    app: victoria-metrics-lt
+    env: production
+    category: observability
+data:
+  values.yaml: |
+    # Cold tier: a SECOND victoria-metrics-single, ~13 months retention, on cheap
+    # pool_0 spinning disk (local PV) — everything older than the hot tier's 30d
+    # lives here, off Longhorn. Prometheus remoteWrite fans out to both instances.
+    # Distinct service -> victoria-metrics-lt-server.monitoring.svc:8428
+    fullnameOverride: victoria-metrics-lt
+
+    server:
+      # 395d = 13 months. At the measured ~1.63 GB/day this is ~645GB on-disk;
+      # the 750Gi PV below has headroom.
+      retentionPeriod: 395d
+
+      # statefulSet: the RWO local PV is bound via a volumeClaimTemplate, avoiding
+      # the rolling-update detach trap (same reason as the hot tier).
+      mode: statefulSet
+
+      persistentVolume:
+        enabled: true
+        # Binds the pre-created static local PV (storageclass.yaml + pv.yaml).
+        storageClassName: local-vm-lt
+        accessModes:
+          - ReadWriteOnce
+        size: 750Gi
+
+      # LOAD-BEARING label: this MUST be victoria-metrics-lt, NOT victoria-metrics.
+      # The velero victoria-metrics-b2 schedule selects app=victoria-metrics; a
+      # matching label would sweep this 750Gi cold volume into a daily B2 backup —
+      # the opposite of intent. Backup here is TrueNAS ZFS snapshots of the pool_0
+      # dataset, not Velero.
+      podLabels:
+        app: victoria-metrics-lt
+        env: production
+        category: observability
+
+      resources:
+        requests:
+          cpu: 100m
+          # Higher floor than the hot tier: year-range queries touch far more
+          # blocks. Tune after observing real usage.
+          memory: 512Mi
+        limits:
+          cpu: "1"
+          memory: 2Gi
+
+      # Scrape VM's own /metrics so cold-tier health (ingestion rate, disk growth,
+      # uptime) is visible in Grafana. Prometheus scrapes all ServiceMonitors.
+      serviceMonitor:
+        enabled: true
+        extraLabels:
+          app: victoria-metrics-lt
+          env: production
+          category: observability

--- a/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/helmrelease.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: victoria-metrics-lt
+  namespace: monitoring
+  labels:
+    app: victoria-metrics-lt
+    env: production
+    category: observability
+spec:
+  interval: 5m
+  releaseName: victoria-metrics-lt
+  chart:
+    spec:
+      chart: victoria-metrics-single
+      version: 0.39.0
+      sourceRef:
+        kind: HelmRepository
+        name: victoria-metrics-repo
+        namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: victoria-metrics-lt-values
+      valuesKey: values.yaml

--- a/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - storageclass.yaml
+  - pv.yaml
+  - configmap.yaml
+  - helmrelease.yaml

--- a/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/pv.yaml
+++ b/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/pv.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: victoria-metrics-lt-data
+  labels:
+    app: victoria-metrics-lt
+    env: production
+    category: observability
+spec:
+  capacity:
+    storage: 750Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  # Retain: never auto-wipe a year of history if the PVC/STS is deleted.
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-vm-lt
+  local:
+    # ext4 mount of the pool_0-VMDK on the pinned node (Phase 0, step 0.7).
+    # PV `local` type is NOT a pod hostPath volume — the "no hostPath" Kyverno
+    # policy targets Pod specs, not PersistentVolumes, so this passes.
+    path: /mnt/vm-lt
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            # Pins the cold-tier pod to the node holding the VMDK mount.
+            # Default k8sworker01; change here if the VMware step landed the
+            # NFS datastore on a different ESXi host / worker.
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - k8sworker01

--- a/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/storageclass.yaml
+++ b/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/storageclass.yaml
@@ -1,0 +1,16 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-vm-lt
+  labels:
+    app: victoria-metrics-lt
+    env: production
+    category: observability
+# Static local storage for the cold-tier VictoriaMetrics volume. The backing
+# disk is a 750Gi VMDK on a pool_0 (spinning-disk) NFS datastore, mounted ext4
+# on one worker (see docs/superpowers/plans/victoriametrics-cold-tier.md, Phase 0).
+# no-provisioner + WaitForFirstConsumer: the PV is pre-created by hand (pv.yaml);
+# binding is deferred until the pod schedules on the node the PV is pinned to.
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Retain

--- a/docs/superpowers/plans/victoriametrics-cold-tier.md
+++ b/docs/superpowers/plans/victoriametrics-cold-tier.md
@@ -1,0 +1,235 @@
+# VictoriaMetrics Cold Tier (Off-Longhorn Long-Term Metrics) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a **second** single-node VictoriaMetrics (`victoria-metrics-lt`, ~395d/13-month retention) whose PVC lives on a **static `local` PV backed by a pool_0 VMDK** (TrueNAS spinning disk, off Longhorn). Prometheus fans out `remote_write` to both the existing hot tier (30d, SSD) and this cold tier, so all metrics older than 30 days live *only* on cheap bulk disk. Purely additive — the hot path is untouched.
+
+**Architecture:** `Prometheus (24h local) → remoteWrite fan-out → { victoria-metrics (hot, 30d, longhorn-r2) , victoria-metrics-lt (cold, 395d, local PV on pool_0) }`. Grafana gets a 3rd datasource (`uid: victoriametrics-lt`) for history panels; hot dashboards keep the default. Backup = TrueNAS ZFS snapshots of the pool_0 dataset (NOT Velero).
+
+**Tech Stack:** Flux CD, Helm (`victoria-metrics-single` chart v0.39.0 — same chart & HelmRepository as the hot tier), kube-prometheus-stack, Grafana, VMware/ESXi, TrueNAS (pool_0).
+
+**Spec:** `docs/superpowers/specs/victoriametrics-cold-tier-design.md`
+
+**Repo conventions:** GitOps repo, **no unit-test runner**. "Validation" = manifest renders (`kubectl kustomize <dir>`) + passes `.claude/rules/flux.md` / `kyverno.md` / `networkpolicy.md`; correctness confirmed async via Flux reconciliation after merge. Never `kubectl apply` under `clusters/`. Never push to `main` — PR only. One branch: `feat/victoria-metrics-cold-tier`.
+
+**Wiring note (simpler than the hot tier was):** reuses the existing `victoria-metrics-repo` HelmRepository (no new source) and the `monitoring` Flux Kustomization already globs app dirs — so **neither `flux-system` index file changes**. Only `monitoring/kustomization.yaml` gets one new line.
+
+---
+
+## Phase 0 — Manual VMware/TrueNAS prerequisite (out-of-band, NOT Flux)
+
+> Done by hand in TrueNAS + vCenter + on the node, **before** any Flux manifests. **No new VM** — you add a VMDK to the existing worker VM.
+
+**Transport: NFS (pool_0 dataset → NFS datastore).** Chosen over iSCSI because the decided backup is ZFS snapshots — with NFS the VMDK is a plain file *inside* the snapshot (trivially browsable/restorable), vs. iSCSI+VMFS burying it under an opaque block device. Also simpler (no target/extent/IQN), native thin, easy grow. iSCSI's only edge is sync-write latency, which is irrelevant to a non-latency-critical cold tier. Full rationale in the spec's decisions table.
+
+- [ ] **Step 0.1: Decide the node.** Default **k8sworker01** (only non-DMZ, non-CP worker with no stability history; w03/w04's only strike was *Longhorn* EIO, irrelevant to a local PV). Final constraint = which ESXi host can reach pool_0 + host the VMDK. Whatever you pick, use it consistently in the PV `nodeAffinity` (Task 1) and record it here: `NODE = ______`.
+
+- [ ] **Step 0.2: TrueNAS — create a dataset on pool_0.** Create a **dataset** (e.g. `pool_0/vm-lt`) from free space — does not touch the media datasets. Record the dataset path.
+
+- [ ] **Step 0.3: TrueNAS — share the dataset via NFS.** Add an NFS share on the dataset, authorized to the ESXi host that runs `NODE` (maproot as appropriate for the ESXi host). Record the NFS export path + TrueNAS IP.
+
+- [ ] **Step 0.4: TrueNAS — snapshot task (this is the cold tier's ONLY backup).** Add a periodic snapshot task on the dataset: **weekly, retain 4–8**. The VMDK file sits inside the snapshot; restore = clone the dataset or copy the `.vmdk` back.
+
+- [ ] **Step 0.5: ESXi — mount the NFS datastore.** On the host running `NODE`: Storage → New Datastore → **NFS** → point at the TrueNAS IP + export path from 0.3 → name it (e.g. `ds-vm-lt`).
+
+- [ ] **Step 0.6: ESXi — add a VMDK to the existing worker VM.** Edit the `NODE` VM → Add Hard Disk → **750 GB** on `ds-vm-lt` → attach to a new SCSI controller position (note the controller/unit). Thin provisioning is fine — the VMDK grows into the dataset's shared pool free space. No reboot needed; the guest hot-adds it.
+
+- [ ] **Step 0.7: On the node — format + mount ext4.** SSH to `NODE`:
+  ```bash
+  lsblk                                   # identify the new empty disk, e.g. /dev/sdX
+  sudo mkfs.ext4 -L vm-lt /dev/sdX
+  sudo mkdir -p /mnt/vm-lt
+  # add to /etc/fstab by UUID so it survives reboot:
+  UUID=$(sudo blkid -s UUID -o value /dev/sdX)
+  echo "UUID=$UUID /mnt/vm-lt ext4 defaults,nofail 0 2" | sudo tee -a /etc/fstab
+  sudo mount /mnt/vm-lt && df -h /mnt/vm-lt
+  ```
+  Record the final **mount path** (`/mnt/vm-lt`) — it feeds the PV in Task 1.
+
+> **Multipath note:** because the transport is NFS at the ESXi layer (not guest-level iSCSI), there is **no** `multipathd`/Longhorn entanglement to worry about — the guest sees a plain VMDK block device, never an iSCSI LUN. This is a second reason NFS is the cleaner choice here.
+
+---
+
+## Phase 1 — Flux manifests (one PR)
+
+### Task 1: Static local StorageClass + PersistentVolume
+
+**Files:**
+- Create: `clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/storageclass.yaml`
+- Create: `clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/pv.yaml`
+
+- [ ] **Step 1: No-provisioner local StorageClass**
+  ```yaml
+  apiVersion: storage.k8s.io/v1
+  kind: StorageClass
+  metadata:
+    name: local-vm-lt
+    labels: { app: victoria-metrics-lt, env: production, category: observability }
+  provisioner: kubernetes.io/no-provisioner
+  volumeBindingMode: WaitForFirstConsumer
+  ```
+
+- [ ] **Step 2: Static `local` PV bound to the VMDK mount** — set `local.path` and `nodeAffinity` values to the `NODE` + mount path from Phase 0.
+  ```yaml
+  apiVersion: v1
+  kind: PersistentVolume
+  metadata:
+    name: victoria-metrics-lt-data
+    labels: { app: victoria-metrics-lt, env: production, category: observability }
+  spec:
+    capacity: { storage: 750Gi }
+    volumeMode: Filesystem
+    accessModes: [ReadWriteOnce]
+    persistentVolumeReclaimPolicy: Retain
+    storageClassName: local-vm-lt
+    local:
+      path: /mnt/vm-lt
+    nodeAffinity:
+      required:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values: [k8sworker01]     # <-- Phase 0 NODE
+  ```
+  > **Kyverno:** PV `local` type ≠ pod `hostPath`; the "no hostPath" policy targets Pod specs, so this passes. Confirmed by CI `kyverno-cli test`.
+
+- [ ] **Step 3: Validate render** — `kubectl kustomize` after Task 4 wires the dir (these two files render alone via `kubectl apply --dry-run=client -f`).
+
+### Task 2: `victoria-metrics-lt` HelmRelease + values
+
+**Files:**
+- Create: `clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/helmrelease.yaml`
+- Create: `clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/configmap.yaml`
+
+- [ ] **Step 1: HelmRelease** (mirror the hot tier's `victoria-metrics/app/helmrelease.yaml`, changing only names/labels; **same chart, same `victoria-metrics-repo` source**)
+  ```yaml
+  apiVersion: helm.toolkit.fluxcd.io/v2
+  kind: HelmRelease
+  metadata:
+    name: victoria-metrics-lt
+    namespace: monitoring
+    labels: { app: victoria-metrics-lt, env: production, category: observability }
+  spec:
+    interval: 5m
+    releaseName: victoria-metrics-lt
+    chart:
+      spec:
+        chart: victoria-metrics-single
+        version: 0.39.0
+        sourceRef: { kind: HelmRepository, name: victoria-metrics-repo, namespace: flux-system }
+    valuesFrom:
+      - kind: ConfigMap
+        name: victoria-metrics-lt-values
+        valuesKey: values.yaml
+  ```
+
+- [ ] **Step 2: Values ConfigMap** — note `retentionPeriod: 395d`, the distinct `fullnameOverride`, and `storageClassName: local-vm-lt`.
+  ```yaml
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: victoria-metrics-lt-values
+    namespace: monitoring
+    labels: { app: victoria-metrics-lt, env: production, category: observability }
+  data:
+    values.yaml: |
+      fullnameOverride: victoria-metrics-lt        # -> victoria-metrics-lt-server.monitoring.svc:8428
+      server:
+        retentionPeriod: 395d
+        mode: statefulSet
+        persistentVolume:
+          enabled: true
+          storageClassName: local-vm-lt
+          accessModes: [ReadWriteOnce]
+          size: 750Gi
+        podLabels: { app: victoria-metrics-lt, env: production, category: observability }
+        resources:
+          requests: { cpu: 100m, memory: 512Mi }
+          limits:   { cpu: "1",  memory: 2Gi }     # year-range queries are RAM-heavier; tune after observing
+        serviceMonitor:
+          enabled: true
+          extraLabels: { app: victoria-metrics-lt, env: production, category: observability }
+  ```
+  > **⚠ Label discipline (load-bearing):** the app label MUST be `victoria-metrics-lt`, NOT `victoria-metrics`. The existing `victoria-metrics-b2` Velero schedule selects `app: victoria-metrics`; a matching label would sweep this 750Gi volume into a daily B2 backup — the opposite of the design intent. Grep the whole dir for `app: victoria-metrics$` before committing.
+
+### Task 3: App kustomization + wire into the monitoring namespace
+
+**Files:**
+- Create: `clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/kustomization.yaml`
+- Modify: `clusters/vollminlab-cluster/monitoring/kustomization.yaml`
+
+- [ ] **Step 1: App kustomization** — list all four resources:
+  ```yaml
+  apiVersion: kustomize.config.k8s.io/v1beta1
+  kind: Kustomization
+  resources:
+    - storageclass.yaml
+    - pv.yaml
+    - configmap.yaml
+    - helmrelease.yaml
+  ```
+
+- [ ] **Step 2: Add to the namespace kustomization** — insert `- victoria-metrics-lt/app` into `monitoring/kustomization.yaml` `resources:` (keep alphabetical, right after `victoria-metrics/app`).
+
+- [ ] **Step 3: Validate render** — `kubectl kustomize clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app` renders cleanly; then `kubectl kustomize clusters/vollminlab-cluster/monitoring | grep victoria-metrics-lt` confirms it's aggregated.
+
+### Task 4: Prometheus remoteWrite fan-out + Grafana datasource
+
+**Files:**
+- Modify: `clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml`
+
+- [ ] **Step 1: Add the second `remoteWrite` endpoint** (append to the existing list — do NOT touch the first entry):
+  ```yaml
+        remoteWrite:
+          - url: http://victoria-metrics-single-server.monitoring.svc.cluster.local:8428/api/v1/write
+          - url: http://victoria-metrics-lt-server.monitoring.svc.cluster.local:8428/api/v1/write
+            name: vm-lt
+            queueConfig:
+              capacity: 10000
+              maxShards: 10
+              maxSamplesPerSend: 2000
+  ```
+  Per-endpoint queue isolation → a slow pool_0 write cannot stall the hot write or scraping.
+
+- [ ] **Step 2: Add the 3rd Grafana datasource** — locate the `additionalDataSources` block (where `prometheus-live` is defined in this same configmap) and add:
+  ```yaml
+        - name: VictoriaMetrics (long-term)
+          type: prometheus
+          uid: victoriametrics-lt
+          access: proxy
+          url: http://victoria-metrics-lt-server.monitoring.svc.cluster.local:8428
+          isDefault: false
+  ```
+  Leave the default (`uid: prometheus` → hot VM) and `prometheus-live` unchanged.
+
+- [ ] **Step 3: Validate render** — `kubectl kustomize clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app` renders; both remoteWrite URLs present, three datasources total.
+
+### Task 5: NetworkPolicy check (verify, likely no change)
+
+- [ ] **Step 1:** The cold VM is in the **same `monitoring` namespace** and listens on the **same container port 8428** as the working hot tier. Prometheus→VM and Grafana→VM already work, so existing monitoring NetworkPolicies should cover it. **Verify, don't assume** — render the monitoring `networkpolicies/` dir and confirm no podSelector pins to `app: victoria-metrics` in a way that would exclude `victoria-metrics-lt`. If a policy is app-scoped rather than namespace/port-scoped, add a matching allow. See `.claude/rules/networkpolicy.md`.
+
+### Task 6: Push branch, open PR
+
+- [ ] **Step 1:** `/new-branch feat/victoria-metrics-cold-tier`, stage the new/modified files **explicitly by name** (never `git add -A`), commit, push, open PR. No test-plan section (async verification). One concern per PR.
+- [ ] **Step 2:** Wait for CI green (kyverno-cli test, gitleaks, yaml lint). Do NOT merge without explicit user approval.
+
+---
+
+## Phase 2 — Post-merge verification (after PR merges + Flux reconciles)
+
+- [ ] **V1:** `flux get hr victoria-metrics-lt -n monitoring` → Ready=True; pod `victoria-metrics-lt-server-0` Running on the Phase 0 `NODE`.
+- [ ] **V2:** `kubectl get pv victoria-metrics-lt-data` → Bound; `kubectl get pvc -n monitoring | grep lt` → templated PVC Bound to it (WaitForFirstConsumer resolved on schedule).
+- [ ] **V3:** Cold ingest rising — from the grafana pod: `curl -s victoria-metrics-lt-server:8428/api/v1/query?query=vm_rows_inserted_total` climbing; `.../query?query=count(up)` returns data.
+- [ ] **V4:** Prometheus fan-out healthy — `prometheus_remote_storage_samples_failed_total{url=~".*lt.*"}` flat at 0; `prometheus_remote_storage_shards{url=~".*lt.*"}` > 0. Hot endpoint unchanged.
+- [ ] **V5:** Grafana — the `victoriametrics-lt` datasource passes "Save & test"; a panel pointed at it renders a >30d range.
+- [ ] **V6:** Backup exclusion confirmed — `kubectl get schedules.velero.io -n velero` shows no new LT schedule and the LT PVC is NOT in any backup (label mismatch + `monitoring` excluded). TrueNAS snapshot task from Phase 0.4 has taken at least one snapshot.
+- [ ] **V7:** Disk growth sane — after ~48h, `vm_data_size_bytes` on the LT instance tracking ~1.6 GB/day against the 750Gi PV (≈13 months of headroom).
+
+## Rollback
+
+Purely additive → revert = remove the LT remoteWrite entry + LT datasource, delete the `victoria-metrics-lt` HelmRelease/PVC (PV is `Retain`, so data survives). Hot tier returns to exact current behavior, zero data loss. The pool_0 zvol/dataset + VMDK can be reclaimed manually afterward.
+
+## Out of scope (v2)
+
+OSS `vmagent` stream-aggregation downsampling on the LT stream · `vmauth` single endpoint · VictoriaLogs for Loki.

--- a/docs/superpowers/specs/victoriametrics-cold-tier-design.md
+++ b/docs/superpowers/specs/victoriametrics-cold-tier-design.md
@@ -1,0 +1,272 @@
+# VictoriaMetrics Cold Tier (Long-Term, Off-Longhorn Metrics) — Design
+
+**Created:** 2026-07-07 (architecture decided 2026-06-21, open questions resolved 2026-07-07)
+**Status:** Finalized — ready for implementation plan.
+**Depends on:** The base VictoriaMetrics rollout (the *hot* tier) is complete and live —
+see `victoriametrics-longterm-design.md` (PRs #831/#834/#835/#836/#837). This spec is purely
+**additive** to that stack; the hot path is untouched throughout.
+
+## Problem / Goal
+
+The hot VictoriaMetrics tier keeps **30 days** of metrics on `longhorn-r2` (replicated SSD).
+The goal is **a full year of queryable metrics where anything older than ~30 days lives on
+storage OUTSIDE Longhorn** — on TrueNAS **pool_0** (the bulk spinning-disk pool that already
+backs the media library and SMB shares, ~22 TiB free). Recent data stays fast on SSD; cold
+history moves to cheap bulk disk. No new hardware, no shared-datastore SSD pressure.
+
+## Why not VictoriaMetrics cluster mode
+
+VM **cluster mode does NOT tier by age.** `vminsert` shards series across `vmstorage` nodes by
+consistent hash; each node holds the full `-retentionPeriod` for *its shard* of series. Putting a
+`vmstorage` on pool_0 would answer *half of all series* (hot **and** cold) from spinning disk.
+Age-based tiering / downsampling (`-retentionFilter`) is **VictoriaMetrics Enterprise-only** (same
+licensing trap that ruled out `vmbackupmanager`). The OSS-correct realization of "old data on
+spinning disk" is a **second single-node instance**, not cluster mode. At ~1.6 GB/day this cluster
+is trivially single-node scale anyway.
+
+## Architecture — two-instance fan-out
+
+```
+                          ┌─ remoteWrite #1 ─▶  victoria-metrics (HOT)
+                          │                     30d · longhorn-r2 SSD · fast · Grafana default
+ Prometheus (24h local) ──┤
+                          │                     victoria-metrics-lt (COLD)
+                          └─ remoteWrite #2 ─▶  ~395d (13mo) · local PV on pool_0 VMDK · spinning
+                                                disk · Grafana 3rd datasource for history panels
+```
+
+- **Hot tier (existing, unchanged):** `victoria-metrics` single, 30d, `longhorn-r2`, stays the
+  Grafana default datasource (`uid: prometheus`). Everything ≤30d served from here.
+- **Cold tier (new):** a **second** `victoria-metrics-single` release, `victoria-metrics-lt`,
+  retention **~395d**, PVC on a **static local PV backed by a pool_0 VMDK**. Because it holds the
+  full 13 months, all data older than 30d exists **only here → off Longhorn** ✓.
+- **Ingest:** Prometheus `remoteWrite` fans out to *both* VM services. Each `remoteWrite` endpoint
+  has its own in-memory queue, so a slow pool_0 write cannot stall the hot write.
+- **Query:** a 3rd Grafana datasource `VictoriaMetrics (long-term)` (`uid: victoriametrics-lt`);
+  pick it explicitly for historical / year-range panels. Hot dashboards keep using the default.
+
+## Decisions (all resolved — do not re-litigate)
+
+| Topic | Decision | Rationale |
+|-------|----------|-----------|
+| Instance model | Second single-node release, **not** cluster mode | Cluster mode can't tier by age; Enterprise-only downsampling |
+| Storage access path | **VMDK on a pool_0-backed VMware datastore → static `local` PV** (ext4) | Guest sees a plain block VMDK + ext4 (true block semantics for the tsdb); the datastore transport is invisible to the guest |
+| **Datastore transport: NFS** (dataset → NFS datastore), **not iSCSI** | Create a pool_0 **dataset**, share via NFS, mount as an NFS datastore; the 750Gi VMDK is a file on it | The decided backup = **ZFS snapshots**, and NFS makes the VMDK a plain file *inside* the snapshot → trivially browsable/restorable; iSCSI+VMFS would bury it under an opaque block device. Also: simpler provisioning (no target/extent/IQN), native thin + shared pool free space, easy grow. iSCSI's only edge (sync-write latency) is irrelevant to a non-latency-critical cold tier — the etcd-parity argument imports the wrong precedent (etcd is fsync-hot-path; this is the opposite) |
+| **SMB/CIFS rejected** | Do **not** point the tsdb at an SMB share | CIFS mmap/locking/fsync semantics fight a database — worst possible tsdb backing. NOTE: this does **not** apply to the NFS *datastore* above — the guest never speaks NFS, it sees a block VMDK; NFS is only the ESXi↔TrueNAS transport |
+| Node placement | **k8sworker01** is the documented default; finalize at the VMware step | Pin follows the local PV's `nodeAffinity`. w02 has NotReady-flap history; w03/w04's only strike was *Longhorn* EIO stale-mounts, which are irrelevant to a **local** PV. Real constraint = which ESXi host has pool_0 datastore access + VMDK room |
+| Backup | **TrueNAS ZFS snapshots of the pool_0 dataset**; **excluded from Velero** | 450Gi of "nice-to-have" history; snapshotting where it already lives is free and avoids B2 bloat |
+| Label discipline | Cold instance uses **`app: victoria-metrics-lt`** (NOT `victoria-metrics`) | The existing `victoria-metrics-b2` Velero schedule selects `app: victoria-metrics`; a matching label would sweep the 450Gi volume into a daily B2 backup — exactly what we're avoiding |
+| Downsampling | **Deferred to a v2** (OSS `vmagent` stream-aggregation on the LT stream only) | Full-resolution 13mo fits pool_0 comfortably; add later if year-range queries feel slow |
+
+## Sizing
+
+- Measured hot-tier growth: **~1.63 GB/day on-disk** (505k active series, ~16.7k samples/sec).
+- 395 days × 1.63 GB/day ≈ **~645 GB raw**. Earlier design note said ~343 GB at 0.87 GB/day —
+  that figure predated the 1.63 GB/day capacity baseline; **use the higher number.**
+- **Provision a 750 Gi VMDK / PV** (645 GB + headroom). pool_0 has ~22 TiB free, so this is safe.
+  Revisit if a later v2 stream-aggregation downsample lands (would cut this severalfold).
+
+> Note: this supersedes the "~450Gi" figure in the original brainstorm — that assumed the older,
+> lower bytes/day estimate. Size to the measured 1.63 GB/day.
+
+## Manual prerequisite (out-of-band — NOT Flux-managed)
+
+Do this **before** the Flux manifests land. **No new VM** — a VMDK is added to the *existing*
+worker VM. Transport is **NFS** (see the decisions table):
+
+1. **TrueNAS:** on **pool_0**, create a **dataset** (e.g. `pool_0/vm-lt`) to back the VMware
+   datastore — carved from free space, media untouched. Enable a **snapshot task** on this dataset
+   (recommended: weekly, retain 4–8) — this is the cold tier's only backup. Share it via **NFS**,
+   authorized to the ESXi host that runs the chosen worker.
+2. **vCenter:** mount the dataset as an **NFS datastore** on that ESXi host, then create a
+   **750 Gi VMDK** on it attached to the existing worker VM (default **k8sworker01**). Thin
+   provisioning is fine — the VMDK grows into the dataset's shared pool free space.
+3. **On the worker node:** the guest hot-adds the VMDK as a plain block device; partition/format it
+   **ext4** and mount at a stable path, e.g. `/mnt/vm-lt` (add to `/etc/fstab` by `UUID=` so it
+   survives reboot).
+4. Record the final **node name** and **mount path** — they feed the `local` PV manifest below.
+
+## Kubernetes / Flux changes
+
+All new files live under `clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/`. The
+`monitoring` Flux Kustomization already reconciles `./clusters/vollminlab-cluster/monitoring`, and
+`monitoring/kustomization.yaml` lists the app dirs — so **neither** `flux-system` index file needs
+changing, and **no new HelmRepository** is needed (reuse `victoria-metrics-repo`).
+
+### Files to create
+
+```
+clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/
+  storageclass.yaml     # no-provisioner local SC (WaitForFirstConsumer)   [only if not reused]
+  pv.yaml               # static `local` PV → the pool_0 VMDK mount, nodeAffinity to the worker
+  helmrelease.yaml      # HelmRelease, chart victoria-metrics-single 0.39.0, name victoria-metrics-lt
+  configmap.yaml        # values: fullnameOverride victoria-metrics-lt, 395d, binds the static PV
+  kustomization.yaml    # lists the above
+```
+
+### One edit to an existing file
+
+- `clusters/vollminlab-cluster/monitoring/kustomization.yaml` — add `- victoria-metrics-lt/app`
+  to `resources:` (keep alphabetical).
+
+### StorageClass — static local, no provisioner
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-vm-lt
+  labels: { app: victoria-metrics-lt, env: production, category: observability }
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer   # bind only when the pod schedules on the pinned node
+```
+
+### PersistentVolume — `local` type bound to the VMDK mount
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: victoria-metrics-lt-data
+  labels: { app: victoria-metrics-lt, env: production, category: observability }
+spec:
+  capacity: { storage: 750Gi }
+  volumeMode: Filesystem
+  accessModes: [ReadWriteOnce]
+  persistentVolumeReclaimPolicy: Retain      # never auto-wipe a year of history
+  storageClassName: local-vm-lt
+  local:
+    path: /mnt/vm-lt                          # <-- the ext4 mount from prereq step 3
+  nodeAffinity:                               # <-- pins the pod; set to the FINAL chosen node
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values: [k8sworker01]           # default; change if VMware step picks another host
+```
+
+> **Kyverno note:** the PV `local` volume type is **not** the same as a pod-level `hostPath`
+> volume — the "no hostPath" enforce policy targets Pod specs, not PersistentVolumes. The pod only
+> mounts a PVC, so this passes policy. Confirm with `kyverno-cli test` in CI as usual.
+
+### HelmRelease
+
+Identical shape to the hot tier's `helmrelease.yaml`, changing only `metadata.name`,
+`releaseName`, labels, and the values ConfigMap name to `victoria-metrics-lt` /
+`victoria-metrics-lt-values`. Same `chart: victoria-metrics-single`, `version: 0.39.0`,
+`sourceRef: victoria-metrics-repo`.
+
+### Values ConfigMap (key differences from the hot tier)
+
+```yaml
+data:
+  values.yaml: |
+    fullnameOverride: victoria-metrics-lt   # -> service victoria-metrics-lt-server.monitoring.svc:8428
+    server:
+      retentionPeriod: 395d                 # 13 months
+      mode: statefulSet                     # RWO local PV via volumeClaimTemplate, no detach trap
+      persistentVolume:
+        enabled: true
+        storageClassName: local-vm-lt       # binds the static local PV above
+        accessModes: [ReadWriteOnce]
+        size: 750Gi
+      podLabels:   { app: victoria-metrics-lt, env: production, category: observability }
+      resources:
+        requests: { cpu: 100m, memory: 512Mi }
+        limits:   { cpu: "1",  memory: 2Gi }   # year-range queries are RAM-heavier than the hot tier; tune after observing
+      serviceMonitor:
+        enabled: true
+        extraLabels: { app: victoria-metrics-lt, env: production, category: observability }
+```
+
+> The StatefulSet's `volumeClaimTemplate` will emit a PVC (`storageClassName: local-vm-lt`,
+> 750Gi, RWO) that binds the pre-created static PV when the pod first schedules on the pinned node.
+
+### Prometheus remoteWrite fan-out (one edit)
+
+In `clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml`, add a
+**second** entry to the existing `remoteWrite:` list (do not touch the first):
+
+```yaml
+        remoteWrite:
+          - url: http://victoria-metrics-single-server.monitoring.svc.cluster.local:8428/api/v1/write
+          - url: http://victoria-metrics-lt-server.monitoring.svc.cluster.local:8428/api/v1/write
+            name: vm-lt
+            queueConfig:                     # isolate the slow spinning-disk endpoint
+              capacity: 10000
+              maxShards: 10
+              maxSamplesPerSend: 2000
+```
+
+Per-endpoint queues mean a slow pool_0 write backs up its own shard queue without stalling the hot
+write or Prometheus scraping.
+
+### Grafana datasource (one edit)
+
+Add a 3rd datasource alongside the existing VM/Prometheus entries (in the kube-prometheus-stack
+Grafana `additionalDataSources`, wherever `prometheus-live` is defined — **confirm the exact file
+at implementation time**):
+
+```yaml
+- name: VictoriaMetrics (long-term)
+  type: prometheus
+  uid: victoriametrics-lt
+  access: proxy
+  url: http://victoria-metrics-lt-server.monitoring.svc.cluster.local:8428
+  isDefault: false
+```
+
+## Backup
+
+- **No Velero change.** The cold volume is excluded automatically: `monitoring` is already excluded
+  from all three main schedules, and the `victoria-metrics-b2` schedule's `labelSelector`
+  (`app: victoria-metrics`) does **not** match `app: victoria-metrics-lt`. This is why the distinct
+  label is load-bearing — verify it's `victoria-metrics-lt` everywhere before merge.
+- **Protection = TrueNAS ZFS snapshots** on the pool_0 dataset backing the datastore (configured in
+  prereq step 1). Weekly, retain 4–8. History is "nice to have"; a snapshot restore is the recovery
+  path, not Velero.
+
+## Verification (post-merge)
+
+1. `flux get hr victoria-metrics-lt -n monitoring` → Ready=True; pod
+   `victoria-metrics-lt-server-0` Running on the pinned node.
+2. `kubectl get pv victoria-metrics-lt-data` → Bound; `kubectl get pvc -n monitoring` shows the
+   templated PVC Bound to it.
+3. Prometheus fan-out healthy: on the Prometheus pod, both remoteWrite endpoints show
+   `prometheus_remote_storage_samples_failed_total` flat at 0 and
+   `prometheus_remote_storage_shards` > 0 for `url=...lt...`.
+4. Cold ingest confirmed:
+   `curl victoria-metrics-lt-server:8428/api/v1/query?query=vm_rows_inserted_total` rising;
+   `.../api/v1/query?query=count(up)` returns data.
+5. Grafana: the `victoriametrics-lt` datasource passes "Save & test"; a panel pointed at it renders.
+6. NetworkPolicy: confirm Prometheus→`:8428` and Grafana→`:8428` reach the LT pod (same namespace
+   + same container port as the working hot tier, so existing monitoring policies should cover it —
+   verify, don't assume; see `.claude/rules/networkpolicy.md`).
+7. Kyverno/CI: `kyverno-cli test` green (labels present, no hostPath/`:latest`, resources set).
+
+## Risks & rollback
+
+- **Single point of failure:** cold tier is one pod, one node, one local disk, no HA. Acceptable —
+  it's non-critical history, snapshot-protected. Hot tier + alerting are unaffected by its loss.
+- **Slow disk backpressure:** mitigated by the isolated remoteWrite queue. If pool_0 ever can't
+  keep up, the LT queue drops samples for the LT stream only; hot tier and scraping are unharmed.
+- **Rollback:** because it's purely additive, revert = remove the LT remoteWrite entry + the LT
+  datasource + delete the `victoria-metrics-lt` HelmRelease/PVC/PV. Hot tier returns to today's
+  exact behavior with zero data loss.
+
+## Out of scope (candidate v2)
+
+- OSS `vmagent` **stream-aggregation downsampling** on the LT stream (e.g. 1-minute) to shrink the
+  volume severalfold and speed year-range queries.
+- Fronting hot + cold with a single `vmauth` endpoint so Grafana has one URL.
+- VictoriaLogs (the same pattern for Loki log retention) — its own future spec.
+
+## Implementation sequencing
+
+1. **Manual VMware/TrueNAS prereq** (datastore + 750Gi VMDK + ext4 mount + ZFS snapshot task);
+   record final node + mount path.
+2. **One PR, its own branch** (`feat/victoria-metrics-cold-tier`) — all Flux files above +
+   the `monitoring/kustomization.yaml`, `kube-prometheus-stack` remoteWrite, and Grafana datasource
+   edits. One concern, one PR.
+3. Merge → Flux reconciles → run the verification checklist.


### PR DESCRIPTION
## What

Adds a **second** \`victoria-metrics-single\` instance (\`victoria-metrics-lt\`) holding **~13 months** of metrics on a **static local PV** backed by a **750Gi VMDK on a pool_0 (spinning-disk) NFS datastore** — off Longhorn. Prometheus \`remoteWrite\` fans out to both the existing hot tier (30d, SSD) and this cold tier, so everything older than 30d lives **only** on cheap bulk disk. Purely additive; the hot path is untouched.

## Why

The hot tier keeps 30d on replicated SSD. Goal is a full year of queryable history without SSD/Longhorn pressure. VM cluster mode can't tier by age and age-based downsampling is Enterprise-only, so the OSS-correct answer is a second single-node instance on bulk disk. Full rationale (incl. the **NFS-vs-iSCSI transport decision**) in the committed spec.

## Changes

- \`local-vm-lt\` StorageClass (no-provisioner, WaitForFirstConsumer) + static \`local\` PV pinned to **k8sworker01 \`/mnt/vm-lt\`** (\`Retain\`)
- \`victoria-metrics-lt\` HelmRelease + values — 395d retention, 750Gi, same chart & \`victoria-metrics-repo\` source as the hot tier
- second Prometheus \`remoteWrite\` endpoint with an **isolated queue** so a slow pool_0 write can't stall the hot write or scraping
- third Grafana datasource (\`uid: victoriametrics-lt\`) for history panels; hot dashboards keep the default
- design spec + implementation plan added under \`docs/superpowers/\`

## Load-bearing detail

Label is **\`app: victoria-metrics-lt\`**, deliberately *not* \`victoria-metrics\` — the \`victoria-metrics-b2\` Velero schedule selects \`app: victoria-metrics\`, and a matching label would sweep the 750Gi cold volume into a daily B2 backup. Backup here is **TrueNAS ZFS snapshots** of the pool_0 dataset (no Velero change needed).

## ⚠️ Merge gate — manual Phase 0 prereq first

The cold pod's PV binds to an ext4 mount on the node. **Hold merge** until the manual out-of-band prereq is done (per \`docs/superpowers/plans/victoriametrics-cold-tier.md\` Phase 0): pool_0 dataset → NFS share → NFS datastore → 750Gi VMDK on the k8sworker01 VM → \`mkfs.ext4\` + fstab mount at \`/mnt/vm-lt\` → weekly ZFS snapshot task. If the datastore lands on a different ESXi host, update the PV \`nodeAffinity\` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)