### PR TITLE
feat: bump longhorn-rebalancing-controller 0.2.0 -> 0.3.0 (surge-move)

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/longhorn-rebalancing-controller-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/longhorn-rebalancing-controller-ocirepository.yaml
@@ -11,6 +11,6 @@ spec:
   interval: 1h
   url: oci://harbor.vollminlab.com/vollminlab/charts/longhorn-rebalancing-controller
   ref:
-    tag: "0.2.0"
+    tag: "0.3.0"
   secretRef:
     name: harbor-vollminlab-pull


### PR DESCRIPTION
Bumps the OCIRepository chart tag to 0.3.0 (controller repo PR vollminlab/longhorn-rebalancing-controller#7, tag `v0.3.0`).

v0.2.0's `evictionRequested` mechanism was canceled same-second by Longhorn's NodeController (100% cancel rate, zero data moved, ~350 GiB wasted rebuild I/O). v0.3.0 surge-moves instead: bump `numberOfReplicas` +1 → wait for the new replica healthy → controller deletes the source replica → restore spec. Daily cap counts only completed moves; aborts hit a separate `move.maxFailuresPerDay` (default 3). Chart 0.3.0 also widens RBAC (volumes +update/patch, replicas +delete) and adds `config.move.*` values — chart defaults are correct for this cluster, no values changes needed.

Verification: next 13:00–19:00 UTC maintenance window — expect w03/w04 (90.8% sched) to shed a replica to w02 with the source removed and the new replica healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015V8prwpMFKDYjhCYj1chwH