### PR TITLE
fix(velero): raise client rate limit so backups stop timing out

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -66,6 +66,20 @@ data:
       # block all PVBs on the affected node indefinitely across multiple backup runs.
       podVolumeOperationTimeout: 30m
 
+      # Client-side rate limit for velero's own kube API calls.
+      # `velero server` defaults are qps=20 / burst=30. A daily-full backup is now
+      # ~5000 items, and for every volume-bearing pod the backup path lists the
+      # node-agent pods. At 20 qps the client-side limiter — not the apiserver —
+      # became the bottleneck: requests queued behind the limiter until their own
+      # context expired, producing 30+ errors per run of
+      #   "failed to list node-agent pods: client rate limiter Wait returned an
+      #    error: context deadline exceeded"
+      # and PartiallyFailed backups on 2026-08-05/06/07/10.
+      # Raised moderately, not maximally: the CP nodes have an armed apiserver
+      # OOM failure mode (8 GB nodes), so this is 2.5x, not 10x.
+      clientQPS: 50
+      clientBurst: 100
+
       # BackupStorageLocations MUST stay nested under configuration: — the velero
       # chart reads configuration.backupStorageLocation. If this drifts out (e.g.
       # displaced by an inserted sibling block), the chart synthesizes an invalid


### PR DESCRIPTION
## Why

Every daily backup since 2026-08-05 has been `PartiallyFailed` (38 / 19 / 15 / 31 / 29 errors, and 20 on a manual verification run today). The error breakdown is almost entirely one error, repeated once per volume-bearing pod:

```
name: /radarr-5bb6bc8dfc-nrzwc  message: /Error backing up item
error: /failed to list node-agent pods: client rate limiter Wait returned an error: context deadline exceeded
```

followed by:

```
message: /timed out waiting for all PodVolumeBackups to complete
```

This is **not cosmetic** — the volume data for those pods (radarr, sonarr, jellyfin, qbittorrent, sabnzbd, the CNPG databases, portainer, seerr, prowlarr, volsync, metrics-server, and more) did not make it into those backups.

## Root cause

The limiter named in the error is **velero's own client-side rate limiter**, not the apiserver. `velero server` defaults to `--client-qps=20 --client-burst=30`, and the deployment sets no override — verified on the live pod.

A daily-full is now ~5000 items, all sharing that 20 qps budget. Requests queue behind the limiter until their own context deadline expires. Listing node-agent pods happens once per volume-bearing pod and is simply the call that loses the race most often; the limiter is saturated by the backup as a whole.

## The change

`configuration.clientQPS: 50` / `configuration.clientBurst: 100` in the values ConfigMap (chart 12.1.0 exposes both).

Deliberately moderate — 2.5x, not the 10x some upstream issues suggest. The CP nodes have an armed apiserver OOM failure mode on 8 GB (cp02 already hit it), so a large multiplier on velero's API call rate is not a free change. If backups still time out after this, raise again from a known baseline rather than overshooting now.

## Not in scope

The `source-controller` `data` PVB failure that appeared in the same runs was already fixed by #1034; the live pod now carries `backup.velero.io/backup-volumes-excludes: tmp,data`. Verified.