### PR TITLE
chore(etcd-defrag): drop stale (leader)/(follower) labels from defrag log lines

### DIFF
--- a/clusters/vollminlab-cluster/kube-system/etcd-defrag/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/kube-system/etcd-defrag/app/cronjob.yaml
@@ -43,15 +43,22 @@ spec:
                   CERTS="--cacert=/etc/kubernetes/pki/etcd/ca.crt --cert=/etc/kubernetes/pki/etcd/server.crt --key=/etc/kubernetes/pki/etcd/server.key"
                   echo "etcd defrag started at $(date)"
 
-                  echo "Defragging k8scp01 (follower)..."
+                  # Defrag each member sequentially. The 10s gap keeps only one
+                  # member offline at a time, so quorum is always preserved. Order
+                  # is fixed and low-stakes here: the DB is small (~285 MB) and each
+                  # defrag finishes in seconds, so even defragging the current leader
+                  # triggers at most a sub-second re-election. The etcd leader is not
+                  # pinned to any node and moves on every restart/election, so members
+                  # are labelled by node name only — never claim a fixed leader.
+                  echo "Defragging k8scp01..."
                   kubectl exec -n kube-system etcd-k8scp01 -- etcdctl --endpoints=https://192.168.152.8:2379 $CERTS --command-timeout=120s defrag
                   sleep 10
 
-                  echo "Defragging k8scp03 (follower)..."
+                  echo "Defragging k8scp03..."
                   kubectl exec -n kube-system etcd-k8scp03 -- etcdctl --endpoints=https://192.168.152.10:2379 $CERTS --command-timeout=120s defrag
                   sleep 10
 
-                  echo "Defragging k8scp02 (leader)..."
+                  echo "Defragging k8scp02..."
                   kubectl exec -n kube-system etcd-k8scp02 -- etcdctl --endpoints=https://192.168.152.9:2379 $CERTS --command-timeout=120s defrag
 
                   echo "etcd defrag complete at $(date)"


### PR DESCRIPTION
## What

The etcd-defrag CronJob's shell script labelled each member as `(leader)` or `(follower)` in its `echo` lines. Those labels were stale — they hardcoded cp02 as the leader, but etcd leadership is dynamic and moves on every restart/election (cp01 is currently leader). A fixed label is misleading in the logs and will always drift.

## Change

- Strip `(leader)`/`(follower)` from the three defrag `echo` lines → members are identified by node name only.
- Add a comment explaining the defrag order is low-stakes here: the DB is small (~285 MB), each defrag finishes in seconds, and the 10s inter-member gap keeps only one member offline at a time, so quorum always holds and the worst case is a sub-second re-election.

No functional change — defrag order (cp01 → cp03 → cp02) and the `etcdctl` commands are unchanged. Cosmetic follow-up to #1006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqmJaX2sTpXx314RGghNC