### PR TITLE
feat(minio): liveness probe + mount-healer integration

### DIFF
--- a/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/cronjob.yaml
@@ -31,7 +31,7 @@ spec:
               command: ["/bin/sh", "/scripts/heal.sh"]
               env:
                 - name: HEAL_NAMESPACES
-                  value: "mediastack monitoring harbor"
+                  value: "mediastack monitoring harbor minio"
                 - name: RESTART_THRESHOLD
                   value: "5"
                 - name: COOLDOWN_SECONDS

--- a/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh
+++ b/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh
@@ -4,7 +4,7 @@
 set -u
 
 # --- tunables (overridable via env in the CronJob) ---
-HEAL_NAMESPACES="${HEAL_NAMESPACES:-mediastack monitoring harbor}"
+HEAL_NAMESPACES="${HEAL_NAMESPACES:-mediastack monitoring harbor minio}"
 RESTART_THRESHOLD="${RESTART_THRESHOLD:-5}"
 COOLDOWN_SECONDS="${COOLDOWN_SECONDS:-21600}"
 DETACH_TIMEOUT_SECONDS="${DETACH_TIMEOUT_SECONDS:-180}"

--- a/clusters/vollminlab-cluster/minio/minio/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/minio/minio/app/helmrelease.yaml
@@ -20,3 +20,37 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: minio-values
+  # The minio/minio chart (5.4.0) templates no probes at all, so the pod stays
+  # Running 1/1 with 0 restarts even when /export is a dead, ext4-latched mount
+  # (2026-06-16 and 2026-07-24 both: a Longhorn replica fault severed the mount,
+  # the fs aborted, MinIO served 503 to every client for ~1h, nothing crashed).
+  # Inject a liveness probe via post-render since there is no values knob.
+  #
+  # /minio/health/cluster returns 503 on write-quorum loss. This is a single-drive
+  # (EC:0) deployment, so quorum loss == the whole store is unwritable == restart
+  # is always the right call (upstream reserves /cluster for readiness only because
+  # a multi-drive set can lose quorum mid-rebuild while still healthy — not us).
+  # A latched ext4 mount only clears on a pod-level remount, which a container
+  # restart alone does NOT do, so the failing probe turns the silent hang into a
+  # visible CrashLoopBackOff that the longhorn-mount-healer then remediates with
+  # scale-0 -> wait-detached -> scale-back (minio was added to its allowlist).
+  #
+  # failureThreshold 6 x periodSeconds 30 = 3 min of sustained quorum loss before
+  # a restart, well clear of a transient Longhorn engine reconnect (~8s).
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: minio
+            patch: |
+              - op: add
+                path: /spec/template/spec/containers/0/livenessProbe
+                value:
+                  httpGet:
+                    path: /minio/health/cluster
+                    port: 9000
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 6


### PR DESCRIPTION
## What

Two changes that convert MinIO's silent-storage-hang failure mode into an auto-healed one:

1. **Liveness probe** on `/minio/health/cluster:9000`, injected via HelmRelease `postRenderers` (the `minio/minio` 5.4.0 chart templates no probes and exposes no values knob for them).
2. **`minio` added to `longhorn-mount-healer`'s `HEAL_NAMESPACES`** (both the CronJob env and the script default, kept in sync).

## Why

MinIO here is single-drive (EC:0). When a Longhorn replica fault severs the `/export` mount, the ext4 fs aborts but the MinIO process keeps running **1/1 with 0 restarts** — it just returns 503 to every client (velero, terraform-state, CNPG backups, loki). This happened on **2026-06-16** and again **2026-07-24**, each time ~1h of silent write outage with nothing crashing or self-healing.

- `/minio/health/cluster` returns 503 on write-quorum loss. Single-drive means quorum loss = total outage = a restart is always the right call. (Upstream reserves `/cluster` for readiness only because a multi-drive set can lose quorum mid-rebuild while still healthy — not our topology.)
- A latched ext4 mount clears only on a **pod-level remount** (CSI NodeUnstage/NodeStage), which a plain container restart does **not** trigger. So the probe alone is not enough — it turns the silent hang into a visible `CrashLoopBackOff`, and the mount-healer then remediates with its proven `scale-0 -> wait-detached -> scale-back` runbook.

`failureThreshold: 6 x periodSeconds: 30` = 3 min of sustained quorum loss before restart, well clear of a transient Longhorn engine reconnect (~8s).

## Notes

- Detection already exists (`MinIODriveOffline` / `MinIODriveIOErrors` in `prometheusrule.yaml`, added after the 2026-06-16 incident) — this PR closes the **remediation** gap, not detection.
- No NetworkPolicy change needed: Calico permits kubelet->local-pod probe traffic under the namespace default-deny (verified against authentik-server, same pattern).
- minio Deployment is already `strategy: Recreate` with an RWO longhorn PVC, so it matches the healer's Deployment/RWO assumptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqmJaX2sTpXx314RGghNC
