### PR TITLE
fix(homepage): use karma's real favicon instead of generic mdi icon

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -348,7 +348,7 @@ data:
             - Karma:
                 description: Alertmanager dashboard and silencing UI
                 href: https://karma.vollminlab.com
-                icon: mdi-bell-alert
+                icon: https://raw.githubusercontent.com/prymitive/karma/main/ui/public/favicon.ico
                 namespace: monitoring
                 app: karma
         - Tools:


### PR DESCRIPTION
## Summary
- Karma has no entry in the [dashboard-icons](https://github.com/homarr-labs/dashboard-icons) set, so it was falling back to the generic `mdi-bell-alert` icon
- Point the homepage widget icon to karma's own `favicon.ico` from its GitHub repo (same pattern already used for kyverno's raw GitHub logo URL, see line 303 of the same file)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01GB7ikaN26Xmm3YPz2PUWJf