### PR TITLE
chore: gitignore .superpowers/ runtime scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Claude Code runtime artifacts
 .codex
+.superpowers/
 .worktrees/
 session-report-*.html
 .claude/scheduled_tasks.lock


### PR DESCRIPTION
The superpowers plugin writes brainstorm-session runtime state (server pids/logs) to `.superpowers/`, which shows up as permanent untracked noise in `git status`. Add it to the Claude Code runtime artifacts block in `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqQeYGKWckXNvihCV4D3Cz