### PR TITLE
fix(qbittorrent): switch gluetun DNS to DoH to stop UDP socket leak OOM crash-loop

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
@@ -94,7 +94,7 @@ spec:
               memory: 128Mi
             limits:
               cpu: 200m
-              memory: 256Mi
+              memory: 512Mi
           env:
             - name: VPN_SERVICE_PROVIDER
               value: "private internet access"
@@ -106,6 +106,10 @@ spec:
               value: "on"
             - name: FIREWALL_INPUT_PORTS
               value: "8080"
+            # DoT upstream in gluetun v3.41.x leaks UDP sockets when queries time out
+            # during VPN degradation (upstream #3351/#3377) — DoH is the endorsed workaround
+            - name: DNS_UPSTREAM_RESOLVER_TYPE
+              value: "doh"
           envFrom:
             - secretRef:
                 name: qbittorrent-pia-credentials


### PR DESCRIPTION
## Problem

`PodCrashLooping` + `CPUThrottlingHigh` firing on `mediastack/qbittorrent`. The **gluetun** sidecar is being repeatedly OOMKilled (exit 137) at its 256Mi limit, with CPU pinned at the 200m limit.

## Root cause (measured live)

gluetun v3.41.1's rewritten in-house DNS forwarder **leaks connected UDP client sockets** when upstream DoT queries time out:

- ~7,000 open UDP sockets in the gluetun process, all `127.0.0.1:ephemeral → 127.0.0.1:53` (its own DNS server), growing at ~40 fds/sec
- Loopback UDP storm ~4–8k pkts/s; qbittorrent-nox itself is innocent (50 fds, ~0 traffic, idle torrents)
- Memory flat at ~65MiB for 10 days → linear leak from ~17:45 UTC 2026-07-20 → first OOM ~03:47 UTC 2026-07-21; replacement containers leak faster because the trigger persists
- Trigger: PIA CA-Montreal instability (dead server TLS timeouts, all public-IP fetchers timing out) → healthcheck (`cloudflare.com:443,github.com:443`, amplified by cluster search domains) retries DNS in a hot loop over the degraded DoT upstream

Matches upstream passteque/gluetun **#3351** ("RAM maxed out overnight" on v3.41.1, open) and **#3377** ("Using dot results in a VPN restart loop (doh works)") — the endorsed workaround is switching the upstream resolver to DoH.

## Change

- `DNS_UPSTREAM_RESOLVER_TYPE: doh` — sidesteps the DoT timeout/leak path (verified against gluetun wiki; default is `dot`)
- gluetun memory limit 256Mi → 512Mi — headroom so a transient VPN flap doesn't OOM the sidecar before it recovers (steady state is ~65MiB; crash-loop alerting still fires if the leak ever recurs)

If it recurs even on DoH, the next lever is `HEALTH_TARGET_ADDRESSES` with IP:port targets to remove DNS from the healthcheck loop entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hbveaNcLBSCnVAoZrhPtC