### PR TITLE
chore: bump vollmint 0.3.1 -> 0.3.2 (Capital One payment descriptor matcher fix)

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/vollmint-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/vollmint-ocirepository.yaml
@@ -11,6 +11,6 @@ spec:
   interval: 1h
   url: oci://harbor.vollminlab.com/vollminlab/charts/vollmint
   ref:
-    tag: "0.3.1"
+    tag: "0.3.2"
   secretRef:
     name: harbor-vollminlab-pull


### PR DESCRIPTION
## Summary
- Bumps the vollmint OCIRepository chart tag to 0.3.2 (chart appVersion drives the image tag, so this deploys the new image too).
- 0.3.2 = vollmint PR #10: the transfer matcher's card-payment pass now recognizes Capital One's post-Discover-sale descriptors (`DISCOVER CAP ONE ONLINE/MOBILE PMT` / `CAPITAL ONE ONLINE/MOBILE PYMT`), so those payoff legs pair as Transfer instead of counting as spend/income.
- Once deployed, the pending $314.79 payment (txn 1625) pairs automatically on the first sync after its card-side credit posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNYieb3KXVmxTbz7pT5HRX