### PR TITLE
chore: bump longhorn-rebalancing-controller 0.3.1 -> 0.4.0 (peak-reduction guard)

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/longhorn-rebalancing-controller-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/longhorn-rebalancing-controller-ocirepository.yaml
@@ -11,6 +11,6 @@ spec:
   interval: 1h
   url: oci://harbor.vollminlab.com/vollminlab/charts/longhorn-rebalancing-controller
   ref:
-    tag: "0.3.1"
+    tag: "0.4.0"
   secretRef:
     name: harbor-vollminlab-pull

--- a/clusters/vollminlab-cluster/longhorn-system/longhorn-rebalancing-controller/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn-rebalancing-controller/app/configmap.yaml
@@ -28,6 +28,12 @@ data:
         # 77GiB MinIO replica rebuild collapsed under the contention on
         # 2026-07-20 (~02:30), degrading the volume right before daily-full.
         maintenanceWindow: "13:00-19:00"
+      move:
+        # After a volume is moved, keep it off the victim list for this long so
+        # a single convergence run can't shuffle the same volume repeatedly
+        # (v0.4.0 peak-reduction guard already prevents oscillation; this is the
+        # belt-and-suspenders bound). 0 disables. Chart default is also 360.
+        perVolumeBackoffMinutes: 360
 
     resources:
       requests:


### PR DESCRIPTION
Bumps the OCIRepository tag to `0.4.0` (image + chart both published to Harbor and verified) and wires the new `perVolumeBackoffMinutes` setting into the live values ConfigMap.

## What v0.4.0 changes

**Peak-reduction move guard** — the old pairwise "no-flip" guard structurally forbade moving worker03's stuck 100 GiB MinIO replica (any single move looked like it would flip the pair's relative load). v0.4.0 replaces it with a guard that computes the true post-move cluster-wide max node load and only permits a move that **strictly lowers** the highest node's scheduledBytes.

- Monotone-decreasing global max → the sequence terminates and **cannot oscillate**.
- Tied-max and higher-peak candidate moves are correctly rejected.
- Directly answers the "no pointless churn after the fix" requirement: once the peak can't be lowered further, no move is made.

**Per-volume backoff** (`perVolumeBackoffMinutes: 360`) — a moved volume is kept off the victim list for 6h, so a single convergence run can't shuffle the same volume repeatedly. Belt-and-suspenders on top of the guard.

## Expected behavior after reconcile

In the next `13:00-19:00` UTC maintenance window: one move of the 100 GiB MinIO replica off worker03, then worker01 chipped down by smaller replicas — then quiescent (no repeated churn).

Controller change: vollminlab/longhorn-rebalancing-controller#9 (merged, tagged v0.4.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqmJaX2sTpXx314RGghNC