### PR TITLE
fix(volsync): stage backup clones on 1-replica StorageClass to cut backup-window I/O

### DIFF
--- a/clusters/vollminlab-cluster/clusterwide/kustomization.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - pv-tv.yaml
   - storageclass-smb.yaml
   - storageclass-longhorn-dmz.yaml
+  - storageclass-longhorn-r1.yaml
   - storageclass-longhorn-r2.yaml
   - disk-cleanup-rbac.yaml
   - disk-cleanup-cronjob.yaml

--- a/clusters/vollminlab-cluster/clusterwide/storageclass-longhorn-r1.yaml
+++ b/clusters/vollminlab-cluster/clusterwide/storageclass-longhorn-r1.yaml
@@ -1,0 +1,18 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-r1
+  labels:
+    app: storageclass-longhorn-r1
+    env: production
+    category: storage
+provisioner: driver.longhorn.io
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  numberOfReplicas: "1"
+  dataLocality: "best-effort"
+  staleReplicaTimeout: "30"
+  fromBackup: ""
+  fsType: "ext4"

--- a/clusters/vollminlab-cluster/harbor/volsync/harbor-registry-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/harbor/volsync/harbor-registry-replicationsource.yaml
@@ -15,5 +15,6 @@ spec:
       weekly: 4
       monthly: 3
     copyMethod: Clone
+    storageClassName: longhorn-r1
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn

--- a/clusters/vollminlab-cluster/mediastack/volsync/audiobookshelf-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/audiobookshelf-config-replicationsource.yaml
@@ -15,5 +15,6 @@ spec:
       weekly: 4
       monthly: 3
     copyMethod: Clone
+    storageClassName: longhorn-r1
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn

--- a/clusters/vollminlab-cluster/mediastack/volsync/audiobookshelf-metadata-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/audiobookshelf-metadata-replicationsource.yaml
@@ -15,5 +15,6 @@ spec:
       weekly: 4
       monthly: 3
     copyMethod: Clone
+    storageClassName: longhorn-r1
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn

--- a/clusters/vollminlab-cluster/mediastack/volsync/bazarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/bazarr-config-replicationsource.yaml
@@ -15,5 +15,6 @@ spec:
       weekly: 4
       monthly: 3
     copyMethod: Clone
+    storageClassName: longhorn-r1
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn

--- a/clusters/vollminlab-cluster/mediastack/volsync/filebrowser-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/filebrowser-config-replicationsource.yaml
@@ -15,6 +15,7 @@ spec:
       weekly: 4
       monthly: 3
     copyMethod: Clone
+    storageClassName: longhorn-r1
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
     moverSecurityContext:

--- a/clusters/vollminlab-cluster/mediastack/volsync/jellyfin-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/jellyfin-config-replicationsource.yaml
@@ -15,5 +15,6 @@ spec:
       weekly: 4
       monthly: 3
     copyMethod: Clone
+    storageClassName: longhorn-r1
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn

--- a/clusters/vollminlab-cluster/mediastack/volsync/prowlarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/prowlarr-config-replicationsource.yaml
@@ -15,6 +15,7 @@ spec:
       weekly: 4
       monthly: 3
     copyMethod: Clone
+    storageClassName: longhorn-r1
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
     moverSecurityContext:

--- a/clusters/vollminlab-cluster/mediastack/volsync/qbittorrent-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/qbittorrent-config-replicationsource.yaml
@@ -15,5 +15,6 @@ spec:
       weekly: 4
       monthly: 3
     copyMethod: Clone
+    storageClassName: longhorn-r1
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn

--- a/clusters/vollminlab-cluster/mediastack/volsync/radarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/radarr-config-replicationsource.yaml
@@ -15,6 +15,7 @@ spec:
       weekly: 4
       monthly: 3
     copyMethod: Clone
+    storageClassName: longhorn-r1
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
     moverSecurityContext:

--- a/clusters/vollminlab-cluster/mediastack/volsync/readarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/readarr-config-replicationsource.yaml
@@ -15,6 +15,7 @@ spec:
       weekly: 4
       monthly: 3
     copyMethod: Clone
+    storageClassName: longhorn-r1
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
     moverSecurityContext:

--- a/clusters/vollminlab-cluster/mediastack/volsync/sabnzbd-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/sabnzbd-config-replicationsource.yaml
@@ -15,5 +15,6 @@ spec:
       weekly: 4
       monthly: 3
     copyMethod: Clone
+    storageClassName: longhorn-r1
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn

--- a/clusters/vollminlab-cluster/mediastack/volsync/seerr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/seerr-config-replicationsource.yaml
@@ -15,5 +15,6 @@ spec:
       weekly: 4
       monthly: 3
     copyMethod: Clone
+    storageClassName: longhorn-r1
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn

--- a/clusters/vollminlab-cluster/mediastack/volsync/sonarr-config-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/mediastack/volsync/sonarr-config-replicationsource.yaml
@@ -15,6 +15,7 @@ spec:
       weekly: 4
       monthly: 3
     copyMethod: Clone
+    storageClassName: longhorn-r1
     cacheCapacity: 1Gi
     cacheStorageClassName: longhorn
     moverSecurityContext:


### PR DESCRIPTION
## Problem

Every VolSync `ReplicationSource` uses `copyMethod: Clone`. With Longhorn that duplicates the entire source PVC into an ephemeral copy volume before restic reads it — and that copy inherited the default `longhorn` StorageClass (`numberOfReplicas: 3`). So each nightly backup wrote **three** replicas of a volume that gets deleted minutes later.

Because every general worker's Longhorn data is physically backed by the **same TrueNAS SSD mirror (pool_1, 2× consumer SSD)**, replica count is a direct write multiplier on that one mirror. These 3-replica ephemeral clones are the dominant I/O in the 00:00–02:00 VolSync window and drive the nightly PSI I/O-stall peaks on the workers (last clean night: 0.13–0.38 full-stall, w03 hottest).

Prior throttle work (#929, kopia read-parallelism) targeted the **separate 03:00 Velero window** — the wrong window. This retargets the fix to where the peaks actually are.

## Change

- New `longhorn-r1` StorageClass (`numberOfReplicas: 1`), wired into the `clusterwide` kustomization.
- `storageClassName: longhorn-r1` on all 13 ReplicationSources, so the point-in-time copy uses one replica instead of three.

The clone is transient and backup-source-only, so it needs no redundancy. Source volumes are untouched (still 3-replica `longhorn`). Net effect: ~3× less clone write load on pool_1 in the backup window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqmJaX2sTpXx314RGghNC