### PR TITLE
fix(trivy): move scanJobTolerations under operator: so scan jobs tolerate CP/DMZ taints

### DIFF
--- a/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
@@ -15,6 +15,20 @@ data:
       sbomReport:
         enabled: false
       scanJobsConcurrentLimit: 1
+      # scanJobTolerations MUST live under operator: — in the trivy-operator
+      # chart this key is operator.scanJobTolerations. A top-level
+      # scanJobTolerations is silently dropped by Helm, so scan pods get no
+      # tolerations and cannot schedule onto the tainted CP/DMZ nodes. With the
+      # 4 general workers CPU-request-saturated, that produced FailedScheduling
+      # -> BackoffLimitExceeded. (nodeCollector is a genuine top-level block.)
+      scanJobTolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: dmz
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       resources:
         requests:
           cpu: 100m
@@ -42,15 +56,6 @@ data:
         limits:
           cpu: 500m
           memory: 1Gi
-
-    scanJobTolerations:
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
-      - key: dmz
-        operator: Equal
-        value: "true"
-        effect: NoSchedule
 
     nodeCollector:
       tolerations:


### PR DESCRIPTION
## Problem

Trivy `scan-vulnerabilityreport-*` jobs in `trivy-system` were failing with `BackoffLimitExceeded`. The underlying pods showed:

```
FailedScheduling: 0/9 nodes are available: 4 Insufficient cpu,
5 node(s) had untolerated taint(s).
```

## Root cause

`scanJobTolerations` was defined at the **top level** of the values ConfigMap. The trivy-operator chart reads this key as `operator.scanJobTolerations` — a top-level `scanJobTolerations` is an unrecognized key that Helm silently drops. As a result, scan jobs were created with **no tolerations** and could not schedule onto the tainted nodes:

- `k8scp01/02/03` — `node-role.kubernetes.io/control-plane:NoSchedule`
- `k8sworker05/06` — `dmz=true:NoSchedule`

The 4 untainted general workers (`k8sworker01-04`) are CPU-**request**-saturated (78–95% requests, ~20% actual use), so scan pods had nowhere to land → `Insufficient cpu` on the 4 workers + `untolerated taint` on the 5 tainted nodes → `BackoffLimitExceeded`.

## Fix

Move the `scanJobTolerations` block under `operator:` (its correct chart path). Scan pods now tolerate the CP and DMZ taints and can use the idle capacity on those 5 nodes.

`nodeCollector.tolerations` is untouched — `nodeCollector` **is** a genuine top-level chart block, so it was already correct.

## Verification (post-merge, async via Flux)

- Scan jobs land on CP/DMZ nodes and complete instead of hitting `BackoffLimitExceeded`.
- `kubectl get vulnerabilityreports -A` repopulates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)