### PR TITLE
feat(harbor): schedule weekly registry garbage collection

### DIFF
--- a/terraform/harbor/gc.tf
+++ b/terraform/harbor/gc.tf
@@ -1,0 +1,13 @@
+# Weekly registry garbage collection. GC has to be scheduled explicitly —
+# without it every overwritten proxy-cache tag and re-pushed CI tag leaks
+# blobs forever (2026-07-22: the 5Gi registry PVC hit 91% with ~2.8Gi of
+# orphans; a manual GC with these same parameters freed 3.5GB).
+# Harbor v2.1+ GC is online/non-blocking, so running during active work is
+# safe. Slot: Saturday 05:00 UTC — clear of VolSync (00-02), Velero (02-04)
+# and the Longhorn rebalancer window (13-19). Harbor cron is 6-field
+# (seconds first).
+resource "harbor_garbage_collection" "weekly" {
+  schedule        = "0 0 5 * * 6"
+  delete_untagged = true
+  workers         = 1
+}


### PR DESCRIPTION
## Why

Harbor GC has **never run** on this cluster — no schedule, empty GC history. Every overwritten proxy-cache tag and re-pushed CI tag has leaked blobs since the registry PVC was created. On 2026-07-22 the (intentionally sized) 5Gi registry PVC hit 91% with ~2.8Gi of orphaned blobs and fired a disk alert. A manual GC with these exact parameters freed **3.5GB** (382 blobs, 98 manifests), dropping usage to 24%.

## What

Adds a `harbor_garbage_collection` resource to the tofu-managed Harbor config:

- **Schedule:** Saturdays 05:00 UTC (`0 0 5 * * 6` — Harbor cron is 6-field, seconds first)
- **`delete_untagged = true`**, **`workers = 1`** — matches the validated manual run
- Slot avoids VolSync (00–02), Velero (02–04), and the Longhorn rebalancer window (13–19 UTC)

Harbor v2.1+ GC is online/non-blocking (concurrent pushes are protected by a time-window), so a run during active work is safe.

## Rollout

`tofu-controller` (`harbor-config` Terraform CR, `approvePlan: auto`, 10m interval) applies this automatically after merge. Verify afterwards with `GET /api/v2.0/system/gc/schedule` showing the cron, and the first run appearing in GC history next Saturday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015V8prwpMFKDYjhCYj1chwH