### PR TITLE
feat(monitoring): deploy karma as a better Alertmanager dashboard UI

### DIFF
--- a/.claude/rules/networkpolicy.md
+++ b/.claude/rules/networkpolicy.md
@@ -76,6 +76,7 @@ Keep this table current whenever a new NetworkPolicy namespace is added.
 | `monitoring` | `kube-prometheus-stack-operator` | 10250 | prometheus-operator admission webhook | allow-webhook-ingress ingress (open source) |
 | `monitoring` | `grafana` | 3000 | Grafana HTTP (homepage widget) | allow-homepage-grafana ingress (from homepage) |
 | `monitoring` | `prometheus` | 9090 | Prometheus HTTP (homepage widget) | allow-homepage-prometheus ingress (from homepage) |
+| `monitoring` | `karma` | 8080 | karma Alertmanager dashboard UI (svc 80→8080) | allow-ingress-nginx ingress (from ingress-nginx) |
 | `authentik` | `server` | 9000 | authentik-server HTTP (homepage widget) | allow-homepage ingress (from homepage) |
 | `authentik` | n/a (ingress target) | 8000 | CNPG instance status API | allow-cnpg-operator ingress |
 | `authentik` | n/a (egress target) | 7844 | Cloudflare tunnel edge (QUIC UDP + http2 TCP) | allow-external-egress egress |

--- a/clusters/vollminlab-cluster/flux-system/repositories/karma-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/karma-ocirepository.yaml
@@ -1,0 +1,17 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: karma-repo
+  namespace: flux-system
+  labels:
+    app: karma
+    env: production
+    category: observability
+spec:
+  url: oci://ghcr.io/wiremind/wiremind-helm-charts/karma
+  interval: 30m
+  ref:
+    tag: 2.13.1
+  layerSelector:
+    mediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip"
+    operation: copy

--- a/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/kustomization.yaml
@@ -26,6 +26,7 @@ resources:
   - ingress-nginx-helmrepository.yaml
   - jellyfin-helmrepository.yaml
   - jellystat-helmrepository.yaml
+  - karma-ocirepository.yaml
   - kyverno-helmrepository.yaml
   - kyverno-policyreporter-helmrepository.yaml
   - local-path-provisioner-gitrepository.yaml

--- a/clusters/vollminlab-cluster/monitoring/karma/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/karma/app/configmap.yaml
@@ -31,6 +31,19 @@ data:
       limits:
         cpu: 100m
         memory: 128Mi
+    # karma blocks its HTTP listener until the FIRST Alertmanager collection finishes.
+    # When Alertmanager is unreachable, that collection retries at the full per-server
+    # `timeout` (below) before giving up, so cold start ≈ 3–4× `timeout`. The chart's
+    # default probe (delay 5, period 5, k8s failureThreshold 3) would kill the container
+    # at ~20s — before it ever listens — causing a CrashLoopBackOff that never becomes
+    # Ready. This only bites where Alertmanager is unreachable (e.g. the CI integration
+    # test's isolated namespace); in production karma runs in `monitoring` and reaches
+    # Alertmanager intra-namespace in <1s, so this delayed first probe simply passes.
+    # The chart applies these same values to BOTH the liveness and readiness probes.
+    livenessProbe:
+      path: /health
+      delay: 40
+      period: 10
     # Kyverno require-labels enforces app/env/category on the pod template.
     podLabels:
       app: karma
@@ -48,5 +61,7 @@ data:
             # covered by the monitoring allow-intra-namespace / allow-all-egress policies.
             - name: vollminlab
               uri: http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093
-              timeout: 20s
+              # 5s is ample for an intra-namespace call to Alertmanager. Kept low so an
+              # unreachable-Alertmanager cold start stays short (see livenessProbe note above).
+              timeout: 5s
               proxy: true

--- a/clusters/vollminlab-cluster/monitoring/karma/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/karma/app/configmap.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: karma-values
+  namespace: monitoring
+  labels:
+    app: karma
+    env: production
+    category: observability
+data:
+  values.yaml: |
+    replicaCount: 1
+    image:
+      repository: ghcr.io/prymitive/karma
+      # Pin the app image explicitly — the OCIRepository tag pins the CHART, not the
+      # image. Chart 2.13.1 ships appVersion v0.131. Kyverno blocks :latest.
+      tag: v0.131
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 80
+      targetPort: http
+    # A dedicated Ingress object (ingress.yaml) carries the Authentik forward-auth
+    # annotations, so the chart's own Ingress stays disabled.
+    ingress:
+      enabled: false
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+    # Kyverno require-labels enforces app/env/category on the pod template.
+    podLabels:
+      app: karma
+      env: production
+      category: observability
+    configMap:
+      enabled: true
+      rawConfig:
+        alertmanager:
+          interval: 60s
+          servers:
+            # proxy: true → the browser talks only to karma; karma's backend proxies
+            # to Alertmanager (needed for silence create/delete and because
+            # Alertmanager is not directly browser-reachable). Egress to :9093 is
+            # covered by the monitoring allow-intra-namespace / allow-all-egress policies.
+            - name: vollminlab
+              uri: http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093
+              timeout: 20s
+              proxy: true

--- a/clusters/vollminlab-cluster/monitoring/karma/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/monitoring/karma/app/helmrelease.yaml
@@ -1,0 +1,20 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: karma
+  namespace: monitoring
+  labels:
+    app: karma
+    env: production
+    category: observability
+spec:
+  interval: 10m
+  releaseName: karma
+  chartRef:
+    kind: OCIRepository
+    name: karma-repo
+    namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: karma-values
+      valuesKey: values.yaml

--- a/clusters/vollminlab-cluster/monitoring/karma/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/monitoring/karma/app/helmrelease.yaml
@@ -18,3 +18,19 @@ spec:
     - kind: ConfigMap
       name: karma-values
       valuesKey: values.yaml
+  # The wiremind karma chart's configmap.yaml hardcodes the legacy `chart` label as
+  # "{{ .Chart.Name }}-{{ .Chart.Version }}" without the standard `| replace "+" "_"`
+  # sanitizer. Flux's OCIRepository appends the layer digest as SemVer build metadata
+  # (e.g. 2.13.1+625850deae9c), so that one label becomes "karma-2.13.1+625850deae9c" —
+  # invalid as a k8s label value ('+' not allowed) → ConfigMap admission is rejected and
+  # the Helm install fails. Strip the deprecated label post-render (nothing selects on it).
+  # Name regex matches both the prod name (karma-config) and CI's rewritten release name.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: ConfigMap
+              name: ".*-config"
+            patch: |
+              - op: remove
+                path: /metadata/labels/chart

--- a/clusters/vollminlab-cluster/monitoring/karma/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/monitoring/karma/app/ingress.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: karma-ingress
+  namespace: monitoring
+  labels:
+    app: karma
+    env: production
+    category: observability
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=https://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/auth-snippet: |
+      proxy_set_header X-Forwarded-Host $http_host;
+    shlink.vollminlab.com/slug: karma
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: karma.vollminlab.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: karma
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - karma.vollminlab.com
+      secretName: wildcard-tls

--- a/clusters/vollminlab-cluster/monitoring/karma/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/monitoring/karma/app/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: karma
+  labels:
+    app: karma
+    env: production
+    category: observability
+resources:
+  - helmrelease.yaml
+  - configmap.yaml
+  - ingress.yaml

--- a/clusters/vollminlab-cluster/monitoring/kustomization.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - networkpolicies
   - harbor-vollminlab-pull-externalsecret.yaml
   - b2-exporter/app
+  - karma/app
   - kube-prometheus-stack/app
   - loki/app
   - promtail/app

--- a/clusters/vollminlab-cluster/monitoring/networkpolicies/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/monitoring/networkpolicies/networkpolicy.yaml
@@ -65,8 +65,9 @@ spec:
         - podSelector: {}
 ---
 # Allow ingress-nginx to reach Grafana (3000), Prometheus (9090), AlertManager (9093),
-# VictoriaMetrics (8428). Grafana's container port is 3000 (service maps 80→3000;
-# ingress-nginx connects to the container port directly via EndpointSlices).
+# VictoriaMetrics (8428), karma (8080). Grafana's container port is 3000 (service maps
+# 80→3000; ingress-nginx connects to the container port directly via EndpointSlices).
+# karma listens on container port 8080 (service maps 80→8080).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -88,6 +89,8 @@ spec:
       ports:
         - protocol: TCP
           port: 3000
+        - protocol: TCP
+          port: 8080
         - protocol: TCP
           port: 8428
         - protocol: TCP


### PR DESCRIPTION
## What

Stands up **karma** ([prymitive/karma](https://github.com/prymitive/karma)) in the `monitoring` namespace as a cleaner UI for viewing and silencing firing alerts than the built-in Alertmanager web UI. This is PR 2 of the "both, separate PRs" pair — PR 1 (#979) durably fixed the policy-reporter RBAC crashloop that was one of the firing alerts.

## Details

- **OCIRepository** `karma-repo` → wiremind chart `2.13.1` (appVersion `v0.131`)
- **HelmRelease + ConfigMap** values: single Alertmanager backend (`kube-prometheus-stack-alertmanager:9093`) with `proxy: true`, so the browser talks only to karma and karma proxies silence create/delete to Alertmanager (Alertmanager itself isn't browser-reachable)
- **Ingress** `karma.vollminlab.com` behind the domain-wide Authentik forward-auth (`vollminlab-forward-auth`, `provider_id=None`), `wildcard-tls`, shlink slug `karma`
- **NetworkPolicy** `allow-ingress-nginx`: add container port `8080` (service maps `80→8080`; ingress-nginx connects to the container port via EndpointSlices)
- **Flux wiring**: repositories index + monitoring namespace aggregation. karma lives under the existing `monitoring` Flux Kustomization CR, so no new `flux-kustomizations` entry is needed.
- `networkpolicy.md`: karma row added to the monitoring port table

## Resources

- No PVC — karma is stateless (reads live from Alertmanager)
- requests 25m/64Mi, limits 100m/128Mi

## Follow-up (out of band, after merge)

Create the Authentik Application entry (`slug=karma`, `meta_launch_url=https://karma.vollminlab.com`) via `ak shell` — required for forward-auth even with `provider_id=None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqmJaX2sTpXx314RGghNC