### PR TITLE
fix(longhorn): move rebalancer maintenance window out of backup window

### DIFF
--- a/clusters/vollminlab-cluster/longhorn-system/longhorn-rebalancing-controller/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn-rebalancing-controller/app/configmap.yaml
@@ -22,6 +22,12 @@ data:
       rebalance:
         maxEvictionsPerDay: 4
         smallestFirst: false
+        # Keep evictions out of the nightly backup window (VolSync 00:00-02:00,
+        # daily-full 03:00, daily-b2 04:00, vm-b2 05:00) — the chart default
+        # 02:00-05:00 sat exactly on top of it, and with smallestFirst:false a
+        # 77GiB MinIO replica rebuild collapsed under the contention on
+        # 2026-07-20 (~02:30), degrading the volume right before daily-full.
+        maintenanceWindow: "13:00-19:00"
 
     resources:
       requests:


### PR DESCRIPTION
## Summary

The rebalancer's chart-default `maintenanceWindow: 02:00-05:00` sits directly on top of the nightly backup window (VolSync 00:00–02:00, daily-full 03:00, daily-b2 04:00, vm-b2 05:00). Since #926 flipped `smallestFirst: false`, it moves the **largest** replicas first — and on 2026-07-20 it ran two back-to-back evictions of MinIO's 77GiB replica at 02:00 and 02:29. The second rebuild's file sync died mid-transfer (`error reading from server: EOF`) under the shared-pool contention, leaving the volume **degraded** minutes before daily-full kicked off.

This overrides the window to `13:00-19:00` UTC — the pool's idle hours — so replica rebuild I/O can never compete with the backup window again.

No other knobs changed: `maxEvictionsPerDay: 4` and `smallestFirst: false` stay as set in #926.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BPawfDCK5RTFcXQ9BVtzG