### PR TITLE
chore(resources): raise CPU limits on 9 persistently throttled workloads

### DIFF
--- a/clusters/vollminlab-cluster/clusterwide/disk-cleanup-cronjob.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/disk-cleanup-cronjob.yaml
@@ -67,7 +67,7 @@ spec:
                   cpu: 50m
                   memory: 64Mi
                 limits:
-                  cpu: 200m
+                  cpu: 500m
                   memory: 128Mi
           restartPolicy: OnFailure
       backoffLimit: 3

--- a/clusters/vollminlab-cluster/homepage/homepage/app/pihole-watchdog-cronjob.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/pihole-watchdog-cronjob.yaml
@@ -169,7 +169,7 @@ spec:
                   cpu: 10m
                   memory: 32Mi
                 limits:
-                  cpu: 100m
+                  cpu: 200m
                   memory: 64Mi
           volumes:
             - name: script

--- a/clusters/vollminlab-cluster/kube-system/etcd-defrag/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/kube-system/etcd-defrag/app/cronjob.yaml
@@ -53,5 +53,5 @@ spec:
                   cpu: 10m
                   memory: 32Mi
                 limits:
-                  cpu: 50m
+                  cpu: 200m
                   memory: 64Mi

--- a/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/cronjob.yaml
@@ -51,7 +51,8 @@ spec:
                   cpu: 10m
                   memory: 32Mi
                 limits:
-                  cpu: 100m
+                  # 98% CFS throttling at 100m — the healer must react fast during mount incidents
+                  cpu: 300m
                   memory: 64Mi
           volumes:
             - name: script

--- a/clusters/vollminlab-cluster/mediastack/bazarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr/app/configmap.yaml
@@ -61,5 +61,5 @@ data:
         cpu: 100m
         memory: 256Mi
       limits:
-        cpu: 500m
+        cpu: 1000m
         memory: 768Mi

--- a/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
@@ -45,11 +45,11 @@ data:
               topologyKey: kubernetes.io/hostname
     resources:
       requests:
-        # VPA target ~35m / upperBound ~50m. Request 100m→50m. Limit unchanged (500m).
+        # VPA target ~35m / upperBound ~50m. Request 100m→50m.
         cpu: 50m
         memory: 256Mi
       limits:
-        cpu: 500m
+        cpu: 1000m
         memory: 512Mi
     podLabels:
       app: readarr

--- a/clusters/vollminlab-cluster/monitoring/b2-exporter/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/monitoring/b2-exporter/app/deployment.yaml
@@ -48,5 +48,5 @@ spec:
               cpu: 10m
               memory: 64Mi
             limits:
-              cpu: 250m
+              cpu: 500m
               memory: 128Mi

--- a/clusters/vollminlab-cluster/monitoring/vmware-exporter/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/vmware-exporter/app/configmap.yaml
@@ -25,7 +25,8 @@ data:
         cpu: 100m
         memory: 128Mi
       limits:
-        cpu: 400m
+        # 23% avg CFS throttling at 400m (bursty scrapes) — sole recurring CPUThrottlingHigh source
+        cpu: 800m
         memory: 256Mi
 
     service:

--- a/clusters/vollminlab-cluster/renovate/renovate/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/renovate/renovate/app/configmap.yaml
@@ -32,7 +32,7 @@ data:
         cpu: 200m
         memory: 512Mi
       limits:
-        cpu: 1000m
+        cpu: 2000m
         memory: 1536Mi
 
     envFrom:


### PR DESCRIPTION
## Why

7-day CFS throttle-ratio analysis (`container_cpu_cfs_throttled_periods_total / container_cpu_cfs_periods_total`) found nine repo-managed workloads persistently throttled. All have tiny average usage but bursty profiles that hit the per-100ms CFS quota — so throttle ratios run 16–98% while p99 usage sits far below the limit.

This is also the source of the recurring CPU-throttling Pushover alerts: the stock `CPUThrottlingHigh` rule (severity=info, routed via the default Pushover receiver) has fired exclusively for **vmware-exporter** over the past 7 days. Raising its limit fixes the alert at the source instead of muting the route.

## What

Limits only — requests untouched, so the #928 right-sizing and scheduling capacity are unaffected.

| Workload | 7d throttle | Limit |
|---|---|---|
| kube-system/longhorn-mount-healer | 97.7% | 100m → 300m |
| kube-system/disk-cleanup | 83.8% | 200m → 500m |
| kube-system/etcd-defrag | 82.9% | 50m → 200m |
| monitoring/vmware-exporter | 23.3% | 400m → 800m |
| monitoring/b2-exporter | 21.1% | 250m → 500m |
| homepage/pihole-watchdog | 25% | 100m → 200m |
| renovate/renovate | 25.3% | 1000m → 2000m |
| mediastack/bazarr | 20.8% | 500m → 1000m |
| mediastack/readarr | 15.9% | 500m → 1000m |

Not included: longhorn-system `trim` (41%, Longhorn-managed RecurringJob pod — limits not set from this repo) and trivy-system scan jobs (transient, never sustain long enough to alert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BPawfDCK5RTFcXQ9BVtzG