### PR TITLE
fix(mediastack): PDBs to stop descheduler evicting the exportarr pods

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/bazarr-exportarr/app/bazarr-exportarr-pdb.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr-exportarr/app/bazarr-exportarr-pdb.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: bazarr-exportarr
+  namespace: mediastack
+  labels:
+    app: bazarr-exportarr
+    env: production
+    category: media
+spec:
+  # 1 replica + minAvailable: 1 => 0 allowed disruptions, so the descheduler's
+  # DefaultEvictor (which honors PDBs) cannot evict this pod during
+  # LowNodeUtilization rebalancing. Stops the ~13x/week eviction churn that
+  # creates metric scrape gaps.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: bazarr-exportarr

--- a/clusters/vollminlab-cluster/mediastack/bazarr-exportarr/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr-exportarr/app/kustomization.yaml
@@ -5,5 +5,6 @@ metadata:
 resources:
   - bazarr-exportarr-apikey-externalsecret.yaml
   - bazarr-exportarr-deployment.yaml
+  - bazarr-exportarr-pdb.yaml
   - bazarr-exportarr-service.yaml
   - bazarr-exportarr-servicemonitor.yaml

--- a/clusters/vollminlab-cluster/mediastack/sabnzbd/app/exportarr-pdb.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sabnzbd/app/exportarr-pdb.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: sabnzbd-exportarr
+  namespace: mediastack
+  labels:
+    app: sabnzbd-exportarr
+    env: production
+    category: media
+spec:
+  # 1 replica + minAvailable: 1 => 0 allowed disruptions, so the descheduler's
+  # DefaultEvictor (which honors PDBs) cannot evict this pod during
+  # LowNodeUtilization rebalancing. Stops the ~13x/week eviction churn that
+  # fragments the download counters and creates metric scrape gaps.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: sabnzbd-exportarr

--- a/clusters/vollminlab-cluster/mediastack/sabnzbd/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sabnzbd/app/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - configmap.yaml
   - sabnzbd-exportarr-apikey-externalsecret.yaml
   - exportarr-deployment.yaml
+  - exportarr-pdb.yaml
   - exportarr-service.yaml
   - exportarr-servicemonitor.yaml
   - helmrelease.yaml


### PR DESCRIPTION
## Problem
`sabnzbd-exportarr` and `bazarr-exportarr` are stateless (no PVC), have no `priorityClassName`, and request only 10m CPU / 32Mi — prime targets for the descheduler's `LowNodeUtilization` rebalancing. Observed churn: **~13 recreations in 7 days** (both pods were caught being evicted off `k8sworker02` within the same hour while diagnosing this). The descheduler's `DefaultEvictor` already protects `PodsWithPVC`, but these fall through.

Each eviction causes two dashboard symptoms:
- **Counter fragmentation** — every new pod starts a new `instance` segment for `sabnzbd_server_downloaded_bytes`, which is why the per-server download panels undercount (fixed on the dashboard side in #1020).
- **Scrape gaps** — a download that runs during the ~30s reschedule window has no fresh sample, so the live speed/queue panels read **idle during an active download**. This PR is what actually fixes that symptom.

## Fix
Add a `PodDisruptionBudget` (`minAvailable: 1`) for each exporter. With a single replica that means **0 allowed disruptions**; the `DefaultEvictor` honors PDBs and skips the pod, ending the rebalancing churn.

## Tradeoff
`minAvailable: 1` also blocks *voluntary* node drains for these two pods, so a node upgrade will need `kubectl drain --disable-eviction` (or a force-delete) for them. Harmless for a stateless exporter that's rescheduled anyway.

## Files
- `mediastack/sabnzbd/app/exportarr-pdb.yaml` (+ kustomization)
- `mediastack/bazarr-exportarr/app/bazarr-exportarr-pdb.yaml` (+ kustomization)

## Verify after merge
```
kubectl get pdb -n mediastack sabnzbd-exportarr bazarr-exportarr
# ALLOWED DISRUPTIONS should be 0
```
Then watch for absence of `descheduler` eviction events on the exporter pods over the next day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqmJaX2sTpXx314RGghNC