### PR TITLE
feat(homepage): add Karma link to Monitoring & Observability

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -345,6 +345,12 @@ data:
                       query: count(ALERTS{alertstate="firing",severity="warning",alertname!~"Watchdog|InfoInhibitor"}) or vector(0)
                       format:
                         type: number
+            - Karma:
+                description: Alertmanager dashboard and silencing UI
+                href: https://karma.vollminlab.com
+                icon: mdi-bell-alert
+                namespace: monitoring
+                app: karma
         - Tools:
             - Homepage:
                 description: This dashboard


### PR DESCRIPTION
Adds a **Karma** entry to the homepage dashboard's *Monitoring & Observability* group.

Karma (the Alertmanager dashboard/silencing UI) was deployed in #980 and is live at https://karma.vollminlab.com, but it was never surfaced on the homepage. This adds a link alongside AlertManager, including the Kubernetes status badge (`namespace: monitoring`, `app: karma` — the karma pod carries `app.kubernetes.io/name: karma`).

No dedicated dashboard-icon exists for karma in the walkxcode/homarr-labs/selfhst icon sets (all return 404), so it uses the `mdi-bell-alert` Material Design icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqmJaX2sTpXx314RGghNC