### PR TITLE
fix(monitoring): disable chart podAntiAffinity preset colliding with explicit prometheus affinity

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -37,6 +37,12 @@ data:
             env: production
             category: observability
         evaluationInterval: 2m
+        # Disable the chart's default podAntiAffinity: "soft" preset — the template
+        # appends it under the same affinity: key as the explicit block below,
+        # rendering a duplicate podAntiAffinity mapping key that fails post-render
+        # (broke the 86.3.2 upgrade when the block below merged). The explicit
+        # block already matches prometheus itself, so self-spread is kept.
+        podAntiAffinity: ""
         # Soft spread of the heavy monitoring set — see victoria-metrics values
         # for rationale (all heavy monitoring pods were stacked on k8sworker02).
         affinity:


### PR DESCRIPTION
## Problem

Since #935 merged, the kube-prometheus-stack HelmRelease is **UpgradeFailed**. Chart 86.3.2 defaults `prometheusSpec.podAntiAffinity: "soft"`, and the chart template appends that preset under the same rendered `affinity:` key as our explicit `prometheusSpec.affinity` block. The rendered Prometheus CR ends up with a duplicate `podAntiAffinity` mapping key, and Flux's kustomize post-render rejects it:

```
mapping key "podAntiAffinity" already defined at line 101
```

The cluster is unaffected in the meantime — helm revision 62 (86.3.2, pre-#935 values) is still deployed — but the #935 spread never rolled out to prometheus/grafana.

## Fix

Set `prometheusSpec.podAntiAffinity: ""` to disable the chart preset. Our explicit block already includes a self-match on `prometheus`, so prometheus self-spread is preserved; grafana's block is unaffected (no chart preset there).

Verified by local `helm template` render against 86.3.2 with the exact edited configmap values: zero documents with duplicate `podAntiAffinity` keys, spread block intact in the Prometheus CR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BPawfDCK5RTFcXQ9BVtzG