### PR TITLE
chore(vollmint): bump chart 0.1.0 -> 0.2.0 (Recurring/Trends/Rules pages)

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/vollmint-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/vollmint-ocirepository.yaml
@@ -11,6 +11,6 @@ spec:
   interval: 1h
   url: oci://harbor.vollminlab.com/vollminlab/charts/vollmint
   ref:
-    tag: "0.1.0"
+    tag: "0.2.0"
   secretRef:
     name: harbor-vollminlab-pull


### PR DESCRIPTION
Bumps the vollmint OCIRepository tag to 0.2.0, deploying vollminlab/vollmint#6 (Recurring page, Trends graphs, Rules management page + Transactions `q` search filter).

Image `harbor.vollminlab.com/vollminlab/vollmint:0.2.0` and chart `0.2.0` published by build run 30417547287 (tag v0.2.0, green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNYieb3KXVmxTbz7pT5HRX