### PR TITLE
fix(volsync): stagger 13 backup schedules across 00:00-02:00 window

### DIFF
--- a/clusters/vollminlab-cluster/harbor/volsync/harbor-registry-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/harbor/volsync/harbor-registry-replicationsource.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   sourcePVC: harbor-registry
   trigger:
-    schedule: "0 3 * * *"
+    schedule: "0 2 * * *"
   restic:
     pruneIntervalDays: 7
     repository: volsync-harbor-registry-restic

--- a/clusters/vollminlab-cluster/mediastack/volsync/audiobookshelf-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/audiobookshelf-config-replicationsource.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   sourcePVC: pvc-audiobookshelf-config
   trigger:
-    schedule: "0 3 * * *"
+    schedule: "0 0 * * *"
   restic:
     pruneIntervalDays: 7
     repository: volsync-audiobookshelf-config-restic

--- a/clusters/vollminlab-cluster/mediastack/volsync/audiobookshelf-metadata-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/audiobookshelf-metadata-replicationsource.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   sourcePVC: pvc-audiobookshelf-metadata
   trigger:
-    schedule: "0 3 * * *"
+    schedule: "10 0 * * *"
   restic:
     pruneIntervalDays: 7
     repository: volsync-audiobookshelf-metadata-restic

--- a/clusters/vollminlab-cluster/mediastack/volsync/bazarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/bazarr-config-replicationsource.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   sourcePVC: pvc-bazarr-config
   trigger:
-    schedule: "0 3 * * *"
+    schedule: "20 0 * * *"
   restic:
     pruneIntervalDays: 7
     repository: volsync-bazarr-config-restic

--- a/clusters/vollminlab-cluster/mediastack/volsync/filebrowser-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/filebrowser-config-replicationsource.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   sourcePVC: pvc-filebrowser-config
   trigger:
-    schedule: "0 3 * * *"
+    schedule: "30 0 * * *"
   restic:
     pruneIntervalDays: 7
     repository: volsync-filebrowser-config-restic

--- a/clusters/vollminlab-cluster/mediastack/volsync/jellyfin-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/jellyfin-config-replicationsource.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   sourcePVC: pvc-jellyfin-config
   trigger:
-    schedule: "0 3 * * *"
+    schedule: "40 0 * * *"
   restic:
     pruneIntervalDays: 7
     repository: volsync-jellyfin-config-restic

--- a/clusters/vollminlab-cluster/mediastack/volsync/prowlarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/prowlarr-config-replicationsource.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   sourcePVC: pvc-prowlarr-config
   trigger:
-    schedule: "0 3 * * *"
+    schedule: "50 0 * * *"
   restic:
     pruneIntervalDays: 7
     repository: volsync-prowlarr-config-restic

--- a/clusters/vollminlab-cluster/mediastack/volsync/qbittorrent-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/qbittorrent-config-replicationsource.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   sourcePVC: pvc-qbittorrent-config
   trigger:
-    schedule: "0 3 * * *"
+    schedule: "0 1 * * *"
   restic:
     pruneIntervalDays: 7
     repository: volsync-qbittorrent-config-restic

--- a/clusters/vollminlab-cluster/mediastack/volsync/radarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/radarr-config-replicationsource.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   sourcePVC: pvc-radarr-config
   trigger:
-    schedule: "0 3 * * *"
+    schedule: "10 1 * * *"
   restic:
     pruneIntervalDays: 7
     repository: volsync-radarr-config-restic

--- a/clusters/vollminlab-cluster/mediastack/volsync/readarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/readarr-config-replicationsource.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   sourcePVC: pvc-readarr-config
   trigger:
-    schedule: "0 3 * * *"
+    schedule: "20 1 * * *"
   restic:
     pruneIntervalDays: 7
     repository: volsync-readarr-config-restic

--- a/clusters/vollminlab-cluster/mediastack/volsync/sabnzbd-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/sabnzbd-config-replicationsource.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   sourcePVC: pvc-sabnzbd-config
   trigger:
-    schedule: "0 3 * * *"
+    schedule: "30 1 * * *"
   restic:
     pruneIntervalDays: 7
     repository: volsync-sabnzbd-config-restic

--- a/clusters/vollminlab-cluster/mediastack/volsync/seerr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/seerr-config-replicationsource.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   sourcePVC: pvc-seerr-config
   trigger:
-    schedule: "0 3 * * *"
+    schedule: "40 1 * * *"
   restic:
     pruneIntervalDays: 7
     repository: volsync-seerr-config-restic

--- a/clusters/vollminlab-cluster/mediastack/volsync/sonarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/sonarr-config-replicationsource.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   sourcePVC: pvc-sonarr-config
   trigger:
-    schedule: "0 3 * * *"
+    schedule: "50 1 * * *"
   restic:
     pruneIntervalDays: 7
     repository: volsync-sonarr-config-restic


### PR DESCRIPTION
## Problem

All 13 VolSync `ReplicationSource`s use `spec.trigger.schedule: "0 3 * * *"` — every config/registry backup fires at 03:00 UTC simultaneously. Each one snapshots its source PVC and spins up a 20Gi Longhorn clone that needs replicas to reach HA. Thirteen concurrent clone rebuilds turn a routine node blip into faulted/thrashing replicas and crash-inconsistent snapshots.

The **2026-07-07 03:00 storm** collided with worker04 sitting near-full and a node/latency blip, and wedged `jellyfin-config` on an ext4 clone that failed `fsck` at a stable corrupt directory inode. (Source repaired out-of-band via offline `e2fsck`; jellyfin is healthy and its backup has caught up.)

## Fix

Spread the schedules 10 min apart across a quiet 00:00–02:00 window (max observed sync ~9m ⇒ ~zero overlap), and off Velero's 03:00 (`daily-full` → MinIO) / 04:00 (`daily-b2` → B2) slots so the two backup systems no longer stack:

| Time | ReplicationSource | Time | ReplicationSource |
|---|---|---|---|
| 00:00 | audiobookshelf-config | 01:00 | qbittorrent-config |
| 00:10 | audiobookshelf-metadata | 01:10 | radarr-config |
| 00:20 | bazarr-config | 01:20 | readarr-config |
| 00:30 | filebrowser-config | 01:30 | sabnzbd-config |
| 00:40 | jellyfin-config | 01:40 | seerr-config |
| 00:50 | prowlarr-config | 01:50 | sonarr-config |
| 02:00 | harbor-registry | | |

One line changed per file (`spec.trigger.schedule`), 13 files.

## Follow-up (tracked, not in this PR)

worker04 near-full (~68G schedulable vs 110–160G elsewhere) is half the storm's fragility — capacity/rebalancer work would remove the underlying pressure so even a same-time storm wouldn't fault replicas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEgN9sG22SAJdroNqHq11s