### PR TITLE
docs: update plan-3 runner-group note — vollmint is now public

### DIFF
--- a/docs/superpowers/plans/vollmint-deploy.md
+++ b/docs/superpowers/plans/vollmint-deploy.md
@@ -504,7 +504,7 @@ Direct copy of longhorn-rebalancing-controller's `build.yml` with names swapped 
     charts/vollmint/templates/service.yaml charts/vollmint/templates/cronjob.yaml
   git commit -m "feat: add Dockerfile, Helm chart, and Harbor release CI"
   ```
-- [ ] **Step 2:** Push and open the PR: `git push -u origin feat/deploy && gh pr create --title "feat: Dockerfile, Helm chart, Harbor release CI" --body "<summary of Part A>"`. Watch CI (`gh pr checks --watch`). Note: if CI jobs sit queued forever, the ARC runner group may not cover the private vollmint repo — report that to Scott (org-settings fix, not a code fix).
+- [ ] **Step 2:** Push and open the PR: `git push -u origin feat/deploy && gh pr create --title "feat: Dockerfile, Helm chart, Harbor release CI" --body "<summary of Part A>"`. Watch CI (`gh pr checks --watch`). Note: if CI jobs sit queued forever, the ARC runner group may not cover the vollmint repo (public as of github-admin PR #16 — the group must allow public repos, as it already does for masters-league) — report that to Scott (org-settings fix, not a code fix).
 - [ ] **Step 3:** **STOP — do not merge.** Merging requires Scott's explicit approval (house rule).
 
 ---


### PR DESCRIPTION
One-line follow-up to #973: the deploy plan's Task 9 troubleshooting note still described vollmint as a private repo. It went public today (github-admin #16), so the note now points at the runner group's public-repo allowance (already proven by masters-league) instead.

This commit was originally pushed to the #973 branch minutes after that PR merged, so it never landed in main — cherry-picked here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNYieb3KXVmxTbz7pT5HRX