### PR TITLE
fix(velero): exclude Flux controller emptyDir volumes from FSB

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/gotk-components.yaml
+++ b/clusters/vollminlab-cluster/flux-system/gotk-components.yaml
@@ -2587,6 +2587,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes-excludes: tmp
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       labels:
@@ -3427,6 +3428,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes-excludes: temp
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       labels:
@@ -4992,6 +4994,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes-excludes: temp
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       labels:
@@ -6454,6 +6457,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes-excludes: temp
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       labels:


### PR DESCRIPTION
## Summary
- Root-caused the chronic Velero `PartiallyFailed` `daily-full`/`daily-b2` backups to a kopia filesystem-backup (FSB) data-path livelock on the `temp`/`tmp` `emptyDir` volumes mounted by the four Flux controllers (helm-controller, kustomize-controller, notification-controller, source-controller) — not a storage/IO capacity problem.
- This is the same class of bug fixed for TrueCharts pods in PR #1009 (`shared` emptyDir hang → recurring PartiallyFailed + orphaned data-movers).
- Adds `backup.velero.io/backup-volumes-excludes` pod-template annotations so kopia FSB skips these emptyDir volumes entirely: `tmp` on source-controller, `temp` on helm-controller/kustomize-controller/notification-controller.

## Test plan
- N/A — verification is async via Flux (see `.claude/rules/git-workflow.md`). After merge, will confirm the annotation lands on live controller pods and that a subsequent `daily-full`/`daily-b2` run completes cleanly.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01K4pjC6sbJ14favM4iGJUSE