### PR TITLE
fix(monitoring): SABnzbd per-server panels undercount by exporter-restart count

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/arr-media-dashboard-configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/arr-media-dashboard-configmap.yaml
@@ -2307,7 +2307,7 @@ data:
                     "uid": "${DS_PROMETHEUS}"
                   },
                   "editorMode": "code",
-                  "expr": "avg(increase(sabnzbd_server_downloaded_bytes{job=~\"${sabnzbd_instance}\"}[$__rate_interval])) by (server)",
+                  "expr": "sum by (server)(increase(sabnzbd_server_downloaded_bytes{job=~\"${sabnzbd_instance}\"}[$__rate_interval]))",
                   "legendFormat": "__auto",
                   "range": true,
                   "refId": "A"
@@ -2539,7 +2539,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "avg(increase(sabnzbd_server_downloaded_bytes{job=~\"${sabnzbd_instance}\"}[$__range])) by (server)",
+                  "expr": "sum by (server)(increase(sabnzbd_server_downloaded_bytes{job=~\"${sabnzbd_instance}\"}[$__range]))",
                   "format": "time_series",
                   "instant": true,
                   "legendFormat": "{{server}}",
@@ -2620,7 +2620,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "avg(increase(sabnzbd_server_downloaded_bytes{job=~\"${sabnzbd_instance}\"}[$__range])) by (server)",
+                  "expr": "sum by (server)(increase(sabnzbd_server_downloaded_bytes{job=~\"${sabnzbd_instance}\"}[$__range]))",
                   "format": "time_series",
                   "instant": true,
                   "legendFormat": "{{server}}",


### PR DESCRIPTION
## Problem
The three per-server SABnzbd panels on the Arr Media dashboard use `avg(increase(sabnzbd_server_downloaded_bytes{...}) by (server)`. That metric carries an ephemeral `instance` label, and the `sabnzbd-exportarr` pod is evicted + recreated **~13×/week** by the descheduler (`LowNodeUtilization`). Each recreation begins a new counter segment, so `avg()` divides the true total by the number of segments in the window.

**Measured over the last 7d:** `sum by (server)(increase[7d])` = **69.2 GB** (matches SABnzbd's own week total) vs the panel's `avg(...) by (server)` = **5.3 GB** — a 13× undercount. This is the "recent downloads not showing" symptom.

## Fix
Switch the aggregation from `avg(...) by (server)` to `sum by (server)(...)`, which correctly adds the per-segment increases across exporter restarts.

Affected panels:
- **Download Rate** (`[$__rate_interval]`)
- **Recent Downloaded By Server** (`[$__range]`)
- **Recent Download Percent** (`[$__range]`)

`Lifetime Downloads By Server` (raw counter gauge) is unchanged.

## Related
The exporter-eviction root cause — which also makes the live speed/queue panels read idle during an active download — is addressed separately with a PodDisruptionBudget (follow-up PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqmJaX2sTpXx314RGghNC