### PR TITLE
fix(arc): bump runner image to 2.336.0 and arc-controller chart to 0.14.1

### DIFF
--- a/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/configmap.yaml
@@ -42,7 +42,7 @@ data:
                   topologyKey: kubernetes.io/hostname
         containers:
           - name: runner
-            image: ghcr.io/actions/actions-runner:2.334.0
+            image: ghcr.io/actions/actions-runner:2.336.0
             command: ["/home/runner/run.sh"]
             env:
               - name: DOCKER_HOST

--- a/clusters/vollminlab-cluster/flux-system/repositories/arc-controller-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/arc-controller-ocirepository.yaml
@@ -11,7 +11,7 @@ spec:
   interval: 1h
   url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller
   ref:
-    tag: "0.14.0"
+    tag: "0.14.1"
   layerSelector:
     mediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip"
     operation: copy


### PR DESCRIPTION
Restores the self-hosted runners. Two changes, one incident.

## Root cause

GitHub's Actions service now rejects runner **2.334.0** as deprecated. ARC ephemeral runners run with self-update disabled, so the runner container exits **code 7** (`RunnerVersionDeprecated`, `actions/runner` `Constants.cs`) about two seconds after start.

ARC treats exit 7 as "outdated":

```
EphemeralRunner    -> phase Outdated   (ephemeralrunner_controller.go, ExitCode == 7)
EphemeralRunnerSet -> phase Outdated   (len(state.outdated) > 0)
AutoscalingRunnerSet -> phase Outdated (latches; nothing clears it)
  -> deletes the listener, the ephemeral runner set, and the GitHub scale set
```

Result: zero runners, every workflow job queued forever. `AutoscalingRunnerSet.Status.Phase` is read back out of status on each reconcile and the outdated branch never resets it, so the teardown is terminal until the underlying cause is removed.

Observed live: runner container `startedAt 23:16:06`, `terminated exitCode 7 finishedAt 23:16:08`.

Note: the earlier reading of this as a controller hang in `deleteRunnerScaleSet` was wrong. That path returns `nil` silently when the `runner-scale-set-id` annotation is already gone, so a completed reconcile emits no log line and looks like a stall.

## Changes

- `arc-runners` values: runner image `2.334.0` -> `2.336.0` (latest, released 2026-07-20; manifest verified present in ghcr.io)
- `arc-controller` OCIRepository: chart `0.14.0` -> `0.14.1`, matching the `arc-runners` chart. The mismatch was a separate real defect — on a version mismatch the controller deletes the `AutoscalingRunnerSet` outright so Helm recreates it.

Both must land together: the chart bump alone leaves runners exiting 7, and the image bump alone leaves the version gate armed.

## Out-of-band cluster state to unwind after merge

Left behind by earlier debugging, not by this PR:

- `OCIRepository/arc-controller-repo` was `kubectl apply`-ed live to `0.14.1`; this PR makes git match.
- The `flux-system` Kustomization is **suspended** — resume it after merge (`flux resume kustomization flux-system`).
- The `vollminlab` `AutoscalingRunnerSet` is latched in phase `Outdated`; clearing `status.phase` plus the `actions.github.com/change-hash` annotation unlatches it once the image is correct.
