### PR TITLE
chore: right-size oversubscribed CPU requests on general workers

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/jellyfin/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/jellyfin/app/configmap.yaml
@@ -52,7 +52,10 @@ data:
               topologyKey: kubernetes.io/hostname
     resources:
       requests:
-        cpu: 500m
+        # VPA target ~109m / upperBound ~128m. Request 500m→200m keeps a floor
+        # above the observed peak while freeing 300m of scheduler reservation.
+        # Limit unchanged (4000m) so transcodes still burst hard.
+        cpu: 200m
         memory: 512Mi
       limits:
         cpu: 4000m

--- a/clusters/vollminlab-cluster/mediastack/prowlarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/prowlarr/app/configmap.yaml
@@ -41,7 +41,9 @@ data:
               topologyKey: kubernetes.io/hostname
     resources:
       requests:
-        cpu: 100m
+        # VPA target ~11m but upperBound ~64m (bursty indexer syncs). Request
+        # 100m→75m keeps the floor above the observed peak. Limit unchanged (500m).
+        cpu: 75m
         memory: 256Mi
       limits:
         cpu: 500m

--- a/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
@@ -60,7 +60,8 @@ spec:
               value: "8080"
           resources:
             requests:
-              cpu: 100m
+              # VPA target/upperBound ~11m. Request 100m→50m. Limit unchanged (1000m).
+              cpu: 50m
               memory: 256Mi
             limits:
               cpu: 1000m

--- a/clusters/vollminlab-cluster/mediastack/radarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/radarr/app/configmap.yaml
@@ -41,7 +41,8 @@ data:
               topologyKey: kubernetes.io/hostname
     resources:
       requests:
-        cpu: 100m
+        # VPA target ~35m. Request 100m→50m. Limit unchanged (500m).
+        cpu: 50m
         memory: 256Mi
       limits:
         cpu: 500m

--- a/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
@@ -45,7 +45,8 @@ data:
               topologyKey: kubernetes.io/hostname
     resources:
       requests:
-        cpu: 100m
+        # VPA target ~35m / upperBound ~50m. Request 100m→50m. Limit unchanged (500m).
+        cpu: 50m
         memory: 256Mi
       limits:
         cpu: 500m

--- a/clusters/vollminlab-cluster/mediastack/sabnzbd/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sabnzbd/app/configmap.yaml
@@ -40,7 +40,9 @@ data:
               topologyKey: kubernetes.io/hostname
     resources:
       requests:
-        cpu: 200m
+        # VPA target ~15m; keep a 100m floor for par2/unrar CPU bursts on download
+        # completion. Request 200m→100m. Limit unchanged (500m).
+        cpu: 100m
         memory: 256Mi
       limits:
         cpu: 500m

--- a/clusters/vollminlab-cluster/mediastack/sonarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sonarr/app/configmap.yaml
@@ -24,7 +24,8 @@ data:
         mountPath: /tv
     resources:
       requests:
-        cpu: 100m
+        # VPA target/upperBound ~23m. Request 100m→50m. Limit unchanged (500m).
+        cpu: 50m
         memory: 256Mi
       limits:
         cpu: 500m

--- a/clusters/vollminlab-cluster/metallb-system/metallb/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/metallb-system/metallb/app/configmap.yaml
@@ -28,7 +28,9 @@ data:
         frr:
           resources:
             requests:
-              cpu: 100m
+              # VPA target/upperBound ~11m (BGP daemon is near-idle). Request
+              # 100m→50m (DaemonSet on every node). No limit block — unchanged.
+              cpu: 50m
               memory: 128Mi
         frrMetrics:
           resources:

--- a/clusters/vollminlab-cluster/tofu/tofu-controller/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/tofu/tofu-controller/app/configmap.yaml
@@ -19,7 +19,9 @@ data:
 
     resources:
       requests:
-        cpu: 200m
+        # VPA target ~15m; controller idles between reconciles (runners do the work).
+        # Request 200m→75m. Limit unchanged (1000m) for reconcile bursts.
+        cpu: 75m
         memory: 256Mi
       limits:
         cpu: 1000m

--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -16,7 +16,10 @@ data:
 
     resources:
       requests:
-        cpu: 500m
+        # VPA target/upperBound ~11m; server is idle between backup runs. Request
+        # right-sized 500m→100m so the scheduler stops reserving idle cores on the
+        # general workers. Limit unchanged — bursts during backups still allowed.
+        cpu: 100m
         memory: 512Mi
       limits:
         cpu: 1000m
@@ -127,7 +130,9 @@ data:
           effect: NoSchedule
       resources:
         requests:
-          cpu: 100m
+          # VPA target ~15m; node-agent idles except during kopia FSB. Request
+          # 100m→50m (DaemonSet ×6). Limit unchanged so backups still burst.
+          cpu: 50m
           memory: 512Mi
         limits:
           cpu: 1000m


### PR DESCRIPTION
## Why

The 4 general workers (k8sworker01–04) sit at **78–95% CPU *requests*** while actual usage is only **6–25%**. The scheduler treats them as full on paper, which is exactly what blocked trivy scan pods from landing there (root cause behind #927's symptom) — and would block anything else that needs to schedule.

This trims inflated CPU **requests** down to each container's existing Goldilocks/VPA recommendation, keeping a floor at or above the observed `upperBound` for the bursty ones.

## What — requests only, limits untouched

Every `limits:` block is left **exactly as-is**. A request is a scheduling reservation + guaranteed floor; it does **not** cap bursting (the limit does). Lowering a request only throttles a container toward that request under genuine node contention — which these idle workers never reach — so burst headroom is fully preserved.

| Container | request → | VPA target / upperBound |
|-----------|-----------|-------------------------|
| velero server | 500m → 100m | ~11m |
| velero node-agent (DaemonSet) | 100m → 50m | ~15m |
| jellyfin | 500m → 200m | 109m / 128m |
| sabnzbd | 200m → 100m | ~15m (floor kept for par2/unrar) |
| tofu-controller | 200m → 75m | ~15m |
| metallb frr-k8s `frr` (DaemonSet) | 100m → 50m | ~11m |
| sonarr | 100m → 50m | ~23m |
| radarr | 100m → 50m | ~35m |
| readarr | 100m → 50m | 35m / 50m |
| prowlarr | 100m → 75m | 11m / 64m (kept above peak) |
| qbittorrent | 100m → 50m | ~11m |

Frees **~1.3 cores** of scheduler reservation across the general workers.

## Deferred (out of scope)

- **Longhorn `guaranteed-instance-manager-cpu`** (12%, ~480m/node) — the biggest single lever, but storage-critical: changing it restarts instance managers → brief volume disruption. Wants its own change window.
- **DMZ minecraft 2000m request** (VPA ~35m) — a gaming judgment call, and it runs on the DMZ workers, not the general workers this PR targets.
- **The long tail of 100m→15m singleton defaults** — high churn, low value.

Happy to expand scope to any of these if wanted.