### PR TITLE
fix(qbittorrent): sync listen_port to gluetun's forwarded port

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
@@ -119,3 +119,32 @@ spec:
           ports:
             - containerPort: 8000
               name: gluetun-ctrl
+        - name: port-sync
+          # Keeps qBittorrent's listen_port in sync with gluetun's PIA-forwarded port.
+          # gluetun's firewall only allows inbound traffic on the forwarded port, but
+          # qBittorrent doesn't know what that port is — without this, qBittorrent listens
+          # on a port the tunnel firewall blocks and can't accept any inbound peers.
+          image: docker.io/curlimages/curl:8.11.1@sha256:c1fe1679c34d9784c1b0d1e5f62ac0a79fca01fb6377cdd33e90473c6f9f9a69
+          command:
+            - sh
+            - -c
+            - |
+              while true; do
+                gluetun_port=$(curl -s -4 http://127.0.0.1:8000/v1/portforward | grep -o '"port":[0-9]*' | cut -d: -f2)
+                if [ -n "$gluetun_port" ]; then
+                  current_port=$(curl -s -4 http://127.0.0.1:8080/api/v2/app/preferences | grep -o '"listen_port":[0-9]*' | cut -d: -f2)
+                  if [ -n "$current_port" ] && [ "$gluetun_port" != "$current_port" ]; then
+                    curl -s -4 -X POST http://127.0.0.1:8080/api/v2/app/setPreferences \
+                      --data-urlencode "json={\"listen_port\":$gluetun_port}"
+                    echo "listen_port: $current_port -> $gluetun_port"
+                  fi
+                fi
+                sleep 30
+              done
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi


### PR DESCRIPTION
## Summary
- qBittorrent's `listen_port` was hardcoded to `6881`, but gluetun's PIA tunnel firewall only allows inbound traffic on PIA's actual forwarded port (currently `22576`) — causing total peer starvation on every queued torrent, unrelated to swarm health or search results.
- Adds a `port-sync` sidecar container that polls gluetun's control-server API (`127.0.0.1:8000/v1/portforward`) every 30s and pushes any change into qBittorrent's WebUI API (`127.0.0.1:8080/api/v2/app/setPreferences`). No shared volume exists between the two containers, so these two localhost HTTP APIs are the only viable sync path.
- Image pinned to `docker.io/curlimages/curl:8.11.1` by digest, verified against the Docker Hub registry API.

Radarr's delay profile is intentionally untouched — that's a separate, unrelated concern and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC2hUu4svzX2FXrbXQUoLJ