### PR TITLE
fix(authentik): lengthen Headlamp login session timeout

### DIFF
--- a/terraform/authentik/providers_oauth2.tf
+++ b/terraform/authentik/providers_oauth2.tf
@@ -38,6 +38,14 @@ resource "authentik_provider_oauth2" "headlamp" {
   sub_mode           = "hashed_user_id"
   logout_uri         = "https://headlamp.vollminlab.com"
 
+  # Default access_token_validity is minutes=10, which logs users out of the
+  # Headlamp UI far too aggressively (Headlamp only silently refreshes while the
+  # tab is focused). Headlamp maps to cluster-admin, so this token is privileged
+  # — hours=8 covers a work session without leaving a long-lived admin bearer
+  # token in the browser. The 30-day refresh token bounds the outer session.
+  access_token_validity  = "hours=8"
+  refresh_token_validity = "days=30"
+
   allowed_redirect_uris = [
     {
       matching_mode = "strict"


### PR DESCRIPTION
## Problem

Headlamp logs the user out after ~10 minutes of idle, even when signed in via OIDC. The Authentik `Headlamp` OAuth2 provider set no token-validity fields, so it inherited Authentik's default `access_token_validity = minutes=10`. Headlamp only silently refreshes its access token while the browser tab is focused — leave the tab idle past the 10-minute mark and the next apiserver call 401s, bouncing you to re-login. Refresh tokens (`offline_access`, 30-day) were already in scope; the short access token was the logout clock.

## Change

Set explicit token lifetimes on `authentik_provider_oauth2.headlamp`:

| Field | Value | Rationale |
|-------|-------|-----------|
| `access_token_validity`  | `hours=8` | Covers a work session without a long-lived privileged token |
| `refresh_token_validity` | `days=30` | Outer session bound (matches the prior Authentik default, now explicit) |

Headlamp is bound to **cluster-admin**, so `hours=8` is a deliberate usability/exposure balance rather than an arbitrarily long value. Raise later if desired.

## Apply path

Authentik is tofu-managed (`terraform/authentik/`). Takes effect on the next tofu apply; existing tokens keep their original expiry until re-login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqmJaX2sTpXx314RGghNC