### PR TITLE
feat(longhorn): add snapshot-delete RecurringJob to cap VolSync clone orphans

### DIFF
--- a/clusters/vollminlab-cluster/longhorn-system/kustomization.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/kustomization.yaml
@@ -5,5 +5,6 @@ metadata:
 resources:
   - namespace.yaml
   - ./longhorn/app
-  - ./longhorn-trim/app
   - ./longhorn-rebalancing-controller/app
+  - ./longhorn-snapshot-retention/app
+  - ./longhorn-trim/app

--- a/clusters/vollminlab-cluster/longhorn-system/longhorn-snapshot-retention/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn-snapshot-retention/app/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - recurringjob.yaml

--- a/clusters/vollminlab-cluster/longhorn-system/longhorn-snapshot-retention/app/recurringjob.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn-snapshot-retention/app/recurringjob.yaml
@@ -1,0 +1,25 @@
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: snapshot-retention
+  namespace: longhorn-system
+  labels:
+    app: longhorn-snapshot-retention
+    env: production
+    category: storage
+spec:
+  name: snapshot-retention
+  # VolSync's copyMethod: Clone leaves one internal source-volume snapshot per
+  # nightly run that Longhorn never cleans up (617 orphans accumulated
+  # 2026-05-30 -> 2026-07-18). snapshot-delete purges snapshots beyond `retain`
+  # on every volume in the default group (= all volumes without explicit
+  # recurring-job labels), capping growth at 3 per volume.
+  task: snapshot-delete
+  # Midday, far from the 00:00-05:30 backup window and the 06:00 trim job —
+  # purge/coalesce is real replica I/O on the shared pool.
+  cron: "0 12 * * *"
+  retain: 3
+  concurrency: 2
+  groups:
+    - default
+  labels: {}


### PR DESCRIPTION
## Problem

VolSync's `copyMethod: Clone` leaks one Longhorn snapshot per volume per night: the CSI clone operation takes an internal snapshot on the **source** volume and never deletes it when the clone PVC is removed. Nothing references these (zero VolumeSnapshot/VolumeSnapshotContent objects cluster-wide), so they accumulate unbounded.

Found 2026-07-18: **617 orphan snapshots** across the 13 VolSync-protected volumes, all accumulated since the 2026-05-30 purge. Impact: radarr's 5Gi config PVC held 9.4 GiB actual; manual purge of just 3 arr volumes recovered ~12 GiB and lifted w01 schedulable from 67 → 82+ GiB.

## Fix

New `snapshot-retention` RecurringJob (`task: snapshot-delete`, Longhorn v1.12):

- `retain: 3` — deletes + purges snapshots beyond the 3 newest on each volume
- `groups: [default]` — auto-applies to all volumes without explicit recurring-job labels, i.e. cluster-wide cap
- `cron: "0 12 * * *"` — midday UTC, clear of the 00:00–05:30 backup window (VolSync, daily-full 03:00, daily-b2 04:00, vm-b2 05:00) and the 06:00 trim job, since purge/coalesce is real replica I/O on the shared pool
- `concurrency: 2` — matches the trim job's gentle pace

Without this, orphans return at 1/volume/night (~13/night) even after today's manual purge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BPawfDCK5RTFcXQ9BVtzG