### PR TITLE
fix(descheduler): exclude velero namespace from eviction

### DIFF
--- a/clusters/vollminlab-cluster/kube-system/descheduler/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kube-system/descheduler/app/configmap.yaml
@@ -46,6 +46,20 @@ data:
                   extraEnabled:
                     - "PodsWithPVC"
                 nodeFit: true
+                # Exclude the velero namespace entirely. Velero's node-agent exposes
+                # non-CSI-snapshot volumes for FSB kopia backup via an ephemeral
+                # hostPath-mounted "hosting" pod — these have no PVC, so the PVC
+                # guard above doesn't protect them. An eviction mid-backup hard-fails
+                # the PodVolumeBackup (2026-08-08: killed 2/3 Jellyfin PVBs, looped
+                # the 3rd for 20+ minutes with zero progress). Only PodsWithLocalStorage
+                # protection (disabled cluster-wide, see above) would have covered this,
+                # so scope the fix to the one namespace instead.
+                namespaceLabelSelector:
+                  matchExpressions:
+                    - key: kubernetes.io/metadata.name
+                      operator: NotIn
+                      values:
+                        - velero
             - name: LowNodeUtilization
               args:
                 thresholds:


### PR DESCRIPTION
## Summary
- Velero's node-agent exposes non-CSI-snapshot volumes for FSB kopia backup via an ephemeral hostPath-mounted "hosting" pod. These have no PVC, so the existing `PodsWithPVC` guard on the descheduler doesn't protect them.
- On 2026-08-08 the descheduler evicted these hosting pods mid-backup on k8sworker03, hard-failing 2 of Jellyfin's 3 PodVolumeBackups and looping the 3rd with zero progress.
- Adds a `namespaceLabelSelector` (`kubernetes.io/metadata.name NotIn [velero]`) to the `DefaultEvictor` plugin, excluding the `velero` namespace entirely — scoped to just that namespace instead of disabling `PodsWithLocalStorage` protection cluster-wide.

## Test plan
N/A — verification is async via Flux reconcile + observing the next descheduler run against an in-progress Velero backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4pjC6sbJ14favM4iGJUSE