### PR TITLE
chore: bump vollmint 0.3.0 -> 0.3.1 (venmo cashout pairing fix)

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/vollmint-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/vollmint-ocirepository.yaml
@@ -11,6 +11,6 @@ spec:
   interval: 1h
   url: oci://harbor.vollminlab.com/vollminlab/charts/vollmint
   ref:
-    tag: "0.3.0"
+    tag: "0.3.1"
   secretRef:
     name: harbor-vollminlab-pull


### PR DESCRIPTION
## Summary

Bumps the vollmint OCIRepository chart/image tag from 0.3.0 to 0.3.1.

v0.3.1 adds matcher pass (a2) (vollmint PR #9): bank-side VENMO CASHOUT credits now pair with venmo_csv "Standard Transfer" rows and both legs become Transfer, eliminating the double-count that inflated income by ~$511 in May. The deployed image must include this before the June/July Venmo statement import Jobs run, so cashouts pair automatically instead of needing manual SQL cleanup.

Build run 30872338781 succeeded — image and chart 0.3.1 published to Harbor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNYieb3KXVmxTbz7pT5HRX