### PR TITLE
chore(trivy): bump trivy-operator chart 0.32.1 -> 0.34.0

### DIFF
--- a/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
@@ -45,7 +45,7 @@ data:
       # both run longhorn-manager) launch concurrent scans against one shared
       # cache emptyDir and deadlock on the lock -> BackoffLimitExceeded. The
       # memory backend has no on-disk lock, so concurrent same-image scans
-      # succeed. Requires trivy >=0.68.1 (chart default is 0.69.3).
+      # succeed. Requires trivy >=0.68.1 (chart 0.34.0 default is 0.72.0).
       configFile:
         cache:
           backend: memory

--- a/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     spec:
       chart: trivy-operator
-      version: 0.32.1
+      version: 0.34.0
       sourceRef:
         kind: HelmRepository
         name: trivy-operator-repo


### PR DESCRIPTION
## Summary

- Bump trivy-operator Helm chart `0.32.1` → `0.34.0` (operator app 0.30.1 → 0.32.0).
- The bundled trivy scanner default moves 0.69.3 → 0.72.0 (we don't pin it in values, so the chart default applies; image tag verified present on mirror.gcr.io).
- Updated the stale scanner-version comment in `configmap.yaml`.

## Why

The remaining intermittent `BackoffLimitExceeded` scan-job failures in trivy-system are a trivy shared-`/tmp` temp-dir race on multi-container workload pods (one trivy process per container in a single scan pod; non-unique work dirs under `/tmp` mean one container's cleanup can yank a sibling's dir mid-scan). Newer trivy reduces this noise; failures are already self-healing (operator retries and reports stay populated), so this is cleanup, not a fix for missing data.

Reviewed release notes for v0.31.0 and v0.32.0 — no breaking changes, deprecations, or migration notes. Our values keys (`operator.scanJobsConcurrentLimit`, `operator.scanJobTolerations`, `trivy.configFile` memory cache backend, `nodeCollector.tolerations`) are unchanged in 0.34.0.

Note: Renovate had already detected this update — it's queued in the Dependency Dashboard's rate-limited section behind the 8 open Renovate PRs (#906–#915). This PR supersedes that queued entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BPawfDCK5RTFcXQ9BVtzG