### PR TITLE
chore(renovate): track container images pinned in Helm values ConfigMaps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ on:
       - 'docs/**'
       - '*.md'
       - '.gitignore'
-      - 'renovate.json'
+      - 'renovate.json5'
       - '.pre-commit-config.yaml'
   pull_request:
     branches: [ main, develop ]
@@ -30,7 +30,7 @@ on:
       - 'docs/**'
       - '*.md'
       - '.gitignore'
-      - 'renovate.json'
+      - 'renovate.json5'
       - '.pre-commit-config.yaml'
   workflow_dispatch:
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -9,7 +9,7 @@
   "prConcurrentLimit": 10,
   "labels": ["renovate", "dependencies"],
   "commitMessagePrefix": "chore(deps):",
-  "enabledManagers": ["flux", "github-actions"],
+  "enabledManagers": ["flux", "github-actions", "custom.regex"],
   "ignorePaths": [
     "clusters/vollminlab-cluster/flux-system/gotk-components.yaml"
   ],
@@ -19,6 +19,21 @@
       "/clusters/vollminlab-cluster/flux-system/repositories/.+-helmrepository\.yaml$/"
     ]
   },
+  // The flux manager only reads helmrelease.yaml / *-helmrepository.yaml, so container images
+  // pinned inside Helm values ConfigMaps are invisible to it. This custom manager picks them up.
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Container images pinned inside Helm values ConfigMaps",
+      "managerFilePatterns": [
+        "/clusters/vollminlab-cluster/.+/app/configmap\.yaml$/"
+      ],
+      "matchStrings": [
+        "image:\\s+(?<depName>[^\\s:]+):(?<currentValue>[^\\s\"']+)"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ],
   "registryAliases": {
     "arc-controller-repo": "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller",
     "arc-runners-repo": "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set",
@@ -57,7 +72,7 @@
     },
     {
       "description": "Flag major updates with an additional label",
-      "matchManagers": ["flux"],
+      "matchManagers": ["flux", "custom.regex"],
       "matchUpdateTypes": ["major"],
       "labels": ["renovate", "dependencies", "major-update"],
       "automerge": false


### PR DESCRIPTION
## Why

Renovate's `flux` manager only scans `helmrelease.yaml` and `*-helmrepository.yaml`. Container images pinned inside Helm **values ConfigMaps** were invisible to it — nothing in the repo was watching them.

That is the root cause behind #1036: `ghcr.io/actions/actions-runner` sat at `2.334.0` until GitHub deprecated that version. The runner container then exited `7` (`RunnerVersionDeprecated`) ~2s after start on every launch, ARC cascaded `EphemeralRunner` → `EphemeralRunnerSet` → `AutoscalingRunnerSet` to `Outdated` and tore down the listener and the GitHub-side scale set. CI then had no runners to satisfy its own required checks, so the fix PR couldn't merge without intervention.

A routine Renovate bump PR would have surfaced this weeks earlier.

## What changed

**`renovate.json5`** — adds a `custom.regex` manager over `clusters/vollminlab-cluster/**/app/configmap.yaml`. Verified against the current tree, it matches exactly four images and produces no false positives:

| File | Image |
|---|---|
| `actions-runner-system/arc-runners/app/configmap.yaml` | `ghcr.io/actions/actions-runner:2.336.0` |
| `actions-runner-system/arc-runners/app/configmap.yaml` | `docker:26-dind` |
| `flux-system/headlamp/app/configmap.yaml` | `ghcr.io/headlamp-k8s/headlamp-plugin-flux:v0.6.0` |
| `velero/velero/app/configmap.yaml` | `velero/velero-plugin-for-aws:v1.14.0` |

`custom.regex` is added to `enabledManagers` and to the existing major-update label rule. No automerge — same manual-review posture as the flux manager.

**`.github/workflows/ci.yaml`** — the paths filter listed `'renovate.json'`, but this repo's config file is `renovate.json5` and no `renovate.json` exists. A PR touching only the Renovate config triggered **no** workflow run, leaving required checks permanently in `expected` and the PR unmergeable. Corrected to `renovate.json5`.

(This PR also touches `.github/workflows/**`, which is already in the filter, so CI does run here.)