### PR TITLE
fix(homepage): exclude emptyDir volumes from FSB

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -509,6 +509,8 @@ data:
       app: homepage
       env: production
       category: apps
+    podAnnotations:
+      backup.velero.io/backup-volumes-excludes: homepage-base-config,logs
     env:
       - name: HOMEPAGE_VAR_OPENWEATHER_API_KEY
         valueFrom:


### PR DESCRIPTION
## Summary

- Adds `backup.velero.io/backup-volumes-excludes: homepage-base-config,logs` as a pod annotation on homepage, excluding both emptyDir volumes from Velero's FileSystemBackup.
- Both PVBs (`homepage-base-config`, `logs`) were getting permanently stuck in `Prepared` phase during backups — zero node-agent log activity on any of the 9 node-agent pods, the same signature as source-controller's pre-fix livelock (#1034). Neither volume is a PVC; both are scratch/log emptyDirs with nothing worth preserving.
- The stuck PVBs cascade into a client-side rate-limiter timeout (`failed to list node-agent pods: client rate limiter Wait returned an error: context deadline exceeded`), which is very likely the cause of most of the ~20 unrelated pod errors seen in recent `daily-full`/`daily-b2` backups.
- Same fix pattern as PR #1034 (source-controller), applied via the bjw-s common library chart's top-level `podAnnotations` values key (confirmed against the actual chart source, not assumed from the existing `podLabels` key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4pjC6sbJ14favM4iGJUSE