### PR TITLE
fix(etcd-defrag): tolerate descheduler eviction with backoffLimit

### DIFF
--- a/clusters/vollminlab-cluster/kube-system/etcd-defrag/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/kube-system/etcd-defrag/app/cronjob.yaml
@@ -15,7 +15,14 @@ spec:
   jobTemplate:
     spec:
       ttlSecondsAfterFinished: 3600
-      backoffLimit: 0
+      # The descheduler (LowNodeUtilization, every 30m) can evict this short-lived
+      # pod mid-run as a stateless rebalance victim — it has no PVC/local storage,
+      # so the descheduler's PVC guard does not cover it. With backoffLimit 0 a
+      # single eviction flips the Job straight to Failed → KubeJobFailed alert.
+      # Allow retries so an eviction just respawns a fresh pod; defrag is idempotent
+      # and completes in seconds, so a re-run of an already-defragged endpoint is
+      # harmless.
+      backoffLimit: 3
       template:
         metadata:
           labels:


### PR DESCRIPTION
## Problem

`KubeJobFailed` fired for `kube-system/etcd-defrag-29763540`. **etcd is healthy** — all 3 members in sync, DB ~285 MB at ~9% fragmentation, no endpoint errors. The Job failed for an unrelated reason:

```
LowNodeUtilization  pod/etcd-defrag-...-sh6hf  pod eviction from k8sworker03 by sigs.k8s.io/descheduler
```

The defrag pod was **evicted mid-run by the descheduler**. The pod is stateless (no PVC, no local storage), so it is not covered by the descheduler's PVC guard and is a valid `LowNodeUtilization` rebalance victim. With `backoffLimit: 0`, that single eviction flipped the Job straight to `Failed`.

Because the descheduler runs every 30 min and the daily 3am job pod can land on any worker, this recurs whenever a descheduler cycle overlaps the job's brief lifetime.

## Fix

Raise `backoffLimit: 0 → 3`. An eviction now just respawns a fresh pod instead of failing the Job. `etcdctl defrag` is idempotent and completes in seconds, so re-defragging an already-processed endpoint is harmless. This mirrors how other descheduler-collateral jobs (mount-healer) self-heal via retry.

Scope is limited to the etcd-defrag manifest; the descheduler config is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqmJaX2sTpXx314RGghNC