### PR TITLE
fix(descheduler): raise LowNodeUtilization memory target 70 -> 80

### DIFF
--- a/clusters/vollminlab-cluster/kube-system/descheduler/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kube-system/descheduler/app/configmap.yaml
@@ -54,7 +54,15 @@ data:
                   pods: 45
                 targetThresholds:
                   cpu: 80
-                  memory: 70
+                  # w03 carries a heavy immovable stateful floor (authentik-server +
+                  # 3 CNPG DBs + minio) that pins its request-memory at ~70%. With the
+                  # PVC guard the descheduler can only move stateless pods, so a 70%
+                  # target left w03 perpetually classified overutilized — it evicted
+                  # ~5 stateless pods every cycle without ever converging below target
+                  # (churn, no benefit). 80% clears the normal stateful floor while
+                  # still catching a node genuinely packed by requests. Actual usage
+                  # on w03 is only ~55%, so this is not masking real pressure.
+                  memory: 80
                   pods: 50
           plugins:
             balance:


### PR DESCRIPTION
## Problem

The descheduler retune in #999 correctly started rebalancing w03 and correctly guards PVC-backed pods (`PodsWithPVC`). But live cycles since deploy show it is **not converging** — after a one-time catch-up eviction of 16, it plateaued at a steady ~5 evictions **every** `*/30` cycle:

| Cycle | Evicted |
|-------|---------|
| 21:30 | 16 (catch-up) |
| 22:30 | 4 |
| 23:00 | 5 |
| 23:30 | 5 |

## Root cause

w03's **request-based** memory sits at exactly **70%** — the `targetThresholds.memory` line — and that floor is almost entirely immovable stateful load: `authentik-server` + three CNPG DBs (`harbor-db-3`, `jellystat-db-1`, `shlink-db-1`) + `minio`. Since the PVC guard restricts the descheduler to stateless pods, evicting them can never bring w03 under 70% — so it re-evicts a handful (including single-replica controllers like `ingress-nginx-controller` and the `external-secrets` webhook) every cycle with no rebalancing benefit.

w03's **actual** usage is only ~55%, so it is not genuinely under memory pressure — the 70% request target is simply too tight for a node legitimately carrying this many databases.

## Fix

Raise `targetThresholds.memory` 70 → 80. This clears w03's normal stateful floor so it stops being classified overutilized (ending the churn), while still catching a node genuinely packed by requests. `cpu`, `pods`, and the underutilized `thresholds` are unchanged. A per-node eviction cap was considered and rejected — it would throttle the churn while hiding the cause rather than fixing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqmJaX2sTpXx314RGghNC