### PR TITLE
chore(ci): canary for #963 validation paths — DO NOT MERGE

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -546,11 +546,21 @@ jobs:
           TEST_NAMESPACE="ci-test-${{ env.RUN_SUFFIX }}"
           echo "TEST_NAMESPACE=$TEST_NAMESPACE" >> $GITHUB_ENV
 
-          kubectl create namespace "$TEST_NAMESPACE" || true
           # Kyverno mutate policies do apiCall lookups on namespace labels —
-          # an unlabeled test namespace fails the fail-closed webhook.
-          kubectl label namespace "$TEST_NAMESPACE" \
-            app=ci-test env=production category=core --overwrite
+          # an unlabeled test namespace fails the fail-closed webhook. Labels
+          # must be set at creation time: the runner ServiceAccount can create
+          # and delete namespaces but not patch them, so kubectl label is
+          # forbidden.
+          kubectl create -f - <<EOF
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: $TEST_NAMESPACE
+            labels:
+              app: ci-test
+              env: production
+              category: core
+          EOF
           echo "✅ Created test namespace: $TEST_NAMESPACE"
 
           # Pre-create Harbor pull secret so OCIRepositories with secretRef can authenticate.
@@ -1168,7 +1178,6 @@ jobs:
             --cache-dir "${{ env.TRIVY_CACHE_DIR }}" \
             --skip-files "*.log,*.tmp,*.cache,node_modules/*,.git/*" \
             --timeout 60s \
-            --skip-db-update \
             "$SCAN_DIR" || {
             echo "⚠️ Trivy filesystem scan timed out or failed"
             echo '{"version": "2.1.0", "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json", "runs": [{"tool": {"driver": {"name": "Trivy", "version": "timeout"}}, "results": []}]}' > trivy-results.sarif
@@ -1182,7 +1191,6 @@ jobs:
             --severity HIGH,CRITICAL \
             --cache-dir "${{ env.TRIVY_CACHE_DIR }}" \
             --timeout 60s \
-            --skip-db-update \
             "$SCAN_DIR" || {
             echo "⚠️ Trivy config scan timed out or failed"
             echo '{"version": "2.1.0", "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json", "runs": [{"tool": {"driver": {"name": "Trivy", "version": "timeout"}}, "results": []}]}' > trivy-config-results.sarif
@@ -1204,10 +1212,14 @@ jobs:
         run: |
           set -euo pipefail
           echo "📦 Installing GitHub CLI..."
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-          sudo apt update
-          sudo apt install gh -y
+          # Static release tarball instead of apt — apt hangs on these
+          # ephemeral ARC runners (same failure mode as the yamllint install,
+          # canary PR #964).
+          GH_VERSION=2.76.1
+          timeout 90 curl -fsSL -o /tmp/gh.tar.gz \
+            "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz"
+          tar -xzf /tmp/gh.tar.gz -C /tmp
+          sudo mv "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh
           gh --version
 
       - name: Upload Trivy SARIF results with retry

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -221,13 +221,18 @@ jobs:
           set -euo pipefail
           echo "🔍 Validating YAML syntax with yamllint..."
 
-          # Self-hosted runner persists packages — only install when missing.
-          # Unconditional apt-get update here once ate the whole 5-minute job
-          # timeout on slow mirrors (canary PR #964).
-          if ! command -v yamllint >/dev/null; then
-            sudo apt-get update
-            sudo apt-get install -y yamllint
-          fi
+          # ARC runners are ephemeral pods — nothing persists between runs, so
+          # yamllint must be installed every time. apt-get hung after fetching
+          # package lists on two consecutive runs (canary PR #964), eating the
+          # whole job timeout, so install via pip instead. The runner image
+          # ships python3 without pip/ensurepip, hence the get-pip bootstrap.
+          # timeout guards make a hung download fail fast instead of stalling
+          # the job to its timeout.
+          timeout 90 curl -sSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
+          timeout 90 python3 /tmp/get-pip.py --user --break-system-packages --quiet
+          timeout 90 python3 -m pip install --user --break-system-packages --quiet yamllint
+          export PATH="$HOME/.local/bin:$PATH"
+          yamllint --version
 
           # Create yamllint config for Kubernetes files
           cat > .yamllint << 'EOF'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,9 +53,11 @@ env:
 
 jobs:
   validate-changes:
+    # timeout raised 5 → 10 after canary #964: first-run tool installs on a
+    # fresh runner can exceed 5 minutes
     name: Validate Kubernetes Manifests
     runs-on: vollminlab
-    timeout-minutes: 5
+    timeout-minutes: 10
     outputs:
       changed: ${{ steps.get-changed-files.outputs.changed }}
       changed_files: ${{ steps.get-changed-files.outputs.changed_files }}
@@ -219,9 +221,13 @@ jobs:
           set -euo pipefail
           echo "🔍 Validating YAML syntax with yamllint..."
 
-          # Install yamllint using system package (much faster than pip)
-          sudo apt-get update
-          sudo apt-get install -y yamllint
+          # Self-hosted runner persists packages — only install when missing.
+          # Unconditional apt-get update here once ate the whole 5-minute job
+          # timeout on slow mirrors (canary PR #964).
+          if ! command -v yamllint >/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y yamllint
+          fi
 
           # Create yamllint config for Kubernetes files
           cat > .yamllint << 'EOF'

--- a/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
@@ -115,6 +115,7 @@ data:
     # on the pod template; repeating it is a duplicate YAML key that fails Flux post-render.
     exporter:
       podLabels:
+        app: harbor
         env: production
         category: storage
       resources:

--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     app: homepage
     env: production
     category: apps
+# CI canary: exercises #963 render + closure paths — reverted before close
 data:
   values.yaml: |
     config:


### PR DESCRIPTION
Throwaway canary to exercise the new CI paths from #963 on a real cluster-file diff:

1. This commit: harmless comment in homepage values ConfigMap → expect **green** (closure pulls in helmrelease.yaml, render step templates homepage with real values, test deploy runs with original ConfigMap names).
2. A follow-up commit will re-introduce the exact #960 duplicate `app` podLabel on Harbor → expect **red at the render step**.

Will be closed unmerged after both checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015V8prwpMFKDYjhCYj1chwH