### PR TITLE
fix(qbittorrent): raise port-sync CPU limit to stop throttling

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/mediastack/qbittorrent/app/deployment.yaml
@@ -143,8 +143,11 @@ spec:
               done
           resources:
             requests:
+              # Two curl forks per 30s loop are bursty enough to hit CFS throttling
+              # at 50m even though average usage is ~1m (CPUThrottlingHigh fired
+              # at ~40-45% of periods). Limit raised to give burst headroom.
               cpu: 10m
               memory: 16Mi
             limits:
-              cpu: 50m
+              cpu: 150m
               memory: 32Mi


### PR DESCRIPTION
## Summary
- `port-sync` sidecar (added in #1024) was hitting CFS CPU throttling ~40-45% of periods on its 50m limit, confirmed via `CPUThrottlingHigh` alert (fired to Pushover) and Prometheus `container_cpu_cfs_throttled_periods_total` — despite ~1m average usage, the two `curl` process forks per 30s loop iteration are bursty enough to blow the quota.
- Raised `port-sync` CPU limit 50m → 150m to give burst headroom.
- `gluetun` was checked too (~1-2% throttle ratio, well below alert threshold) — left unchanged, not the source of the alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC2hUu4svzX2FXrbXQUoLJ