### PR TITLE
fix(longhorn): accelerate rebalancer drain of hot nodes

### DIFF
--- a/clusters/vollminlab-cluster/longhorn-system/longhorn-rebalancing-controller/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn-rebalancing-controller/app/configmap.yaml
@@ -19,6 +19,9 @@ data:
 
     config:
       dryRun: false
+      rebalance:
+        maxEvictionsPerDay: 4
+        smallestFirst: false
 
     resources:
       requests:


### PR DESCRIPTION
## Problem

The `longhorn-rebalancing-controller` is live and healthy, and it correctly identifies worker04 as the hot node — but it's throttled by its own conservative rollout defaults:

- worker04: **201/248 GiB = 80.8%**, 19 replicas (every other node 44–62%)
- Every reconcile ends with `daily cap reached cap:2` — it evicts only the **2 smallest** replicas per night, then stops
- Result: worker04 drains ~2 tiny replicas/night, so real headroom is weeks away

worker04's tight free space was half the fragility behind the 2026-07-07 VolSync backup storm (13 simultaneous 20Gi clones vs ~47Gi free).

## Change

Our values CM previously only overrode `config.dryRun`, so the rebalance-mode knobs were all chart defaults. This adds two overrides:

| Knob | Old (default) | New | Effect |
|---|---|---|---|
| `rebalance.maxEvictionsPerDay` | 2 | 4 | Doubles the nightly drain rate |
| `rebalance.smallestFirst` | true | false | Moves larger replicas first → frees real GiB per eviction, fewer moves needed |

## Safety

Unchanged: `nodeUsageThreshold: 75`, `maintenanceWindow: 02:00-05:00`, `cooldownMinutes: 30`, and the eviction gates (all volumes robustness=Healthy, no replica rebuilding, target volume at full replica count). So this only speeds up the *rate* of an already-safe operation — worker04 relieved in a couple of nights instead of a couple of weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEgN9sG22SAJdroNqHq11s