### PR TITLE
fix: mount-healer backoffLimit 0 -> 2 to stop KubeJobFailed eviction noise

### DIFF
--- a/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/cronjob.yaml
@@ -15,7 +15,15 @@ spec:
   jobTemplate:
     spec:
       ttlSecondsAfterFinished: 3600
-      backoffLimit: 0
+      # backoffLimit 2 (not 0): the heal script never self-fails (set -u, every
+      # path returns 0 — even a detach timeout only logs + emits an event), so a
+      # Failed job is always external pod death — almost always the descheduler
+      # LowNodeUtilization plugin evicting this tiny Burstable pod off a hot node.
+      # With backoffLimit 0 that single eviction => Failed job => KubeJobFailed
+      # noise. The script is idempotent and restore_orphans repairs any interrupted
+      # heal on the next run, so retrying is safe; a genuine persistent breakage
+      # (RBAC/image-pull) still exhausts retries and alerts.
+      backoffLimit: 2
       template:
         metadata:
           labels:


### PR DESCRIPTION
## What

Bump `longhorn-mount-healer` CronJob `jobTemplate.spec.backoffLimit` from **0 → 2**.

## Why

`KubeJobFailed` has been firing repeatedly for `longhorn-mount-healer-*` jobs. The healer isn't failing to heal — the **descheduler is evicting its pod mid-run**:

```
Evicted pod pod="kube-system/longhorn-mount-healer-...-pjsdg" strategy="LowNodeUtilization" node="k8sworker03"
```

When a node goes overutilized, the descheduler's LowNodeUtilization plugin evicts low-priority Burstable pods off it — the healer (req 32Mi / 10m, Burstable) is an easy target. With `backoffLimit: 0`, that single eviction marks the Job `Failed` → `KubeJobFailed`.

It's pure collateral:
- The heal script **never self-fails** — `set -u` (not `-e`), and every path returns 0, including a detach timeout (it only logs + emits a `HealedStaleMountTimeout` event). So a Failed Job is *always* external pod death, never heal-logic failure.
- Interruption is already self-repairing: `restore_orphans` runs first on every invocation and restores any Deployment a killed heal left at 0 replicas (via the `original-replicas` annotation).
- Evicting a 32Mi pod off a hot node frees essentially nothing.

## The change

`backoffLimit: 2` lets an evicted pod be replaced; the idempotent script re-runs and Completes, so no `KubeJobFailed`. A genuine persistent breakage (RBAC gone, image-pull failure) still exhausts the retries and alerts — no real signal lost.

Considered and rejected as heavier for one tiny pod: high `priorityClassName`/`system-cluster-critical` (drags in preemption semantics), `maxUnavailable: 0` PDB (blocks node drains), descheduler evictor tuning (too broad).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqmJaX2sTpXx314RGghNC