### PR TITLE
fix(harbor): size registry PVC to the real working set (5Gi -> 12Gi)

### DIFF
--- a/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
@@ -57,7 +57,19 @@ data:
         registry:
           storageClass: longhorn
           accessMode: ReadWriteOnce
-          size: 5Gi
+          # 2026-08-10: raised 5Gi -> 12Gi. Measured live artifact bytes after a
+          # manual GC (which freed 881MB and took the volume 84% -> 67%):
+          #   dockerhub-proxy 2845 MiB, vollminlab 587 MiB, library 46 MiB = ~3.4 GiB
+          # i.e. used space is essentially all live content — there is no orphan
+          # backlog left to reclaim. The proxy cache is already bounded (Harbor
+          # auto-creates a 7-day n_days_since_last_pull retention on proxy cache
+          # projects; policy id 1 runs daily and succeeds), so 2.8 GiB is its real
+          # working set, not a leak. On a 5Gi volume the HarborRegistryVolumeFilling
+          # alert trips above 3.84 GiB used — only ~640 MiB of headroom over the
+          # legitimate steady state, so it re-fires after every GC.
+          # 12Gi = 36Gi across 3 Longhorn replicas; verified schedulable (smallest
+          # node had 50.9Gi available).
+          size: 12Gi
         jobservice:
           jobLog:
             storageClass: longhorn

--- a/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
@@ -57,7 +57,7 @@ data:
         registry:
           storageClass: longhorn
           accessMode: ReadWriteOnce
-          # 2026-08-10: raised 5Gi -> 12Gi. Measured live artifact bytes after a
+          # 2026-08-10: raised 5Gi -> 8Gi. Measured live artifact bytes after a
           # manual GC (which freed 881MB and took the volume 84% -> 67%):
           #   dockerhub-proxy 2845 MiB, vollminlab 587 MiB, library 46 MiB = ~3.4 GiB
           # i.e. used space is essentially all live content — there is no orphan
@@ -67,9 +67,15 @@ data:
           # working set, not a leak. On a 5Gi volume the HarborRegistryVolumeFilling
           # alert trips above 3.84 GiB used — only ~640 MiB of headroom over the
           # legitimate steady state, so it re-fires after every GC.
-          # 12Gi = 36Gi across 3 Longhorn replicas; verified schedulable (smallest
-          # node had 50.9Gi available).
-          size: 12Gi
+          # Sized against Longhorn's scheduling ledger, not physical free space:
+          # the three replicas live on k8sworker02/05/06, and w06 has only 6.79Gi
+          # of scheduling headroom left (180Gi scheduled of 186.8Gi capacity, and
+          # 26.3% physically available against Longhorn's 25% floor). A +7Gi bump
+          # to 12Gi would take w06 to -0.21Gi. +3Gi to 8Gi leaves it 3.8Gi.
+          # 8Gi -> ~7.7Gi usable, so the 20%-free alert trips above ~6.2Gi used —
+          # ~2.8Gi of headroom over the 3.4Gi steady state instead of ~0.6Gi.
+          # Expand further via Longhorn online resize once w06 is relieved.
+          size: 8Gi
         jobservice:
           jobLog:
             storageClass: longhorn

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -408,8 +408,8 @@ spec:
           annotations:
             summary: "Harbor garbage collection failed"
             description: >-
-              A Harbor GC job failed within the last 24h. The registry PVC is only 5Gi
-              (intentionally); check the GC run log in Harbor (Administration ->
+              A Harbor GC job failed within the last 24h. The registry PVC is small
+              (12Gi, intentionally); check the GC run log in Harbor (Administration ->
               Clean Up -> Garbage Collection) and the jobservice pod logs.
 
         # Registry-fill detector (replaces the old increase()-based
@@ -420,9 +420,12 @@ spec:
         # and increase(...[8d]) reads 0 (the absent->1 arming edge is invisible),
         # firing for ~a week after any jobservice restart even though GC ran.
         # There is no last-GC-timestamp gauge in Harbor metrics, so guard the
-        # actual risk instead — the 5Gi registry PVC filling (what GC stopping
+        # actual risk instead — the registry PVC filling (what GC stopping
         # would cause). Reset-immune, same pattern as the MinIO PVC alerts above.
         # HarborGarbageCollectionFailed (above) still catches explicit failures.
+        # 2026-08-10: the PVC was 5Gi against a ~3.4 GiB live working set, so this
+        # alert re-fired within days of every GC. Volume raised to 12Gi; at that
+        # size 20% free is a genuine growth signal, not steady-state noise.
         - alert: HarborRegistryVolumeFilling
           expr: |
             kubelet_volume_stats_available_bytes{namespace="harbor",persistentvolumeclaim="harbor-registry"}
@@ -433,7 +436,9 @@ spec:
           annotations:
             summary: "Harbor registry PVC below 20% free"
             description: >-
-              The 5Gi harbor-registry PVC has {{ $value | humanizePercentage }} free.
+              The 12Gi harbor-registry PVC has {{ $value | humanizePercentage }} free.
               Weekly GC (Sat 05:00 UTC, harbor-config tofu) may have stopped reclaiming
               blobs. Check the GC run log (Administration -> Clean Up -> Garbage
               Collection) and jobservice health; a manual GC frees orphaned blobs.
+              If GC is healthy and the volume is still filling, the working set has
+              genuinely grown — check per-project size before expanding again.

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -409,7 +409,7 @@ spec:
             summary: "Harbor garbage collection failed"
             description: >-
               A Harbor GC job failed within the last 24h. The registry PVC is small
-              (12Gi, intentionally); check the GC run log in Harbor (Administration ->
+              (8Gi, intentionally); check the GC run log in Harbor (Administration ->
               Clean Up -> Garbage Collection) and the jobservice pod logs.
 
         # Registry-fill detector (replaces the old increase()-based
@@ -424,8 +424,9 @@ spec:
         # would cause). Reset-immune, same pattern as the MinIO PVC alerts above.
         # HarborGarbageCollectionFailed (above) still catches explicit failures.
         # 2026-08-10: the PVC was 5Gi against a ~3.4 GiB live working set, so this
-        # alert re-fired within days of every GC. Volume raised to 12Gi; at that
-        # size 20% free is a genuine growth signal, not steady-state noise.
+        # alert re-fired within days of every GC. Volume raised to 8Gi (capped by
+        # k8sworker06's Longhorn scheduling headroom, not by need); at that size
+        # 20% free is a genuine growth signal, not steady-state noise.
         - alert: HarborRegistryVolumeFilling
           expr: |
             kubelet_volume_stats_available_bytes{namespace="harbor",persistentvolumeclaim="harbor-registry"}
@@ -436,7 +437,7 @@ spec:
           annotations:
             summary: "Harbor registry PVC below 20% free"
             description: >-
-              The 12Gi harbor-registry PVC has {{ $value | humanizePercentage }} free.
+              The 8Gi harbor-registry PVC has {{ $value | humanizePercentage }} free.
               Weekly GC (Sat 05:00 UTC, harbor-config tofu) may have stopped reclaiming
               blobs. Check the GC run log (Administration -> Clean Up -> Garbage
               Collection) and jobservice health; a manual GC frees orphaned blobs.

--- a/terraform/harbor/retention.tf
+++ b/terraform/harbor/retention.tf
@@ -1,0 +1,37 @@
+# Tag retention for the vollminlab project — the only project with no bound.
+#
+# Measured 2026-08-10 (live artifact bytes, after a manual GC):
+#   dockerhub-proxy 2845 MiB   already bounded: Harbor auto-creates a 7-day
+#                              n_days_since_last_pull retention on every proxy
+#                              cache project (policy id 1 here, runs daily,
+#                              succeeding) — that 2.8 GiB is a true LRU working
+#                              set, not a leak.
+#   vollminlab       587 MiB   unbounded: every release tag ever pushed is kept
+#                              forever (longhorn-rebalancing-controller v0.1.0 ->
+#                              v0.4.0, shlink-ingress-controller v0.3.1 -> v0.3.6,
+#                              vollmint v0.1.0 -> v0.3.2, masters-league,
+#                              b2-exporter, ...).
+#   library           46 MiB   negligible.
+#
+# Growth here is a few artifacts per month, so this is a ceiling, not a cleanup:
+# the largest repo currently holds 8 artifacts, so this policy deletes nothing
+# today. It exists so the project cannot grow without limit — GC only reclaims
+# blobs that no artifact references, and nothing ever stops referencing them
+# while every historical tag is retained.
+#
+# The dockerhub-proxy policy is deliberately NOT imported into terraform: it is
+# created and owned by Harbor when a proxy cache project is created, it is
+# correct as-is, and adopting it would add a conflict risk for no gain.
+resource "harbor_retention_policy" "vollminlab" {
+  scope    = harbor_project.vollminlab.id
+  schedule = "Daily"
+
+  # Keep the 10 most recently pushed artifacts per repository. Anything not
+  # matched by a retain rule is deleted, so one rule covering **/** is the whole
+  # policy — with 10 kept, current repos (max 8 artifacts) are untouched.
+  rule {
+    most_recently_pushed = 10
+    repo_matching        = "**"
+    tag_matching         = "**"
+  }
+}


### PR DESCRIPTION
## What

- `harbor-registry` PVC **5Gi → 8Gi**
- Update the two alert annotations that hardcoded `5Gi`
- New `terraform/harbor/retention.tf` — tag retention on the `vollminlab` project

## Why

`HarborRegistryVolumeFilling` has been firing repeatedly. A manual GC yesterday freed 881 MB and took the volume 84% → 67%, but that is a temporary reprieve, not a fix.

Measured live artifact bytes (Harbor artifacts API, per project):

| Project | Live bytes |
|---|---|
| `dockerhub-proxy` | 2845 MiB |
| `vollminlab` | 587 MiB |
| `library` | 46 MiB |
| **total** | **~3.4 GiB** |

`df` on the registry volume reports 3.2G used of 4.8G. **Live content ≈ all used space — there is no orphan backlog left for GC to reclaim.**

The earlier hypothesis (an unbounded pull-through cache) is wrong. Harbor auto-creates a 7-day `n_days_since_last_pull` retention on every proxy cache project; here that is policy id 1 on project 5, cron `0 0 0 * * *`, with the last five executions all `Success` (2026-08-07 → 08-11). So 2.8 GiB is the cache's genuine LRU working set.

The volume is simply undersized. The alert trips below 20% free — above 3.84 GiB used — and the legitimate steady state is already 3.2 GiB. That is ~640 MiB of headroom, which is why the alert returns within days of every GC.

## Sizing

8Gi × 3 Longhorn replicas = 24Gi. **Sized against Longhorn's scheduling ledger, not physical free space** — the first pass used physical free space, which is the wrong metric. This volume's replicas live on k8sworker02/05/06, whose scheduling headroom is 56.96 / 39.79 / **6.79** Gi. k8sworker06 is the most over-committed node in the cluster (180Gi scheduled of 186.8Gi capacity, 26.3% physically available against Longhorn's 25% floor), so the originally proposed +7Gi bump to 12Gi would have taken it to **-0.21Gi** — Longhorn would stop scheduling anything else there, and a replica rebuild on that node could fail.

8Gi (+3Gi) leaves w06 3.8Gi of headroom and still fixes the reported problem: ~7.7Gi usable means the 20%-free alert trips above ~6.2Gi used, giving ~2.8Gi of headroom over the 3.4Gi live working set instead of the ~0.6Gi that made it re-fire days after every GC. Further growth is a Longhorn online resize once w06 is relieved. The harbor registry Deployment is already `strategy: Recreate`.

## Retention scope

`vollminlab` is the only project with no bound (`retention_id = None`; `library` likewise but it holds 46 MiB). Its contents are release tags, not CI churn — `longhorn-rebalancing-controller` v0.1.0→v0.4.0, `shlink-ingress-controller` v0.3.1→v0.3.6, `vollmint` v0.1.0→v0.3.2, `masters-league`, `b2-exporter`. Growth is a few artifacts per month.

The policy keeps the 10 most recently pushed artifacts per repository. The largest repo currently holds 8, so **this deletes nothing today** — it is a ceiling so the project cannot grow unbounded, since GC can only reclaim blobs no artifact references.

Deliberately *not* done here:

- The `dockerhub-proxy` retention policy is left unmanaged by terraform. Harbor creates and owns it, it is working, and importing it adds conflict risk for no gain.
- GC frequency left weekly. Orphans are not the problem — twice-weekly GC would reclaim nothing extra.

`terraform/harbor` is `approvePlan: auto`, so the retention policy applies within the tofu-controller's 10m interval after merge.
