### PR TITLE
fix(velero): exclude source-controller data volume from FSB

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/gotk-components.yaml
+++ b/clusters/vollminlab-cluster/flux-system/gotk-components.yaml
@@ -2587,7 +2587,7 @@ spec:
   template:
     metadata:
       annotations:
-        backup.velero.io/backup-volumes-excludes: tmp
+        backup.velero.io/backup-volumes-excludes: tmp,data
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       labels:


### PR DESCRIPTION
## Summary
- PR #1033 excluded source-controller's `tmp` emptyDir from Velero FSB, but the livelock was actually on the `data` emptyDir (where source-controller stores fetched Flux artifacts — git repos, Helm chart tarballs, OCI artifacts), not `tmp`.
- Node-agent logs confirm a livelock: the PVB for `source-controller-...`'s `data` volume repeated the identical "PVB is prepared / hosting pod running / creating data path routine" log sequence every ~5s from `acceptedTimestamp` onward, never leaving phase `Prepared` (`progress: {}`), and kept reconciling even after the parent Backup had already gone `PartiallyFailed` at its 4h `ItemOperationTimeout`.
- This is the same class of livelock as PR #1009 (TrueCharts `shared` emptyDir) and PR #1033 (Flux controllers' `tmp`/`temp`), just on the volume PR #1033 missed for this specific controller. `data` is a re-fetchable artifact cache, safe to exclude from FSB the same way.

## Test plan
N/A — verification is async via Flux + the next scheduled `daily-full`/`daily-b2` runs.