### PR TITLE
fix(mediastack): normalize exportarr job labels to clean app names

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/bazarr-exportarr/app/bazarr-exportarr-service.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr-exportarr/app/bazarr-exportarr-service.yaml
@@ -7,6 +7,10 @@ metadata:
     app: bazarr-exportarr
     env: production
     category: media
+    # jobLabel source for the ServiceMonitor — makes the Prometheus `job` label
+    # (and thus the Arr Media dashboard row) read "bazarr" instead of
+    # "bazarr-exportarr", matching the native radarr/sonarr/prowlarr/readarr rows.
+    app.kubernetes.io/name: bazarr
 spec:
   type: ClusterIP
   selector:

--- a/clusters/vollminlab-cluster/mediastack/bazarr-exportarr/app/bazarr-exportarr-servicemonitor.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr-exportarr/app/bazarr-exportarr-servicemonitor.yaml
@@ -11,7 +11,7 @@ spec:
   endpoints:
     - path: /metrics
       port: metrics
-  jobLabel: app
+  jobLabel: app.kubernetes.io/name
   selector:
     matchLabels:
       app: bazarr-exportarr

--- a/clusters/vollminlab-cluster/mediastack/sabnzbd/app/exportarr-service.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sabnzbd/app/exportarr-service.yaml
@@ -7,6 +7,10 @@ metadata:
     app: sabnzbd-exportarr
     env: production
     category: media
+    # jobLabel source for the ServiceMonitor — makes the Prometheus `job` label
+    # (and thus the Arr Media dashboard row) read "sabnzbd" instead of
+    # "sabnzbd-exportarr", matching the native radarr/sonarr/prowlarr/readarr rows.
+    app.kubernetes.io/name: sabnzbd
 spec:
   type: ClusterIP
   selector:

--- a/clusters/vollminlab-cluster/mediastack/sabnzbd/app/exportarr-servicemonitor.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sabnzbd/app/exportarr-servicemonitor.yaml
@@ -11,7 +11,7 @@ spec:
   endpoints:
     - path: /metrics
       port: metrics
-  jobLabel: app
+  jobLabel: app.kubernetes.io/name
   selector:
     matchLabels:
       app: sabnzbd-exportarr


### PR DESCRIPTION
## What

Makes the SABnzbd and Bazarr rows on the **Arr Media** Grafana dashboard read `SABnzbd - sabnzbd` / `Bazarr - bazarr` instead of `SABnzbd - sabnzbd-exportarr` / `Bazarr - bazarr-exportarr`, matching the four native exporters.

## Why

The row headers are `App - ${app_instance}`, and `${app_instance}` resolves to the Prometheus `job` label. The six exporters were wired two different ways:

| Exporter | `jobLabel` | resolved `job` |
|----------|-----------|----------------|
| radarr / sonarr / prowlarr / readarr | `app.kubernetes.io/name` | `radarr` … (clean) |
| sabnzbd / bazarr (standalone `*-exportarr` Deployments) | `app` | `sabnzbd-exportarr` / `bazarr-exportarr` |

SABnzbd and Bazarr have no native metrics, so they run exportarr as separate Deployments whose ServiceMonitor used `jobLabel: app` — hence the `-exportarr` suffix leaking into the dashboard.

## Change

- Add `app.kubernetes.io/name: sabnzbd` / `bazarr` to each exporter Service.
- Repoint each ServiceMonitor `jobLabel: app` → `jobLabel: app.kubernetes.io/name`.

The dashboard's template variables auto-discover the job value via `query_result(...)`, so **no dashboard edit is needed** — the rows repopulate with the clean name on next load.

## Notes

- Purely cosmetic; metrics are unaffected.
- One-time continuity break on the `job=` label for those two series (old `job="…-exportarr"` stops, new `job="sabnzbd"`/`"bazarr"` begins) — range queries spanning the cutover show a one-time segment boundary.
- No hardcoded `job="…-exportarr"` references exist anywhere in the repo (alerts, recording rules, other dashboards all clear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)