### PR TITLE
fix(policy-reporter): enable Flux drift detection so deleted RBAC self-heals

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/policyreporter/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/kyverno/policyreporter/app/helmrelease.yaml
@@ -10,6 +10,14 @@ metadata:
 spec:
   interval: 10m
   releaseName: policy-reporter
+  # Self-heal RBAC: the chart-rendered ClusterRole/ClusterRoleBinding (fixed name
+  # "policy-reporter", cluster-scoped) was deleted out-of-band, which crash-looped
+  # the pod (wginformer could not list policyreports). Helm's release state still
+  # recorded them as present, so the normal reconcile never noticed — recovery
+  # required a manual `flux reconcile --force`. Drift detection makes Flux re-apply
+  # any deleted/mutated managed resource within the reconcile interval.
+  driftDetection:
+    mode: enabled
   chart:
     spec:
       chart: policy-reporter


### PR DESCRIPTION
## What

Add `spec.driftDetection.mode: enabled` to the `policy-reporter` HelmRelease.

## Why

The `policy-reporter` **ClusterRole** and **ClusterRoleBinding** (fixed name, cluster-scoped) were deleted out-of-band. That crash-looped the pod: the wgpolicy informer could no longer `list` `policyreports`/`clusterpolicyreports`, so its health check failed and liveness killed it in a loop (`CrashLoopBackOff`).

The chart renders that RBAC correctly — the objects were simply missing from the cluster. But **Helm's release state still recorded them as present**, so Flux's normal 10-minute reconcile detected no drift and never re-applied them. Recovery required a manual `flux reconcile helmrelease policy-reporter -n kyverno --force`.

Enabling drift detection makes helm-controller diff the live cluster against the release manifest every interval and re-apply any deleted or mutated managed resource — so this class of failure self-heals within 10 minutes instead of needing a human with a `--force`.

## Scope

- One HelmRelease, one field. No values/RBAC content change (the chart RBAC is already correct).
- The CI-clobber path itself was already closed by #972 (the cluster-scoped orphan sweep only deletes objects whose `meta.helm.sh/release-namespace` equals the ephemeral test namespace; prod objects carry `kyverno`). This PR addresses the *residual* fragility — that recovery wasn't automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqmJaX2sTpXx314RGghNC