### PR TITLE
fix(ci): derive test HelmRelease name from metadata.name — basename collides on multi-HR PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1028,7 +1028,12 @@ jobs:
               TEST_SOURCE_REF="$(grep "^${ORIG_SOURCE_REF}:" "$OCI_MAPPING_FILE" | cut -d: -f2 || true)"
               [[ -z "$TEST_SOURCE_REF" ]] && TEST_SOURCE_REF="test-${ORIG_SOURCE_REF}-${RUN_SUFFIX}"
 
-              CLEAN_NAME="$(basename "$file" | sed -E 's/\.(ya?ml)$//' | tr '[:upper:]' '[:lower:]' \
+              # Derive from metadata.name, not the file basename — every HelmRelease
+              # file in this repo is named helmrelease.yaml, so basenames collide
+              # when a PR touches more than one HR: the second apply becomes a
+              # patch of the first test object, which the runner SA is (by design)
+              # not allowed to do.
+              CLEAN_NAME="$(yq eval '.metadata.name' "$file" | tr '[:upper:]' '[:lower:]' \
                 | sed -E 's/[^a-z0-9-]+/-/g;s/-+/-/g;s/^-|-$//g')"
 
               # ── GUARD A: neutralize the release identity ─────────────────────


### PR DESCRIPTION
## Problem

PR #977's Integration Test failed:

```
❌ Failed: clusters/vollminlab-cluster/vollmint/vollmint/app/helmrelease.yaml
helmreleases.helm.toolkit.fluxcd.io "test-helmrelease-30172360319-2732" is forbidden:
User "system:serviceaccount:actions-runner-system:github-actions-runner" cannot patch
resource "helmreleases" ... in the namespace "ci-test-30172360319-2732"
```

The test-deploy step (Guard A, added in #972) derives the per-run test HelmRelease name from the **file basename** — but repo convention names every HelmRelease file `helmrelease.yaml`. On any PR that pulls ≥2 HelmReleases into CHANGED_FILES (vollmint's new HR + homepage's HR, dragged in by the homepage configmap edit), both rewrites collapse to `test-helmrelease-<run-suffix>`. The second `kubectl apply` then becomes a **patch** of the first object, and the runner SA deliberately lacks `patch` on helmreleases (the #972 anti-clobber guard) → Forbidden → job fails.

#977 is the first multi-HelmRelease PR since #972 landed, which is why this only surfaced now.

## Fix

Derive `CLEAN_NAME` from the HelmRelease's `metadata.name` (unique per HR) instead of the basename — the same pattern the repositories first pass already uses (`TEST_NAME="test-${ORIG_NAME}-${RUN_SUFFIX}"`).

The dry-run section's `DRY_NAME` also uses the basename, but is harmless (`--dry-run=server` persists nothing, so nothing collides) — left unchanged to keep the diff minimal. Guard B (fullnameOverride skip) untouched.

## After merge

Re-running #977's failed Integration Test picks up this fix automatically (PR checks run against the merge ref with main). No changes needed on `feat/vollmint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNYieb3KXVmxTbz7pT5HRX
