### PR TITLE
fix(monitoring): spread heavy monitoring pods across workers via soft anti-affinity

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -37,6 +37,23 @@ data:
             env: production
             category: observability
         evaluationInterval: 2m
+        # Soft spread of the heavy monitoring set — see victoria-metrics values
+        # for rationale (all heavy monitoring pods were stacked on k8sworker02).
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchExpressions:
+                      - key: app.kubernetes.io/name
+                        operator: In
+                        values:
+                          - prometheus
+                          - loki
+                          - grafana
+                          - victoria-metrics-single
         resources:
           requests:
             cpu: 500m
@@ -77,6 +94,23 @@ data:
         app: grafana
         env: production
         category: observability
+      # Soft spread of the heavy monitoring set — see victoria-metrics values
+      # for rationale (all heavy monitoring pods were stacked on k8sworker02).
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                        - prometheus
+                        - loki
+                        - grafana
+                        - victoria-metrics-single
       grafana.ini:
         feature_toggles:
           kubernetesDashboards: false

--- a/clusters/vollminlab-cluster/monitoring/loki/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/loki/app/configmap.yaml
@@ -56,6 +56,26 @@ data:
     singleBinary:
       replicas: 1
 
+      # Soft spread of the heavy monitoring set — see victoria-metrics values for
+      # rationale (all heavy monitoring pods were stacked on k8sworker02). This
+      # overrides the chart's default hard self-anti-affinity, which is moot at
+      # replicas: 1; loki is included in the In-list below instead.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                        - prometheus
+                        - loki
+                        - grafana
+                        - victoria-metrics-single
+
       extraEnv:
         - name: AWS_ACCESS_KEY_ID
           valueFrom:

--- a/clusters/vollminlab-cluster/monitoring/victoria-metrics/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/victoria-metrics/app/configmap.yaml
@@ -36,6 +36,27 @@ data:
         env: production
         category: observability
 
+      # Soft spread of the heavy monitoring set (prometheus, loki, grafana, both
+      # VM tiers via app.kubernetes.io/name=victoria-metrics-single). All of
+      # these were stacked on k8sworker02 → NodeMemoryMajorPagesFaults thrash +
+      # backup-window IO concentration. Preferred, not required: 5 heavy pods on
+      # 4 general workers (vm-lt pinned to w01) — a hard rule could not schedule.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                        - prometheus
+                        - loki
+                        - grafana
+                        - victoria-metrics-single
+
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
## Problem

Every heavy monitoring pod is currently on **k8sworker02**: prometheus, loki, victoria-metrics (hot tier), grafana, plus alertmanager-2, kube-state-metrics, and the vmware/b2 exporters. Consequences:

- `NodeMemoryMajorPagesFaults` firing on w02 — 632 majfaults/s vs the 500 threshold, node at 86% of 11.7 GiB, min 1.25 GiB available.
- Backup-window IO concentrates on one node — w02 is the worst PSI offender in the nightly 3–4:30am stall (84% peak) and the node that flaps NotReady under pressure.

Nothing keeps the scheduler from re-stacking these pods; this PR adds a preference against it.

## Change

The same weight-100 **preferred** (soft) `podAntiAffinity` block added in four places across three values ConfigMaps:

| File | Values path |
|------|-------------|
| `kube-prometheus-stack/app/configmap.yaml` | `prometheus.prometheusSpec.affinity` |
| `kube-prometheus-stack/app/configmap.yaml` | `grafana.affinity` |
| `loki/app/configmap.yaml` | `singleBinary.affinity` |
| `victoria-metrics/app/configmap.yaml` | `server.affinity` |

Selector: `app.kubernetes.io/name In (prometheus, loki, grafana, victoria-metrics-single)`, topology `kubernetes.io/hostname`.

## Design notes

- **Why `app.kubernetes.io/name`:** the only label uniform across all four charts. The victoria-metrics chart forces `app=server` on its pods (chart selector labels beat `podLabels`), so our `app` label is unusable. Verified live on all five heavy pods.
- **`victoria-metrics-single` matches both VM tiers** (hot + vm-lt). vm-lt is pinned to k8sworker01 by its local PV and gets no affinity of its own, but being in the In-list means the other pods softly avoid w01 too — which is what we want (w01 is the hot Longhorn node).
- **Soft, not hard:** 5 heavy pods, 4 general workers → a `required` rule could leave one unschedulable.
- **Loki:** overrides the chart's default *hard* self-anti-affinity, which is a no-op at `replicas: 1`.
- Alertmanager replicas, KSM, and exporters are too small to be worth including.

## Rollout

Post-merge, Flux redeploys the four workloads and the scheduler spreads them. STS updates delete-before-create, so no RWO Multi-Attach; grafana's Deployment is already `strategy: Recreate`. Since only ConfigMaps change, a `flux reconcile helmrelease` per release (or waiting for the next drift detection) may be needed to trigger the rollout promptly. Expect a brief restart of prometheus, loki, grafana, and victoria-metrics.

This is also the pre-positioned next lever if tonight's #929 kopia-throttle run doesn't clear the backup-window PSI bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BPawfDCK5RTFcXQ9BVtzG