### PR TITLE
fix(minio): allow Helm post-upgrade hook to reach MinIO API

### DIFF
--- a/.claude/rules/networkpolicy.md
+++ b/.claude/rules/networkpolicy.md
@@ -80,6 +80,7 @@ Keep this table current whenever a new NetworkPolicy namespace is added.
 | `authentik` | n/a (ingress target) | 8000 | CNPG instance status API | allow-cnpg-operator ingress |
 | `authentik` | n/a (egress target) | 7844 | Cloudflare tunnel edge (QUIC UDP + http2 TCP) | allow-external-egress egress |
 | `harbor` | n/a (ingress target) | 8000 | CNPG instance status API | allow-cnpg-operator ingress |
+| `minio` | `minio` | 9000 | S3 API — reached by the Helm post-upgrade hook pod (`app: minio-job`) to create buckets/users | allow-post-job-egress (from hook) + allow-post-job-ingress (to minio); intra-namespace |
 | `tofu` | n/a (egress target → mediastack) | 7878/8989/8787/9696 | radarr/sonarr/readarr/prowlarr API (arr Terraform providers) | allow-mediastack-arr-egress egress |
 | `tofu` | n/a (egress target → harbor) | 8443 | Harbor API; svc 443→**8443**, egress evaluated post-DNAT so 443 ≠ enough | allow-harbor-egress egress |
 

--- a/clusters/vollminlab-cluster/minio/networkpolicies/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/minio/networkpolicies/networkpolicy.yaml
@@ -205,3 +205,58 @@ spec:
     - ports:
         - protocol: TCP
           port: 443
+---
+# Allow the Helm post-upgrade hook Job (minio-post-job) to reach the MinIO API on
+# 9000 to create buckets/users/policies. The ephemeral hook pod carries app=minio-job,
+# which no cross-namespace allow rule covers, and default-deny-all blocks intra-namespace
+# pod-to-pod in both directions. Without this the hook's mc client times out dialing
+# minio:9000 and the HelmRelease upgrade is marked failed even though MinIO is healthy
+# (surfaced on the first upgrade after PR #970, the first in ~2 months).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-post-job-egress
+  namespace: minio
+  labels:
+    app: minio
+    env: production
+    category: security
+spec:
+  podSelector:
+    matchLabels:
+      app: minio-job
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: minio
+      ports:
+        - protocol: TCP
+          port: 9000
+---
+# Companion ingress: MinIO must accept the hook pod's connection on the API port.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-post-job-ingress
+  namespace: minio
+  labels:
+    app: minio
+    env: production
+    category: security
+spec:
+  podSelector:
+    matchLabels:
+      app: minio
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: minio-job
+      ports:
+        - protocol: TCP
+          port: 9000


### PR DESCRIPTION
## Problem

Merging #970 (MinIO liveness probe) triggered MinIO's first Helm upgrade in ~2 months. The upgrade's post-hook Job `minio-post-job` runs `mc` against `http://minio:9000` to create buckets/users/policies, but it hangs and times out — marking the whole HelmRelease upgrade **failed** even though the MinIO pod itself is healthy (1/1, probe applied, serving backups).

## Root cause

The `minio` namespace's `default-deny-all` NetworkPolicy blocks intra-namespace pod-to-pod traffic in **both** directions. Every real client (velero, cnpg, tofu, monitoring) has a cross-namespace allow rule, but the ephemeral hook pod — labeled `app: minio-job` — has no rule in either direction. DNS resolves; the TCP connect to `minio:9000` is silently dropped (`dial tcp …:9000: i/o timeout`).

## Fix

Add a matched pair of NetworkPolicies scoped to the hook pod:
- `allow-post-job-egress` — `app: minio-job` → `app: minio` on TCP/9000
- `allow-post-job-ingress` — `app: minio` ← `app: minio-job` on TCP/9000

Port 9000 is the verified container port for the S3 API (post-DNAT, per the port-trap rule). Also adds the `minio` row to the port-reference table in `.claude/rules/networkpolicy.md`.

Once merged, Flux reconciles the NetworkPolicies independently of the HelmRelease, and the next post-job retry succeeds → HR goes Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqmJaX2sTpXx314RGghNC