### PR TITLE
fix(monitoring): make Velero warning alerts self-resolve after recovery

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -86,7 +86,10 @@ spec:
             severity: warning
           annotations:
             summary: "Velero daily-full has had no successful backup in 26 hours"
-            description: "Last fully-successful daily-full backup was {{ $value | humanizeDuration }} ago — the nightly run failed, partially failed, or never ran. Check 'velero backup get'. Resolves on the next Completed backup."
+            description: >-
+              Last fully-successful daily-full backup was {{ $value | humanizeDuration }} ago —
+              the nightly run failed, partially failed, or never ran. Check 'velero backup get'.
+              Resolves on the next Completed backup.
 
         # last_status is 0 only when the most recent backup outright Failed (PartiallyFailed
         # reports 1). Gauge-based, so it resolves as soon as any later run does better —

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -70,37 +70,38 @@ spec:
         # velero_backup_last_successful_timestamp is a stable gauge — immune to pod restarts.
         # increase(velero_backup_attempt_total[26h]) was used previously but fires false positives
         # after any Velero pod restart (counter resets to 0, increase() returns 0 for the window).
-        - alert: VeleroBackupNotAttempted
+        # This alert also covers Failed/PartiallyFailed runs, not just missing ones: the
+        # timestamp only advances on a fully-Completed backup, so any bad nightly run leaves
+        # it stale and this fires ~2h after the failed 03:00 run. It self-resolves on the
+        # next Completed backup. There is deliberately no separate PartiallyFailed alert —
+        # the old increase(velero_backup_partial_failure_total[26h]) form kept firing for a
+        # full 26h after one bad run even when a later run succeeded, and there is no
+        # per-run gauge to key on instead (velero_backup_last_status reports 1 for
+        # PartiallyFailed — verified live 2026-07-19).
+        - alert: VeleroBackupNotSucceeding
           expr: |
             time() - velero_backup_last_successful_timestamp{schedule="velero-daily-full"} > 26 * 3600
           for: 30m
           labels:
             severity: warning
           annotations:
-            summary: "Velero daily-full backup has not run in 26 hours"
-            description: "Last successful daily-full backup was {{ $value | humanizeDuration }} ago. Check the Velero schedule."
+            summary: "Velero daily-full has had no successful backup in 26 hours"
+            description: "Last fully-successful daily-full backup was {{ $value | humanizeDuration }} ago — the nightly run failed, partially failed, or never ran. Check 'velero backup get'. Resolves on the next Completed backup."
 
+        # last_status is 0 only when the most recent backup outright Failed (PartiallyFailed
+        # reports 1). Gauge-based, so it resolves as soon as any later run does better —
+        # unlike a counter increase() lookback, it never keeps alerting after recovery.
         - alert: VeleroBackupFailed
           expr: |
-            increase(velero_backup_failure_total{schedule="velero-daily-full"}[26h]) > 0
+            velero_backup_last_status{schedule="velero-daily-full"} == 0
           for: 15m
           labels:
             severity: warning
           annotations:
             summary: "Velero daily-full backup failed"
-            description: "A daily-full backup has Failed in the last 26 hours. Check velero backup get."
+            description: "The most recent daily-full backup Failed outright. Check 'velero backup get'. Resolves on the next non-Failed run."
 
-        - alert: VeleroBackupPartiallyFailed
-          expr: |
-            increase(velero_backup_partial_failure_total{schedule="velero-daily-full"}[26h]) > 0
-          for: 15m
-          labels:
-            severity: warning
-          annotations:
-            summary: "Velero daily-full backup partially failed"
-            description: "A daily-full backup has PartiallyFailed in the last 26 hours. Check velero backup describe."
-
-        # Escalation guard. VeleroBackupNotAttempted/PartiallyFailed are warnings that can be
+        # Escalation guard. VeleroBackupNotSucceeding/VeleroBackupFailed are warnings that can be
         # tolerated for days — on 2026-07-02 a wedged InProgress backup left daily-full
         # PartiallyFailed for 4 days, silently pinning kopia blocks (maintenance can't GC an
         # in-use snapshot) until MinIO hit 100%. This fires critical when NO fully-successful


### PR DESCRIPTION
## Summary

The Velero warning alerts `VeleroBackupFailed` / `VeleroBackupPartiallyFailed` used `increase(velero_backup_*_total[26h]) > 0` counter lookbacks. One bad nightly run kept them firing for the full 26 hours **even after a later run succeeded** — pure noise once the schedule had recovered. Tonight's `daily-full` PartiallyFailed (radarr PVB lost to the k8sworker02 flap) would have nagged all day regardless of a clean re-run.

## Changes

- **`VeleroBackupNotAttempted` → `VeleroBackupNotSucceeding`** — expression unchanged (`time() - velero_backup_last_successful_timestamp > 26h`, restart-immune), but renamed and re-described for what it actually catches: the timestamp only advances on a fully-**Completed** backup, so a Failed/PartiallyFailed nightly run also trips it (~2h after the 03:00 run) and it self-resolves on the next Completed backup.
- **`VeleroBackupFailed`** — now gauge-based: `velero_backup_last_status{schedule="velero-daily-full"} == 0`. Fires promptly on an outright Failed run and resolves as soon as a later run does better.
- **`VeleroBackupPartiallyFailed`** — removed. There is no per-run gauge that distinguishes partial failure (`velero_backup_last_status` reports **1** for PartiallyFailed — verified live against tonight's PartiallyFailed backup), and the counter form can't self-resolve. Partial failures are covered by `VeleroBackupNotSucceeding` (warning, ~2h) and `VeleroBackupPersistentlyFailing` (critical, 72h), both unchanged.

Net effect: one warning per bad night that goes quiet on recovery, with the 72h critical escalation as the safety net — no more day-long stale Velero alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BPawfDCK5RTFcXQ9BVtzG