### PR TITLE
chore(ci): fail the build when README structure drifts from the cluster tree

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Runs unconditionally and needs no tooling or cluster access — it only
+      # compares the namespace directories on disk to the README's structure
+      # block. Deliberately a step inside this job rather than a job of its own,
+      # so it blocks merges through the existing required check instead of
+      # needing a new one added to branch protection.
+      - name: Check README structure block
+        run: ./scripts/check-readme-structure.sh
+
       - name: Install kubectl
         run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ docs/                                   # Documentation (synced to the Obsidian 
 scripts/                                # Utility scripts
 ```
 
+> CI enforces this block. `scripts/check-readme-structure.sh` runs in the **Validate Kubernetes
+> Manifests** check and fails the PR if a namespace directory is added or removed without the
+> matching line here — so what you're reading is as current as the last merge.
+
 ---
 
 ## Deployed Applications

--- a/scripts/check-readme-structure.sh
+++ b/scripts/check-readme-structure.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Fails when the namespace directories under clusters/vollminlab-cluster/ and the
+# "Repository Structure" block in README.md disagree.
+#
+# Why this exists: the README went stale for four months and nothing noticed. The
+# expensive part wasn't the drift itself, it was that a DR reader had no way to
+# tell. Versions are handled by pointing at self-maintaining sources instead of
+# copying them; structure can't be, so it gets checked here. This fires on the PR
+# that adds or removes a namespace — the moment a human is already editing the
+# repo layout and should be editing the doc with it.
+#
+# Usage: scripts/check-readme-structure.sh [path/to/README.md]
+# Exits 0 when the two agree, 1 otherwise.
+
+set -euo pipefail
+
+README="${1:-README.md}"
+CLUSTER_DIR="clusters/vollminlab-cluster"
+
+[[ -f "$README" ]] || { echo "❌ README not found: $README"; exit 1; }
+[[ -d "$CLUSTER_DIR" ]] || { echo "❌ Cluster dir not found: $CLUSTER_DIR"; exit 1; }
+
+# What exists on disk
+actual=$(find "$CLUSTER_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
+
+# What the README documents. The block is a fenced tree; take every line indented
+# exactly two spaces between the "clusters/vollminlab-cluster/" line and the next
+# unindented line (blank lines and deeper-indented sub-entries are ignored).
+# The trailing `|| true` matters: grep exits 1 on no match, which under
+# `set -euo pipefail` would kill the script before the empty-block guard below
+# could explain what went wrong.
+documented=$(
+  {
+    sed -n '\#^clusters/vollminlab-cluster/#,/^[^[:space:]]/p' "$README" \
+      | grep -oE '^  [A-Za-z0-9._-]+/' \
+      | tr -d ' /' \
+      | sort
+  } || true
+)
+
+# A renamed heading or deleted block must fail loudly, not pass vacuously.
+if [[ -z "$documented" ]]; then
+  echo "❌ Could not find the 'clusters/vollminlab-cluster/' tree in $README."
+  echo "   The Repository Structure block is what this check validates against —"
+  echo "   if it moved or was reformatted, update this script too."
+  exit 1
+fi
+
+missing=$(comm -23 <(printf '%s\n' "$actual") <(printf '%s\n' "$documented"))
+extra=$(comm -13 <(printf '%s\n' "$actual") <(printf '%s\n' "$documented"))
+
+if [[ -z "$missing" && -z "$extra" ]]; then
+  echo "✅ README structure block matches all $(printf '%s\n' "$actual" | wc -l) namespace directories"
+  exit 0
+fi
+
+echo "❌ README.md is out of sync with $CLUSTER_DIR/"
+echo
+
+if [[ -n "$missing" ]]; then
+  echo "   Directories that exist but are NOT in the README:"
+  printf '     %s/\n' $missing
+  echo
+fi
+
+if [[ -n "$extra" ]]; then
+  echo "   Documented in the README but NO LONGER on disk:"
+  printf '     %s/\n' $extra
+  echo
+fi
+
+echo "   Fix: edit the 'Repository Structure' block in $README so it lists each"
+echo "   namespace directory once, indented two spaces, with a short description."
+exit 1


### PR DESCRIPTION
Follow-up to #1041 (README refresh) and #1042 (dropped the version numbers).

#1042 solved version drift by deleting the copies and pointing at three sources that maintain themselves — the app's own `helmrelease.yaml` / `OCIRepository` tag, Renovate's Dependency Dashboard (#216), and `flux get helmreleases -A`. **Structure can't be delegated that way.** The list of namespace directories only exists in the README, so nothing notices when it goes stale — which is exactly what happened for four months.

This adds the check.

## What it does

`scripts/check-readme-structure.sh` compares `clusters/vollminlab-cluster/*/` on disk against the Repository Structure block in `README.md` and fails on disagreement in either direction:

- a namespace directory added without a README line
- a README line left behind after a namespace directory is deleted
- the structure block itself renamed, reformatted, or removed (fails loudly rather than passing vacuously on an empty parse)

The failure output names the specific directories and says what to edit.

## Why a step, not a job

It runs as a step inside the existing `validate-changes` job. That job is already the required check **Validate Kubernetes Manifests**, so the guard blocks merges without you having to add a new required check to branch protection. It needs no tooling and no cluster access, so it is deliberately *not* gated behind `CLUSTER_CI` — it still runs when the ARC runners are in break-glass mode.

## Timing

It only fires on the PR that adds or removes a namespace — the moment someone is already editing repo layout and should be editing the doc alongside it. No cron, no bot PRs, no maintenance surface of its own.

Verified locally against five scenarios: current tree (passes, 34 directories), undocumented new directory, README ghost entry, deleted README line, and a removed structure block. All four failure modes exit 1 with the right message.