### PR TITLE
fix(monitoring): raise grafana memory limit + loosen readiness probe (503 fix)

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -131,10 +131,26 @@ data:
       resources:
         requests:
           cpu: 100m
-          memory: 384Mi
+          # Bumped 384Mi -> 512Mi: steady-state RSS sat at ~764Mi against the old
+          # 768Mi limit (cgroup hit memory.max 44k+ times), so the reservation was
+          # unrealistically low. Heavier after the 103-panel CNPG dashboard landed.
+          memory: 512Mi
         limits:
           cpu: 500m
-          memory: 768Mi
+          # Raised 768Mi -> 1Gi. At 768Mi grafana pinned the cgroup ceiling, stalled
+          # on allocation, and the /api/health probe timed out -> pod pulled from the
+          # Service -> ingress 503 flapping. 1Gi leaves ~256Mi headroom.
+          memory: 1Gi
+      # The chart default leaves readiness on the k8s 1s timeout. A brief GC pause
+      # near the memory ceiling was enough to miss it 3x and eject grafana from the
+      # Service (hard 503). 5s tolerates transient stalls without masking a real hang.
+      readinessProbe:
+        httpGet:
+          path: /api/health
+          port: 3000
+        timeoutSeconds: 5
+        periodSeconds: 10
+        failureThreshold: 3
       plugins:
         - grafana-lokiexplore-app
 


### PR DESCRIPTION
**BLUF:** Grafana was flapping hard 503s because the container pinned its 768Mi cgroup ceiling and the 1s readiness-probe timeout couldn't survive the resulting allocation stalls. This raises the memory limit to 1Gi and loosens the readiness probe.

## Root cause

Grafana sat at the cgroup wall, not the node:
- `memory.current` 767.9Mi vs `memory.max` 768Mi
- `memory.events` `max` counter = **44827** (allocation throttled at the ceiling 44k+ times)
- `oom_kill` = **0** — never OOM-killed, no restart, no data loss; just starved

When it stalled on allocation near the ceiling, the readiness probe on `/api/health` (chart default = k8s 1s timeout) missed 3× → grafana was pulled from the Service EndpointSlice → ingress-nginx returned 503, flapping as the pod cycled ready/not-ready. Headlamp showed the readiness/liveness `context deadline exceeded` events matching this.

The 103-panel CloudNativePG dashboard (PR #1012) pushed steady-state RSS right up to the old limit, which is what tipped it over.

## Fix

- `limits.memory` 768Mi → **1Gi** (~256Mi headroom over observed steady-state)
- `requests.memory` 384Mi → **512Mi** (reservation matched to real RSS)
- add `readinessProbe.timeoutSeconds: 5` (was the implicit 1s) so a transient GC pause near the ceiling no longer trips a hard 503; `periodSeconds`/`failureThreshold` unchanged

Immediate relief already applied out-of-band: the grafana pod was restarted (fresh pod ~181Mi, endpoint ready), so it's serving now — this PR is the durable fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqmJaX2sTpXx314RGghNC