### PR TITLE
fix: bump longhorn-rebalancing-controller 0.3.0 -> 0.3.1 (volume merge-patch fix)

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/longhorn-rebalancing-controller-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/longhorn-rebalancing-controller-ocirepository.yaml
@@ -11,6 +11,6 @@ spec:
   interval: 1h
   url: oci://harbor.vollminlab.com/vollminlab/charts/longhorn-rebalancing-controller
   ref:
-    tag: "0.3.0"
+    tag: "0.3.1"
   secretRef:
     name: harbor-vollminlab-pull


### PR DESCRIPTION
## What

Bumps the `longhorn-rebalancing-controller` OCIRepository chart tag `0.3.0` → `0.3.1`.

## Why

v0.3.0 could never start a surge-move. At the first maintenance window (07-22 13:00 UTC), every surge attempt was denied by Longhorn's admission webhook — the controller's partial `LonghornVolumeSpec` type serialized spec without `size` on full-object Updates, which the `validator.longhorn.io` webhook read as a shrink from 100Gi to zero. v0.3.1 converts all four Volume writes in the move state machine to JSON merge patches carrying only `numberOfReplicas` + the move annotations.

Upstream fix: vollminlab/longhorn-rebalancing-controller#8 (merged, tag `v0.3.1` built).
Image `0.3.1` and chart `0.3.1` verified present in Harbor.

Today's maintenance window is open until 19:00 UTC — merging in time lets the first real surge-move run today (w03/w04 at ~91% shedding toward w02 at ~10%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015V8prwpMFKDYjhCYj1chwH