### PR TITLE
feat(radarr,sonarr): 60-minute torrent delay on default delay profile

### DIFF
--- a/terraform/radarr/delay-profiles.tf
+++ b/terraform/radarr/delay-profiles.tf
@@ -1,0 +1,14 @@
+# Default delay profile (tags = [] is the built-in, non-deletable profile).
+# Torrent delay raised to 60 min so usenet (already delay-free) wins the race
+# on releases available via both protocols.
+resource "radarr_delay_profile" "default" {
+  tags = []
+
+  preferred_protocol        = "usenet"
+  enable_usenet             = true
+  enable_torrent            = true
+  usenet_delay              = 0
+  torrent_delay             = 60
+  bypass_if_highest_quality = true
+  order                     = 2147483647
+}

--- a/terraform/radarr/imports.tf
+++ b/terraform/radarr/imports.tf
@@ -35,3 +35,9 @@ import {
   to = radarr_download_client_sabnzbd.sabnzbd
   id = "1"
 }
+
+# ID fetched 2026-08-08 via kubectl exec radarr /api/v3/delayprofile
+import {
+  to = radarr_delay_profile.default
+  id = "1"
+}

--- a/terraform/sonarr/delay-profiles.tf
+++ b/terraform/sonarr/delay-profiles.tf
@@ -1,0 +1,16 @@
+# Default delay profile (tags = [] is the built-in, non-deletable profile).
+# Torrent delay raised to 60 min so usenet (already delay-free) wins the race
+# on releases available via both protocols.
+resource "sonarr_delay_profile" "default" {
+  tags = []
+
+  preferred_protocol                  = "usenet"
+  enable_usenet                       = true
+  enable_torrent                      = true
+  usenet_delay                        = 0
+  torrent_delay                       = 60
+  bypass_if_highest_quality           = true
+  bypass_if_above_custom_format_score = false
+  minimum_custom_format_score         = 0
+  order                               = 2147483647
+}

--- a/terraform/sonarr/imports.tf
+++ b/terraform/sonarr/imports.tf
@@ -35,3 +35,9 @@ import {
   to = sonarr_download_client_sabnzbd.sabnzbd
   id = "1"
 }
+
+# ID fetched 2026-08-08 via kubectl exec sonarr /api/v3/delayprofile
+import {
+  to = sonarr_delay_profile.default
+  id = "1"
+}


### PR DESCRIPTION
## Summary
- Import the existing default delay profile (`tags = []`, the built-in non-deletable profile) into Terraform for both Radarr and Sonarr
- Set `torrent_delay = 60` on both so usenet grabs (already delay-free) get a 60-minute head start on releases available via both protocols before torrent grabs are allowed
- All other fields left matching current live state (`preferred_protocol = usenet`, `bypass_if_highest_quality = true`, `usenet_delay = 0`)

## Test plan
Flux applies these via the `tofu` namespace CronJob; verify post-merge with `GET /api/v3/delayprofile` on both Radarr and Sonarr shows `torrentDelay: 60`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC2hUu4svzX2FXrbXQUoLJ