### PR TITLE
fix(harbor): drop duplicate app podLabel that broke exporter post-render

### DIFF
--- a/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
@@ -111,9 +111,10 @@ data:
 
     # The exporter deployment template only applies exporter.podLabels — the global
     # podLabels below does not reach it, so the Kyverno-required labels must be set here.
+    # Do NOT add `app` — the chart's harbor.labels helper already emits app: "harbor"
+    # on the pod template; repeating it is a duplicate YAML key that fails Flux post-render.
     exporter:
       podLabels:
-        app: harbor
         env: production
         category: storage
       resources:


### PR DESCRIPTION
## What

Removes `app: harbor` from `exporter.podLabels` in the Harbor values ConfigMap. Keeps `env` and `category`.

## Why

PR #960 enabled the Harbor metrics exporter and set `exporter.podLabels: {app, env, category}` for Kyverno. The chart's `harbor.labels` helper already emits `app: "harbor"` on the exporter pod template, so the extra `app` key rendered a duplicate YAML mapping key and the Helm upgrade failed at Flux post-render:

```
Helm upgrade failed for release harbor/harbor with chart harbor@1.19.1:
error while running post render on manifests:
... line 44: mapping key "app" already defined at line 36
```

The failure happened before anything was applied — the live Harbor release is unchanged and serving normally. Kyverno's required `app` label stays satisfied by the chart's own `app: harbor`; the chart does not set `env`/`category`, so those remain in `exporter.podLabels`.

CI didn't catch this because manifest/Kyverno validation doesn't render the Helm chart through the post-renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015V8prwpMFKDYjhCYj1chwH