### PR TITLE
feat(vollmint): deploy vollmint — namespace, CNPG DB, HelmRelease, ingress, netpols, Authentik app, homepage tile

### DIFF
--- a/.claude/rules/networkpolicy.md
+++ b/.claude/rules/networkpolicy.md
@@ -83,6 +83,8 @@ Keep this table current whenever a new NetworkPolicy namespace is added.
 | `minio` | `minio` | 9000 | S3 API — reached by the Helm post-upgrade hook pod (`app: minio-job`) to create buckets/users | allow-post-job-egress (from hook) + allow-post-job-ingress (to minio); intra-namespace |
 | `tofu` | n/a (egress target → mediastack) | 7878/8989/8787/9696 | radarr/sonarr/readarr/prowlarr API (arr Terraform providers) | allow-mediastack-arr-egress egress |
 | `tofu` | n/a (egress target → harbor) | 8443 | Harbor API; svc 443→**8443**, egress evaluated post-DNAT so 443 ≠ enough | allow-harbor-egress egress |
+| `vollmint` | `vollmint` | 8080 | API + SPA (ingress-nginx) | allow-ingress-nginx ingress |
+| `vollmint` | n/a (egress target) | 443 | SimpleFIN Bridge HTTPS (sync CronJob) | allow-external-egress egress |
 
 Add a row here when writing a new NetworkPolicy with a port restriction. This is the source of
 truth — do not rely on service port numbers.

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/kustomization.yaml
@@ -31,6 +31,7 @@ resources:
   - monitoring-kustomization.yaml
   - portainer-kustomization.yaml
   - shlink-kustomization.yaml
+  - vollmint-kustomization.yaml
   - minio-kustomization.yaml
   - renovate-kustomization.yaml
   - reloader-kustomization.yaml

--- a/clusters/vollminlab-cluster/flux-system/flux-kustomizations/vollmint-kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/flux-kustomizations/vollmint-kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: vollmint
+  namespace: flux-system
+  labels:
+    app: vollmint
+    env: production
+    category: apps
+spec:
+  interval: 10m
+  path: ./clusters/vollminlab-cluster/vollmint
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 10m
+  dependsOn:
+    - name: cnpg-system
+    - name: external-secrets

--- a/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
@@ -53,6 +53,7 @@ resources:
   - velero-helmrepository.yaml
   - victoria-metrics-helmrepository.yaml
   - vmware-exporter-helmrepository.yaml
+  - vollmint-ocirepository.yaml
   - volsync-helmrepository.yaml
   - harbor-vollminlab-pull-externalsecret.yaml
   - vollminlab-ocirepository.yaml

--- a/clusters/vollminlab-cluster/flux-system/repositories/vollmint-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/vollmint-ocirepository.yaml
@@ -1,0 +1,16 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: vollmint-repo
+  namespace: flux-system
+  labels:
+    app: vollmint
+    env: production
+    category: apps
+spec:
+  interval: 1h
+  url: oci://harbor.vollminlab.com/vollminlab/charts/vollmint
+  ref:
+    tag: "0.1.0"
+  secretRef:
+    name: harbor-vollminlab-pull

--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -364,6 +364,12 @@ data:
                 icon: shlink.png
                 namespace: shlink
                 app: shlink-web
+            - Vollmint:
+                description: Household budget tracker
+                href: https://vollmint.vollminlab.com
+                icon: mdi-cash-multiple
+                namespace: vollmint
+                app: vollmint
             - Vollminlab Org:
                 description: All Vollminlab repositories
                 href: https://github.com/vollminlab

--- a/clusters/vollminlab-cluster/vollmint/kustomization.yaml
+++ b/clusters/vollminlab-cluster/vollmint/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - vollmint/app
+  - vollmint-db/app
+  - networkpolicies

--- a/clusters/vollminlab-cluster/vollmint/namespace.yaml
+++ b/clusters/vollminlab-cluster/vollmint/namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vollmint
+  labels:
+    app: vollmint
+    env: production
+    category: apps
+    goldilocks.fairwinds.com/enabled: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/clusters/vollminlab-cluster/vollmint/networkpolicies/kustomization.yaml
+++ b/clusters/vollminlab-cluster/vollmint/networkpolicies/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - networkpolicy.yaml

--- a/clusters/vollminlab-cluster/vollmint/networkpolicies/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/vollmint/networkpolicies/networkpolicy.yaml
@@ -1,0 +1,197 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: vollmint
+  labels:
+    app: vollmint
+    env: production
+    category: security
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns
+  namespace: vollmint
+  labels:
+    app: vollmint
+    env: production
+    category: security
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+        - podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+---
+# Allow pods within vollmint to communicate (serve/sync → vollmint-db:5432,
+# CNPG instance-to-instance replication)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-intra-namespace
+  namespace: vollmint
+  labels:
+    app: vollmint
+    env: production
+    category: security
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+  egress:
+    - to:
+        - podSelector: {}
+---
+# Allow ingress-nginx to reach vollmint. NetworkPolicy is post-DNAT at the pod,
+# so container ports apply: 8080 (API + SPA).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-nginx
+  namespace: vollmint
+  labels:
+    app: vollmint
+    env: production
+    category: security
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 8080
+---
+# Allow CNPG operator (cnpg-system) to manage vollmint-db.
+# Port 5432: PostgreSQL connections. Port 8000: instance manager status API
+# (CNPG operator polls /pg/status on each database pod for health/fencing decisions).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cnpg-operator
+  namespace: vollmint
+  labels:
+    app: vollmint
+    env: production
+    category: security
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cnpg-system
+      ports:
+        - protocol: TCP
+          port: 5432
+        - protocol: TCP
+          port: 8000
+---
+# Allow Prometheus scraping from monitoring namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-monitoring-scrape
+  namespace: vollmint
+  labels:
+    app: vollmint
+    env: production
+    category: security
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+---
+# Allow egress to Kubernetes API server (CNPG instance manager)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-kube-api-egress
+  namespace: vollmint
+  labels:
+    app: vollmint
+    env: production
+    category: security
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - protocol: TCP
+          port: 6443
+---
+# Allow egress to MinIO for CNPG database backups (vollmint-db → minio S3)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-minio-egress
+  namespace: vollmint
+  labels:
+    app: vollmint
+    env: production
+    category: security
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: minio
+      ports:
+        - protocol: TCP
+          port: 9000
+---
+# Allow external egress: SimpleFIN Bridge HTTPS (sync CronJob)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-external-egress
+  namespace: vollmint
+  labels:
+    app: vollmint
+    env: production
+    category: security
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - protocol: TCP
+          port: 443

--- a/clusters/vollminlab-cluster/vollmint/vollmint-db/app/cluster.yaml
+++ b/clusters/vollminlab-cluster/vollmint/vollmint-db/app/cluster.yaml
@@ -1,0 +1,38 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: vollmint-db
+  namespace: vollmint
+  labels:
+    app: vollmint-db
+    env: production
+    category: apps
+spec:
+  instances: 2
+  inheritedMetadata:
+    labels:
+      app: vollmint-db
+      env: production
+      category: apps
+  storage:
+    size: 5Gi
+    storageClass: longhorn
+  bootstrap:
+    initdb:
+      database: vollmint
+      owner: vollmint
+  backup:
+    barmanObjectStore:
+      destinationPath: s3://cnpg-backups/vollmint-db
+      endpointURL: http://minio.minio.svc.cluster.local:9000
+      s3Credentials:
+        accessKeyId:
+          name: cnpg-minio-credentials
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: cnpg-minio-credentials
+          key: ACCESS_SECRET_KEY
+      wal:
+        compression: gzip
+        maxParallel: 2
+    retentionPolicy: "14d"

--- a/clusters/vollminlab-cluster/vollmint/vollmint-db/app/cnpg-minio-credentials-externalsecret.yaml
+++ b/clusters/vollminlab-cluster/vollmint/vollmint-db/app/cnpg-minio-credentials-externalsecret.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cnpg-minio-credentials
+  namespace: vollmint
+  labels:
+    app: vollmint-db
+    env: production
+    category: apps
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: onepassword-cluster-store
+    kind: ClusterSecretStore
+  target:
+    name: cnpg-minio-credentials
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        ACCESS_KEY_ID: "{{ .access_key_id }}"
+        ACCESS_SECRET_KEY: "{{ .secret_access_key }}"
+  dataFrom:
+    - extract:
+        key: "CNPG MinIO Credentials"

--- a/clusters/vollminlab-cluster/vollmint/vollmint-db/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/vollmint/vollmint-db/app/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster.yaml
+  - scheduled-backup.yaml
+  - cnpg-minio-credentials-externalsecret.yaml

--- a/clusters/vollminlab-cluster/vollmint/vollmint-db/app/scheduled-backup.yaml
+++ b/clusters/vollminlab-cluster/vollmint/vollmint-db/app/scheduled-backup.yaml
@@ -1,0 +1,14 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: vollmint-db-backup
+  namespace: vollmint
+  labels:
+    app: vollmint-db
+    env: production
+    category: apps
+spec:
+  schedule: "0 45 1 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: vollmint-db

--- a/clusters/vollminlab-cluster/vollmint/vollmint/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/vollmint/vollmint/app/configmap.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vollmint-values
+  namespace: vollmint
+  labels:
+    app: vollmint
+    env: production
+    category: apps
+data:
+  values.yaml: |
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+    sync:
+      schedule: "10 6,18 * * *"
+      suspend: false

--- a/clusters/vollminlab-cluster/vollmint/vollmint/app/harbor-vollminlab-pull-externalsecret.yaml
+++ b/clusters/vollminlab-cluster/vollmint/vollmint/app/harbor-vollminlab-pull-externalsecret.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: harbor-vollminlab-pull
+  namespace: vollmint
+  labels:
+    app: vollmint
+    env: production
+    category: apps
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: onepassword-cluster-store
+    kind: ClusterSecretStore
+  target:
+    name: harbor-vollminlab-pull
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |
+          {"auths":{"harbor.vollminlab.com":{"username":"{{ .username }}","password":"{{ .password }}","auth":"{{ printf "%s:%s" .username .password | b64enc }}"}}}
+  dataFrom:
+    - extract:
+        key: "Harbor Cluster Pull Robot Account"

--- a/clusters/vollminlab-cluster/vollmint/vollmint/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/vollmint/vollmint/app/helmrelease.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vollmint
+  namespace: vollmint
+  labels:
+    app: vollmint
+    env: production
+    category: apps
+spec:
+  interval: 10m
+  timeout: 5m
+  chartRef:
+    kind: OCIRepository
+    name: vollmint-repo
+    namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: vollmint-values

--- a/clusters/vollminlab-cluster/vollmint/vollmint/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/vollmint/vollmint/app/ingress.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: vollmint-ingress
+  namespace: vollmint
+  labels:
+    app: vollmint
+    env: production
+    category: apps
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=https://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/auth-snippet: |
+      proxy_set_header X-Forwarded-Host $http_host;
+    shlink.vollminlab.com/slug: vollmint
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - vollmint.vollminlab.com
+      secretName: wildcard-tls
+  rules:
+    - host: vollmint.vollminlab.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: vollmint
+                port:
+                  number: 8080

--- a/clusters/vollminlab-cluster/vollmint/vollmint/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/vollmint/vollmint/app/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - configmap.yaml
+  - vollmint-simplefin-externalsecret.yaml
+  - harbor-vollminlab-pull-externalsecret.yaml
+  - ingress.yaml

--- a/clusters/vollminlab-cluster/vollmint/vollmint/app/vollmint-simplefin-externalsecret.yaml
+++ b/clusters/vollminlab-cluster/vollmint/vollmint/app/vollmint-simplefin-externalsecret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: vollmint-simplefin
+  namespace: vollmint
+  labels:
+    app: vollmint
+    env: production
+    category: apps
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: onepassword-cluster-store
+    kind: ClusterSecretStore
+  target:
+    name: vollmint-simplefin
+    creationPolicy: Owner
+  data:
+    - secretKey: token
+      remoteRef:
+        key: "SimpleFIN Access URL"
+        property: token

--- a/docs/cluster-reference.md
+++ b/docs/cluster-reference.md
@@ -300,6 +300,7 @@ All Kustomizations use `interval: 10m`, `prune: true`, source `flux-system` GitR
 | `sealed-secrets` | `./clusters/vollminlab-cluster/sealed-secrets` | |
 | `shlink` | `./clusters/vollminlab-cluster/shlink` | |
 | `velero` | `./clusters/vollminlab-cluster/velero` | |
+| `vollmint` | `./clusters/vollminlab-cluster/vollmint` | |
 
 ### Headlamp (Kubernetes UI)
 
@@ -352,6 +353,7 @@ All Kustomizations use `interval: 10m`, `prune: true`, source `flux-system` GitR
 | tautulli-repo | HelmRepository | https://k8s-at-home.com/charts/ |
 | velero-repo | HelmRepository | https://vmware-tanzu.github.io/helm-charts |
 | vollminlab-repo | OCIRepository | oci://harbor.vollminlab.com/vollminlab/charts/shlink-ingress-controller |
+| vollmint-repo | OCIRepository | oci://harbor.vollminlab.com/vollminlab/charts/vollmint (tag: 0.1.0) |
 
 ---
 
@@ -410,6 +412,7 @@ All ingresses use `ingressClassName: nginx`, TLS termination via `wildcard-tls`,
 | `vl.vollminlab.com` | shlink-shlink-backend | 8080 | shlink | wildcard-tls |
 | `vollm.in` | shlink-shlink-backend | 8080 | shlink | vollm-in-tls (Let's Encrypt) |
 | `minio.vollminlab.com` | minio | 9001 | minio | wildcard-tls |
+| `vollmint.vollminlab.com` | vollmint | 8080 | vollmint | wildcard-tls |
 
 ---
 
@@ -764,7 +767,7 @@ per-namespace port table.
 
 ## CNPG (CloudNative-PG)
 
-Operator deployed in `cnpg-system`. Manages PostgreSQL clusters in other namespaces (authentik, harbor, mediastack/jellystat, shlink).
+Operator deployed in `cnpg-system`. Manages PostgreSQL clusters in other namespaces (authentik, harbor, mediastack/jellystat, shlink, vollmint — `vollmint-db`, 2 instances × 5Gi, barman backup to MinIO at 01:45).
 
 ### Container ports — cnpg-system operator pod
 

--- a/terraform/authentik/applications.tf
+++ b/terraform/authentik/applications.tf
@@ -247,6 +247,14 @@ resource "authentik_application" "truenas" {
   open_in_new_tab = false
 }
 
+resource "authentik_application" "vollmint" {
+  name             = "Vollmint"
+  slug             = "vollmint"
+  meta_description = "Household budget tracker"
+  meta_launch_url  = "https://vollmint.vollminlab.com"
+  open_in_new_tab  = false
+}
+
 resource "authentik_application" "vollminlab_forward_auth" {
   name              = "Vollminlab Forward Auth"
   slug              = "vollminlab-forward-auth"


### PR DESCRIPTION
Deploys **vollmint** (household budget tracker) to the cluster — the Part B half of `docs/superpowers/plans/vollmint-deploy.md`. Companion to the vollmint repo PRs #4/#5 (image + chart already published to Harbor).

## What's in this PR

**New namespace `vollmint`** (`clusters/vollminlab-cluster/vollmint/`):
- `vollmint-db` — CNPG Cluster, 2 instances × 5Gi longhorn (30Gi total incl. replicas; headroom verified 2026-07-25, every node ≥68Gi schedulable). Barman WAL archiving + base backups to MinIO (`s3://cnpg-backups/vollmint-db`), 14d retention, ScheduledBackup at **01:45** (next free slot after authentik 01:00 / harbor 01:15 / shlink 01:30). Uses the CNPG auto-generated `vollmint-db-app` Secret (`uri` key) — no custom bootstrap secret, first cluster in the fleet on this pattern.
- `vollmint` HelmRelease — `chartRef` → OCIRepository `vollmint-repo` (chart 0.1.0 from `oci://harbor.vollminlab.com/vollminlab/charts/vollmint`), values via `vollmint-values` ConfigMap. Image pulled with the `harbor-vollminlab-pull` dockerconfigjson ExternalSecret.
- Ingress `vollmint.vollminlab.com` → `vollmint:8080`, wildcard-tls, Authentik forward-auth (domain-wide provider, incl. `auth-snippet` X-Forwarded-Host), `shlink.vollminlab.com/slug: vollmint`. LAN/Tailscale only — not exposed via Cloudflare tunnel.
- Nine NetworkPolicies (default-deny + DNS, intra-namespace, ingress-nginx→8080, CNPG operator 5432+8000, monitoring scrape, kube-api 6443, MinIO 9000, external 443 for SimpleFIN).

**Flux wiring:** `vollmint-ocirepository.yaml` + `vollmint-kustomization.yaml` (dependsOn `cnpg-system` + `external-secrets`), both index files updated.

**Supporting changes:** Authentik Application `vollmint` (tofu, forward_domain — no dedicated provider), Homepage tile in Tools, port-table rows in `.claude/rules/networkpolicy.md`, `docs/cluster-reference.md` rows.

## Merge gates

- ~~vollmint v0.1.0 image + chart published in Harbor~~ — **satisfied** (vollmint PRs #4/#5 merged; `vollmint:0.1.0` image and chart 0.1.0 verified live in Harbor).
- ⚠️ **Outstanding:** the 1Password item **"SimpleFIN Access URL"** does not exist yet in the Homelab vault. The `vollmint-simplefin` ExternalSecret will show `SecretSyncedError` (and the sync CronJob will fail) until Scott creates it: item name `SimpleFIN Access URL`, concealed field labeled `token`, tag `Homelab`. Everything else (app, DB, ingress) deploys fine without it — this can be created before or shortly after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNYieb3KXVmxTbz7pT5HRX
