### PR TITLE
fix(qbittorrent): bump gluetun v3.41.1 -> v3.41.3 (residual DNS memory leak)

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
@@ -83,7 +83,7 @@ spec:
             - name: downloads
               mountPath: /downloads
         - name: gluetun
-          image: ghcr.io/qdm12/gluetun:v3.41.1@sha256:2f33c71e5e164fcd51a962cb950134df25155593edf0c3e1201f888d027049b4
+          image: ghcr.io/qdm12/gluetun:v3.41.3@sha256:fa19cc76b2af13d57a8d3dc3066f2ada061b1c761b8aecf989b3877c0486e027
           securityContext:
             capabilities:
               add: [NET_ADMIN]
@@ -108,6 +108,9 @@ spec:
               value: "8080"
             # DoT upstream in gluetun v3.41.x leaks UDP sockets when queries time out
             # during VPN degradation (upstream #3351/#3377) — DoH is the endorsed workaround
+            # (#956). A slower residual anon-memory leak remains on the DoH path; v3.41.3
+            # pulls in the post-v3.41.1 DNS-engine / DoT-pool fixes to reduce it. The 512Mi
+            # limit stays as the circuit-breaker (OOM-restart) if any leak persists.
             - name: DNS_UPSTREAM_RESOLVER_TYPE
               value: "doh"
           envFrom:


### PR DESCRIPTION
## Problem

karma is firing **NodeMemoryMajorPagesFaults** on `k8sworker03` (~835–1,000 majflt/s vs a 500 threshold, chronic). While investigating the node's memory pressure, the gluetun VPN sidecar in `qbittorrent` surfaced as a distinct issue:

- gluetun holds **~509 MiB anonymous RSS** (only 1 MiB cache), **pinned at its 512Mi limit** — the node has **no swap**, so anonymous memory can't be reclaimed.
- Normal gluetun steady-state is 30–80 MiB, so this is a genuine leak, not working set.
- #956 (switch to DoH) stopped the fast DoT crash-loop — **0 restarts in 14 days** — but a **slower residual leak persists on the DoH path** (~25 MiB/day creep), leaving the sidecar one allocation from OOM and adding memory pressure to w03, the most memory-dense worker.

## Change

Bump gluetun **v3.41.1 → v3.41.3** (latest stable). The project now continues under the `passteque` fork after qdm12 handed it off post-v3.41.1; images are still published to `ghcr.io/qdm12/gluetun`. Verified the tag exists as a multi-arch OCI index with `linux/amd64` and pinned by digest `sha256:fa19cc76…`.

v3.41.3 pulls in the post-v3.41.1 DNS-engine and **DoT connection-pool** fixes (v3.41.2) plus a port-forwarding deadlock fix.

## Honest caveat

Our leak is now on the **DoH** path (post-#956), whereas v3.41.2's headline fix targets **DoT** pool behavior — so this is the right maintenance move and *may* reduce the residual leak, but it is not guaranteed to fully eliminate it. DoH and the **512Mi cap are retained**; the cap stays as the circuit-breaker (OOM-restart) if any leak survives. Confirmation is via the gluetun RSS trend after deploy.

Companion PR (separate concern) will tune the `NodeMemoryMajorPagesFaults` alert, whose primary driver on w03 is qbittorrent's torrent disk I/O, not gluetun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqmJaX2sTpXx314RGghNC