### PR TITLE
feat(homepage): add missing Goldilocks + Filebrowser dashboard links

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -351,6 +351,12 @@ data:
                 icon: https://raw.githubusercontent.com/prymitive/karma/main/ui/public/favicon.ico
                 namespace: monitoring
                 app: karma
+            - Goldilocks:
+                description: VPA resource right-sizing recommendations
+                href: https://goldilocks.vollminlab.com
+                icon: mdi-scale-balance
+                namespace: goldilocks
+                app: goldilocks
         - Tools:
             - Homepage:
                 description: This dashboard
@@ -370,6 +376,12 @@ data:
                 icon: shlink.png
                 namespace: shlink
                 app: shlink-web
+            - Filebrowser:
+                description: Web file manager for media storage
+                href: https://filebrowser.vollminlab.com
+                icon: filebrowser.png
+                namespace: mediastack
+                app: filebrowser
             - Vollmint:
                 description: Household budget tracker
                 href: https://vollmint.vollminlab.com


### PR DESCRIPTION
## What

Adds Homepage dashboard links for the two in-cluster services that have web frontends but were missing from the dashboard:

- **Goldilocks** → *Monitoring & Observability* group (VPA resource right-sizing dashboard)
- **Filebrowser** → *Tools* group (web file manager, mediastack)

Both are simple href buttons with a Kubernetes status badge (`namespace` + `app`). The target pods already carry matching `app.kubernetes.io/name` labels, so no widget API keys or RBAC changes are required. Both services sit behind the domain-wide Authentik forward-auth, so a plain link is the correct treatment.

## Scan result

Cross-referenced every in-cluster Ingress host against the Homepage config. These two were the only real dashboards not linked. Excluded (correctly): `go`/`vollm.in` (Shlink redirect domains, not UIs) and `s3` (MinIO S3 API endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqmJaX2sTpXx314RGghNC