### PR TITLE
fix(velero): throttle kopia FSB read parallelism to 2 files per snapshot

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -159,6 +159,17 @@ data:
           ttl: 96h
           storageLocation: minio
           defaultVolumesToFsBackup: true
+          # Throttle kopia's per-snapshot file read parallelism. The default is the
+          # node CPU count (4 on general workers), and all worker VMDKs sit on the
+          # same shared datastore — a full FSB pass drives PSI full I/O-stall to
+          # 26-48% on every general worker simultaneously, which liveness-kills pods
+          # on whichever node hosts the most attached volumes (restart storms on
+          # k8sworker02, nightly 03:00-04:30). node-agent loadConcurrency is already
+          # at its minimum (1 per node), so this is the remaining throttle knob.
+          # 2 halves the concurrent pool readers while keeping daily-full (~20 min)
+          # well clear of the 04:00 daily-b2 slot.
+          uploaderConfig:
+            parallelFilesUpload: 2
           excludedNamespaces:
             - kyverno
             - longhorn-system
@@ -189,6 +200,9 @@ data:
           ttl: 2160h
           storageLocation: b2
           defaultVolumesToFsBackup: true
+          # Throttle kopia file read parallelism — see daily-full for rationale.
+          uploaderConfig:
+            parallelFilesUpload: 2
           excludedNamespaces:
             - kyverno
             - longhorn-system
@@ -219,6 +233,9 @@ data:
           ttl: 8760h
           storageLocation: b2
           defaultVolumesToFsBackup: true
+          # Throttle kopia file read parallelism — see daily-full for rationale.
+          uploaderConfig:
+            parallelFilesUpload: 2
           excludedNamespaces:
             - kyverno
             - longhorn-system
@@ -249,6 +266,9 @@ data:
           ttl: 2160h
           storageLocation: b2
           defaultVolumesToFsBackup: true
+          # Throttle kopia file read parallelism — see daily-full for rationale.
+          uploaderConfig:
+            parallelFilesUpload: 2
           includedNamespaces:
             - monitoring
           labelSelector:


### PR DESCRIPTION
## Why

The nightly backup window (03:00–04:30 UTC) saturates the shared datastore that all four general-worker VMDKs sit on. 30-day PSI history shows full I/O-stall peaks of 26–48% on **all** general workers simultaneously most nights (worst 0.79 on k8sworker02, 07-03). The stall liveness-kills pods on whichever node hosts the most attached volumes — k8sworker02 (monitoring stack + harbor-db + arr configs) took two restart waves on 07-18 (03:10 and ~04:35), producing the PodCrashLooping alert storm.

## Why this lever

This PR started as "stagger the backup schedules," but that work is already done and live:

- **VolSync** — the 13 ReplicationSources were staggered 00:00–02:00 at 10-min spacing in #925 (merged 07-08); confirmed live via lastSyncTime.
- **Velero schedules** — daily-full (03:00, ~20 min), daily-b2 (04:00), victoria-metrics-b2 (05:00) don't overlap each other.
- **node-agent loadConcurrency** — already at the Velero minimum (1 concurrent PVB per node).

The remaining knob is kopia's per-snapshot file read parallelism, which defaults to the node CPU count (4 on general workers) — up to ~24 concurrent pool readers across the 6 node-agents during a pass.

## What

Adds `uploaderConfig.parallelFilesUpload: 2` to the backup template of all four schedules (daily-full, daily-b2, monthly-b2, victoria-metrics-b2). This halves the concurrent read pressure per snapshot while keeping daily-full comfortably clear of the 04:00 daily-b2 slot. Field verified present in the deployed Velero v1.18.1 Schedule CRD (`spec.template.uploaderConfig.parallelFilesUpload`).

Expected effect: lower/shorter PSI stall peaks during 03:00–04:30 at the cost of moderately longer backup runtimes. If stalls persist after a few nights, the next levers are storage-side (separate datastore for the hottest volumes, as done for etcd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BPawfDCK5RTFcXQ9BVtzG