### PR TITLE
fix(monitoring): memory-gate NodeMemoryMajorPagesFaults to stop w03 false positive

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -266,6 +266,14 @@ data:
       disabled:
         KubeClientCertificateExpiration: true
         KubeJobFailed: true
+        # Replaced by a memory-gated variant in prometheusrule-custom.yaml. The stock
+        # rule fires on major-fault RATE alone (>500/s for 15m), which on k8sworker03
+        # is driven purely by qbittorrent torrent disk I/O churning the page cache
+        # while the node has ~36% memory free — a chronic false positive. The
+        # replacement additionally requires MemAvailable < 15% so it only fires on
+        # genuine memory-starvation thrash, matching the alert's own "check that there
+        # is enough memory available" remediation text.
+        NodeMemoryMajorPagesFaults: true
 
     kube-state-metrics:
       podLabels:

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -190,6 +190,40 @@ spec:
             summary: "Node {{ $labels.instance }} root disk below 10% free"
             description: "Node {{ $labels.instance }} has {{ $value | humanizePercentage }} free on root filesystem. Immediate action required."
 
+    # Memory-gated replacement for the stock node-exporter NodeMemoryMajorPagesFaults
+    # rule (disabled via defaultRules.disabled in configmap.yaml). The stock rule alerts
+    # on the major-fault RATE alone (rate(node_vmstat_pgmajfault[5m]) > 500 for 15m). On
+    # k8sworker03 that rate sits chronically at ~800-1300/s purely from qbittorrent
+    # torrent disk I/O refaulting the page cache — while the node has ~36% memory free.
+    # That is a benign I/O signature, not memory exhaustion, so the stock alert was a
+    # standing false positive whose own text ("check that there is enough memory
+    # available") contradicted the node's actual state. Adding the MemAvailable < 15%
+    # conjunction makes it fire only when high fault rate coincides with genuinely low
+    # available memory — the real memory-starvation thrash the alert is meant to catch
+    # (which inherently drives MemAvailable down as reclaim churns). I/O-driven fault
+    # storms on a node with ample free memory no longer trip it.
+    - name: node-memory
+      rules:
+        - alert: NodeMemoryMajorPagesFaults
+          expr: |
+            (rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > 500)
+              and on(instance)
+            (
+              node_memory_MemAvailable_bytes{job="node-exporter"}
+                / node_memory_MemTotal_bytes{job="node-exporter"} < 0.15
+            )
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Memory major page faults are occurring at very high rate."
+            description: >-
+              Memory major pages are occurring at very high rate at {{ $labels.instance }}
+              ({{ printf "%.0f" $value }} major faults/s over the last 15 minutes) while
+              available memory on the node is below 15%. The node is likely thrashing on
+              genuine memory pressure — check workloads and memory requests on this node.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodememorymajorpagesfaults
+
     - name: pod-health
       rules:
         - alert: PodCrashLooping


### PR DESCRIPTION
## Summary

The `NodeMemoryMajorPagesFaults` warning that karma has been reporting active on **k8sworker03** is a chronic false positive. The stock node-exporter mixin rule alerts on the major-fault *rate* alone (`rate(node_vmstat_pgmajfault[5m]) > 500` for 15m). On w03 that rate sits chronically at ~800–1300/s — but it's driven purely by **qbittorrent torrent disk I/O** refaulting the page cache, while the node has **~36% memory free**. That's a benign I/O signature, not memory exhaustion, so the alert's own remediation text ("check that there is enough memory available") contradicts the node's actual state.

## Change

- Disable the chart-default rule via `defaultRules.disabled.NodeMemoryMajorPagesFaults` in `configmap.yaml`.
- Add a **memory-gated replacement** in `prometheusrule-custom.yaml` (new `node-memory` group) that keeps the `> 500` fault-rate condition but additionally requires `node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes < 0.15`.

The alert now fires only when a high fault rate coincides with genuinely low available memory — the real memory-starvation thrash it's meant to catch (which inherently drives `MemAvailable` down as reclaim churns). I/O-driven fault storms on a node with ample free memory no longer trip it.

Same threshold (500/s), same `for: 15m`, same `severity: warning` — only the memory gate is added. `promtool check rules` passes.

This is the alert-tuning half of the w03 major-page-fault investigation; the gluetun memory-leak half is #1002 (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqmJaX2sTpXx314RGghNC