### PR TITLE
chore(longhorn): bump rebalancing controller to 0.2.0 (destination guards)

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/longhorn-rebalancing-controller-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/longhorn-rebalancing-controller-ocirepository.yaml
@@ -11,6 +11,6 @@ spec:
   interval: 1h
   url: oci://harbor.vollminlab.com/vollminlab/charts/longhorn-rebalancing-controller
   ref:
-    tag: "0.1.3"
+    tag: "0.2.0"
   secretRef:
     name: harbor-vollminlab-pull


### PR DESCRIPTION
Bumps the `longhorn-rebalancing-controller` OCIRepository chart tag 0.1.3 → 0.2.0.

Picks up [controller PR #6](https://github.com/vollminlab/longhorn-rebalancing-controller/pull/6) (merged, tagged `v0.2.0`, image + chart published to Harbor and verified pullable):

- **Anti-affinity-aware destination modeling** — nodes holding a replica of the same volume are no longer counted as rebuild destinations
- **No-flip guard** — a move must leave the destination no hotter than the source it drained
- **Free-disk floor** — destination must retain ≥ `minDestinationFreePct` (default 25%) actual free disk after absorbing the replica

Root cause of the 2026-07-21 w04 NodeDiskSpaceLow ping-pong. New config knob `minDestinationFreePct` uses the chart default (25); no values ConfigMap change needed. Runtime config hot-reloads — no pod restart required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hbveaNcLBSCnVAoZrhPtC