### PR TITLE
docs(cluster-reference): update disk-cleanup CPU limit after #933

### DIFF
--- a/docs/cluster-reference.md
+++ b/docs/cluster-reference.md
@@ -182,7 +182,7 @@ All volumes are `ReadWriteMany`, `100Gi`, backed by SMB shares at `192.168.150.2
 | Schedule | `0 2 * * *` (2 AM daily) |
 | Image | `alpine/k8s:1.30.3` |
 | Tasks | Delete evicted pods; delete completed/failed pods older than 1 hour |
-| CPU | req: 50m, limits: 200m |
+| CPU | req: 50m, limits: 500m |
 | Memory | req: 64Mi, limits: 128Mi |
 
 ---


### PR DESCRIPTION
PR #933 raised the disk-cleanup CronJob CPU limit 200m → 500m (it was 83.8% CFS-throttled at the old limit). This syncs the one stale row in `docs/cluster-reference.md`. None of the other eight #933 workloads have CPU rows in this doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BPawfDCK5RTFcXQ9BVtzG