### PR TITLE
fix(b2-exporter): bump image to 1.0.2, rebuilt after registry data loss

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/b2-exporter/app/deployment.yaml
+++ b/clusters/vollminlab-cluster/monitoring/b2-exporter/app/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - name: harbor-vollminlab-pull
       containers:
         - name: b2-exporter
-          image: harbor.vollminlab.com/vollminlab/b2-exporter:1.0.1
+          image: harbor.vollminlab.com/vollminlab/b2-exporter:1.0.2
           ports:
             - name: metrics
               containerPort: 8080


### PR DESCRIPTION
## Summary
- `b2-exporter:1.0.1` was still cataloged in Harbor's DB (tag + artifact record present), but the underlying manifest, blob, and repository directory were missing from Harbor's registry storage — confirmed via `kubectl exec` into the harbor-registry pod (`/storage/docker/registry/v2/repositories/vollminlab/b2-exporter` did not exist). Genuine registry-side data loss, not a bad tag reference.
- Pushed tag `b2-exporter/v1.0.2` to re-trigger the existing `build-b2-exporter.yaml` CI workflow, rebuilding `build/b2-exporter/` from source and pushing a fresh image. Build succeeded; the new manifest was verified pullable via the Harbor registry v2 API (HTTP 200) before this PR.
- Bumps `deployment.yaml` to `harbor.vollminlab.com/vollminlab/b2-exporter:1.0.2`.

## Test plan
N/A — verification is async via Flux.