### PR TITLE
fix(ci): skip Ingress in supporting-resource test deploy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -878,9 +878,14 @@ jobs:
               # kyverno-cli validates these statically), Terraform (tf-controller
               # would run real tofu plans), Connector/ClusterSecretStore
               # (cluster-scoped — the namespace override has no effect, kubectl
-              # would apply them for real).
+              # would apply them for real). Ingress: the nginx admission webhook
+              # rejects any host+path already claimed by the live Ingress (which
+              # every existing app's ingress is), and a test Ingress has real
+              # side effects — external-dns creates DNS records from it and the
+              # shlink-ingress-controller mints a vollm.in slug. Static render,
+              # kubeconform, and Kyverno already validate Ingress manifests.
               case "$KIND" in
-                ClusterRole|ClusterRoleBinding|ClusterPolicy|ClusterPolicyReport|CustomResourceDefinition|Namespace|Node|PersistentVolume|StorageClass|ValidatingAdmissionWebhook|MutatingAdmissionWebhook|Kustomization|Role|RoleBinding|Policy|PolicyException|Terraform|Connector|ClusterSecretStore)
+                ClusterRole|ClusterRoleBinding|ClusterPolicy|ClusterPolicyReport|CustomResourceDefinition|Namespace|Node|PersistentVolume|StorageClass|ValidatingAdmissionWebhook|MutatingAdmissionWebhook|Kustomization|Role|RoleBinding|Policy|PolicyException|Terraform|Connector|ClusterSecretStore|Ingress)
                   echo "Skipping $KIND resource: $file"
                   continue
                   ;;


### PR DESCRIPTION
## Problem

Canary PR #964's Integration Test (run 29948413421) failed after #965 merged, in the supporting-resource test deploy:

```
❌ Failed to deploy: clusters/vollminlab-cluster/homepage/homepage/app/ingress.yaml
Error from server (BadRequest): admission webhook "validate.nginx.ingress.kubernetes.io" denied the request:
host "homepage.vollminlab.com" and path "/" is already defined in ingress homepage/homepage-ingress
```

This hits **every** PR whose app-unit closure includes an `ingress.yaml` for an existing app — the nginx admission webhook rejects any host+path already claimed by the live Ingress, regardless of namespace.

Test-deploying Ingresses is also actively unsafe in this cluster:
- **external-dns** watches Ingresses and would create real DNS records from a test copy
- **shlink-ingress-controller** would mint a real `vollm.in/<slug>` short URL from the annotation

## Fix

Add `Ingress` to the supporting-resource deploy skip-list. Ingress manifests remain fully validated by the static render step, kubeconform (schema), and Kyverno policy validation — the live test deploy added no signal, only false failures and side-effect risk.

One-line diff (plus comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015V8prwpMFKDYjhCYj1chwH
