### PR TITLE
fix(velero): FSB emptyDir excludes were dead config — move to workload.main.podSpec.annotations + exclude `shared`

### DIFF
--- a/clusters/vollminlab-cluster/1password/1password-connect/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/1password/1password-connect/app/configmap.yaml
@@ -16,6 +16,14 @@ data:
     connect:
       credentialsName: onepassword-connect
       credentialsKey: 1password-credentials.json
+      # Velero FSB: exclude the re-syncable `shared-data` cache emptyDir from
+      # file-system backup. Certain ephemeral shared emptyDirs hang the kopia
+      # data-mover (PartiallyFailed backups + orphaned pods). The DR-critical
+      # Connect credentials live in the separate credentials secret volume, not
+      # here, so excluding this cache is safe. The opc/connect chart honors
+      # connect.podAnnotations (lands on the API+sync pod template).
+      podAnnotations:
+        backup.velero.io/backup-volumes-excludes: "shared-data"
       api:
         serviceMonitor:
           enabled: true

--- a/clusters/vollminlab-cluster/mediastack/audiobookshelf/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/audiobookshelf/app/configmap.yaml
@@ -53,3 +53,13 @@ data:
       app: audiobookshelf
       env: production
       category: media
+    # Velero FSB: exclude ephemeral scratch emptyDirs. MUST live under
+    # workload.main.podSpec.annotations — the TrueCharts common chart ignores a
+    # top-level podAnnotations key, so the annotation never reached the pod. The
+    # `shared` volume in particular hangs the kopia data-mover (PartiallyFailed
+    # backups + orphaned pods); the rest are pure scratch not worth backing up.
+    workload:
+      main:
+        podSpec:
+          annotations:
+            backup.velero.io/backup-volumes-excludes: "tmp,varlogs,varrun,devshm,shared"

--- a/clusters/vollminlab-cluster/mediastack/prowlarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/prowlarr/app/configmap.yaml
@@ -18,8 +18,16 @@ data:
       app: prowlarr
       env: production
       category: media
-    podAnnotations:
-      backup.velero.io/backup-volumes-excludes: "tmp,varlogs,varrun,devshm"
+    # Velero FSB: exclude ephemeral scratch emptyDirs. MUST live under
+    # workload.main.podSpec.annotations — the TrueCharts common chart ignores a
+    # top-level podAnnotations key, so the annotation never reached the pod. The
+    # `shared` volume in particular hangs the kopia data-mover (PartiallyFailed
+    # backups + orphaned pods); the rest are pure scratch not worth backing up.
+    workload:
+      main:
+        podSpec:
+          annotations:
+            backup.velero.io/backup-volumes-excludes: "tmp,varlogs,varrun,devshm,shared"
     env:
       PROWLARR__AUTH__METHOD: "External"
     terminationGracePeriodSeconds: 60

--- a/clusters/vollminlab-cluster/mediastack/radarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/radarr/app/configmap.yaml
@@ -51,8 +51,16 @@ data:
       app: radarr
       env: production
       category: media
-    podAnnotations:
-      backup.velero.io/backup-volumes-excludes: "tmp,varlogs,varrun,devshm"
+    # Velero FSB: exclude ephemeral scratch emptyDirs. MUST live under
+    # workload.main.podSpec.annotations — the TrueCharts common chart ignores a
+    # top-level podAnnotations key, so the annotation never reached the pod. The
+    # `shared` volume in particular hangs the kopia data-mover (PartiallyFailed
+    # backups + orphaned pods); the rest are pure scratch not worth backing up.
+    workload:
+      main:
+        podSpec:
+          annotations:
+            backup.velero.io/backup-volumes-excludes: "tmp,varlogs,varrun,devshm,shared"
     env:
       RADARR__AUTH__METHOD: "External"
     securityContext:

--- a/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/readarr/app/configmap.yaml
@@ -55,14 +55,19 @@ data:
       app: readarr
       env: production
       category: media
-    podAnnotations:
-      backup.velero.io/backup-volumes-excludes: "tmp,varlogs,varrun,devshm"
     image:
       repository: ghcr.io/pennydreadful/bookshelf
       tag: hardcover-v0.4.20.129@sha256:388eecc94362580eae31ee0a454be6af516f8a311f8432a521c202fb475f4359
     workload:
       main:
         podSpec:
+          # Velero FSB: exclude ephemeral scratch emptyDirs. MUST live under
+          # workload.main.podSpec.annotations — the TrueCharts common chart ignores
+          # a top-level podAnnotations key, so the annotation never reached the pod.
+          # The `shared` volume in particular hangs the kopia data-mover
+          # (PartiallyFailed backups + orphaned pods); the rest are pure scratch.
+          annotations:
+            backup.velero.io/backup-volumes-excludes: "tmp,varlogs,varrun,devshm,shared"
           containers:
             main:
               env:

--- a/clusters/vollminlab-cluster/mediastack/sabnzbd/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sabnzbd/app/configmap.yaml
@@ -26,6 +26,16 @@ data:
       app: sabnzbd
       env: production
       category: media
+    # Velero FSB: exclude ephemeral scratch emptyDirs. MUST live under
+    # workload.main.podSpec.annotations — the TrueCharts common chart ignores a
+    # top-level podAnnotations key, so the annotation never reached the pod. The
+    # `shared` volume in particular hangs the kopia data-mover (PartiallyFailed
+    # backups + orphaned pods); the rest are pure scratch not worth backing up.
+    workload:
+      main:
+        podSpec:
+          annotations:
+            backup.velero.io/backup-volumes-excludes: "tmp,varlogs,varrun,devshm,shared"
     affinity:
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:

--- a/clusters/vollminlab-cluster/mediastack/sonarr/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sonarr/app/configmap.yaml
@@ -34,8 +34,16 @@ data:
       app: sonarr
       env: production
       category: media
-    podAnnotations:
-      backup.velero.io/backup-volumes-excludes: "tmp,varlogs,varrun,devshm"
+    # Velero FSB: exclude ephemeral scratch emptyDirs. MUST live under
+    # workload.main.podSpec.annotations — the TrueCharts common chart ignores a
+    # top-level podAnnotations key, so the annotation never reached the pod. The
+    # `shared` volume in particular hangs the kopia data-mover (PartiallyFailed
+    # backups + orphaned pods); the rest are pure scratch not worth backing up.
+    workload:
+      main:
+        podSpec:
+          annotations:
+            backup.velero.io/backup-volumes-excludes: "tmp,varlogs,varrun,devshm,shared"
     env:
       SONARR__AUTH__METHOD: "External"
     securityContext:


### PR DESCRIPTION
## Problem

The recurring "Velero backups haven't been running" symptom is **PartiallyFailed backups + orphaned data-mover pods**, not a scheduling failure. Backups trigger nightly, but the kopia data-path microservice hangs forever on certain ephemeral shared `emptyDir` volumes (arr `shared`, connect `shared-data`). The node-agent spins in a 5s retry livelock, the parent backup runs to the ~4h `itemOperationTimeout` and finishes `PartiallyFailed`, and the data-mover pod stays `Running` for 16–20h.

## Root cause (the surprise)

Every mediastack arr configmap already carried a `backup.velero.io/backup-volumes-excludes` annotation — but under a **top-level `podAnnotations` key**. TrueCharts common charts read pod-template annotations **only** from `workload.main.podSpec.annotations` (`charts/common/templates/class/_deployment.tpl`); the top-level key is silently ignored. So the excludes **never reached the pods** — Velero has been FSB-backing-up every scratch emptyDir (`tmp/varlogs/varrun/devshm`) on every arr pod all along, and nothing was excluding the problematic `shared` volume.

## Fix

- Move the exclude to `workload.main.podSpec.annotations` for all 6 arr apps (prowlarr, radarr, sonarr, readarr, audiobookshelf, sabnzbd) and add `shared` → `tmp,varlogs,varrun,devshm,shared`.
- Add `connect.podAnnotations` to onepassword-connect excluding its re-syncable `shared-data` cache emptyDir. The `opc/connect` chart **does** honor `connect.podAnnotations`; the DR-critical Connect credentials live in the separate credentials secret volume, so excluding the cache is safe.

Verified with `helm template` against each app's own chart: the exclude annotation lands on every pod template, and readarr's existing `LSIO_NON_ROOT_USER` env override is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqmJaX2sTpXx314RGghNC