### PR TITLE
fix(ci): exclude RBAC-forbidden GET wrapper line in dry-run filter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -584,8 +584,17 @@ jobs:
               #      limit, not a problem with the manifest.
               # Everything else (Kyverno "denied the request", schema "invalid",
               # unknown fields) is a real rejection and fails the job.
+              #
+              # kubectl's "retrieving current configuration" GET-before-patch step
+              # (needed for the 3-way merge on every update) prints its own generic
+              # wrapper line ("Error from server (Forbidden): error when retrieving
+              # current configuration of:") before the actual forbidden reason on a
+              # later line. That wrapper line matches the positive filter above but
+              # contains none of the RBAC-forbidden phrases below it, so it must be
+              # excluded here too — otherwise any chart with RBAC objects (ClusterRole,
+              # RoleBinding, webhook configs, etc.) always false-fails.
               DRYRUN_ERRORS=$(grep -iE 'error|denied|invalid|forbidden|must |required|not allowed' "$RENDER_DIR/dryrun.out" 2>/dev/null \
-                | grep -ivE 'unable to recognize|no matches for kind|ensure CRDs are installed|is forbidden|cannot (create|patch|get|update|delete) resource|forbidden: User|does not match the namespace' \
+                | grep -ivE 'unable to recognize|no matches for kind|ensure CRDs are installed|is forbidden|cannot (create|patch|get|update|delete) resource|forbidden: User|does not match the namespace|error when retrieving current configuration' \
                 || true)
               if [[ -n "$DRYRUN_ERRORS" ]]; then
                 echo "❌ $RELEASE_NAME rejected by server-side dry-run:"


### PR DESCRIPTION
## Summary

- The server-side dry-run integration test (from #986) false-fails any chart that creates RBAC objects (ClusterRole, ClusterRoleBinding, Role, RoleBinding, webhook configs).
- Root cause: kubectl's "retrieving current configuration" GET-before-patch step prints a generic wrapper line (`Error from server (Forbidden): error when retrieving current configuration of:`) before the actual forbidden reason, which lands on a later line. The wrapper matches the positive error filter but none of the existing RBAC-forbidden exclusions, so it survives and fails the job even though the paired detail line is already correctly classified as benign CI-identity noise.
- Fix: add `error when retrieving current configuration` to the negative-match exclusion list.
- Verified by replaying the captured dry-run output from PR #984 (authentik v2026.5.6) and #985 (kube-prometheus-stack v87.20.0) through the old and new filter locally — both currently fail, both pass with this change, with no other error class affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GB7ikaN26Xmm3YPz2PUWJf