### PR TITLE
feat(monitoring): page on sustained user-facing crashloops

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -225,6 +225,29 @@ spec:
               is a stale Longhorn mount, run the manual runbook (scale the Deployment to 0,
               wait for the Longhorn volume to report detached, scale it back up).
 
+        # Escalated sibling of PodCrashLooping for user-facing namespaces: a crashloop
+        # still accruing restarts after 30 minutes there is an outage in progress, not a
+        # transient blip. severity=critical routes to the priority-1 Pushover receiver
+        # (route lives in the "Alertmanager Config" 1Password item), which repeats every
+        # 4h instead of 12h. The plain PodCrashLooping warning keeps firing alongside —
+        # this adds escalation, it suppresses nothing. Context: the 2026-07-13 shlink
+        # crashloop ran ~30h because it only ever surfaced as a quiet priority-0 warning.
+        - alert: UserFacingPodCrashLooping
+          expr: |
+            increase(kube_pod_container_status_restarts_total{namespace=~"shlink|mediastack|homepage|authentik"}[30m]) > 3
+          for: 30m
+          labels:
+            severity: critical
+          annotations:
+            summary: "User-facing pod {{ $labels.namespace }}/{{ $labels.pod }} crash-looping for 30m+"
+            description: >-
+              Container {{ $labels.container }} in {{ $labels.namespace }}/{{ $labels.pod }}
+              has restarted {{ $value | printf "%.0f" }} times in the last 30 minutes and the
+              loop has persisted past the 30-minute escalation window. Treat as a user-facing
+              outage: check `kubectl describe pod` and recent events in the namespace, and if
+              it is a stale Longhorn mount follow the scale-0 -> wait-detached -> scale-up
+              runbook.
+
         - alert: PodNotReady
           expr: |
             (


### PR DESCRIPTION
## Summary

Adds `UserFacingPodCrashLooping` (`severity: critical`) to the pod-health rule group: a crashloop in **shlink / mediastack / homepage / authentik** that persists past 30 minutes escalates to critical. The existing `PodCrashLooping` warning is untouched and continues to fire alongside — this adds escalation, it suppresses nothing.

## Why

The 2026-07-13 shlink outage (shlink-backend + shlink-db crashlooping) ran ~30 hours. The warning fired, but every alert — warning and critical alike — currently lands on the same priority-0 Pushover receiver with a 12h repeat, so it blended in. A sustained crashloop on a user-facing service is an outage in progress and needs to page.

## Companion change (not in this PR)

The Alertmanager config lives in the 1Password "Alertmanager Config" item (pulled whole by ESO). It gains a `severity=critical` route to a new `pushover-critical` receiver at **priority 1** (bypasses quiet hours) with a **4h repeat**. Warnings keep today's priority-0 behavior. This also promotes existing criticals (NodeDiskSpaceCritical, LonghornVolumeFaulted, VeleroBackupPersistentlyFailing, StorageHealerNotCoping, …) to actual pages, which is the intended prod posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BPawfDCK5RTFcXQ9BVtzG