### PR TITLE
fix(homepage): use real Goldilocks icon

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -354,7 +354,7 @@ data:
             - Goldilocks:
                 description: VPA resource right-sizing recommendations
                 href: https://goldilocks.vollminlab.com
-                icon: mdi-scale-balance
+                icon: goldilocks.png
                 namespace: goldilocks
                 app: goldilocks
         - Tools:


### PR DESCRIPTION
Swaps the `mdi-scale-balance` placeholder for the dedicated `goldilocks.png` from dashboard-icons (verified present: `png`/`svg`/`webp` all resolve).

Single-line change in `homepage/homepage/app/configmap.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqmJaX2sTpXx314RGghNC