### PR TITLE
docs(dmz): document masters-league and fix single-node/SealedSecret drift

### DIFF
--- a/clusters/vollminlab-cluster/dmz/README.md
+++ b/clusters/vollminlab-cluster/dmz/README.md
@@ -21,7 +21,7 @@ The DMZ namespace is designed for services that need to be accessible from the i
 - **Policy**: `dmz-enforce-node-placement` (ClusterPolicy)
 - **Action**: Automatically adds `nodeSelector` and `tolerations` to all DMZ pods
 - **Benefit**: Developers don't need to remember node placement configuration
-- **Result**: All DMZ pods automatically run **only** on k8sworker05
+- **Result**: All DMZ pods automatically run **only** on the DMZ nodes (`k8sworker05`, `k8sworker06`)
 
 #### External Access Restriction (Validation)
 - **Policy**: `dmz-restrict-external-access` (ClusterPolicy)
@@ -51,6 +51,38 @@ All traffic is denied by default via `networkpolicy-default-deny.yaml`
 - **Applies to**: Pods with label `internet-egress: "true"`
 - **Blocks**: RFC 1918 private networks, link-local, loopback
 - **Use for**: Downloading updates, external API calls
+
+## Deployed Services
+
+| Service | Deployed as | Exposure | Network policy |
+|---------|-------------|----------|----------------|
+| `minecraft` | HelmRelease (`minecraft/app/helmrelease.yaml`) | NodePort 30565 (+ BlueMap service) | `external-access` / `internet-egress` labels |
+| `masters-league` | Raw Deployments + Services (`masters-league/app/`) | NodePort 32567, `externalTrafficPolicy: Local` | Dedicated `masters-league` + `masters-redis` policies |
+
+Both are listed in `kustomization.yaml`; Flux will silently ignore anything not in that list.
+
+### masters-league
+
+A two-replica FastAPI app serving Masters golf leaderboard data, backed by a single-replica Redis
+cache. It is the DMZ's second workload and follows a different network pattern from Minecraft.
+
+| Component | Detail |
+|-----------|--------|
+| Image | `harbor.vollminlab.com/vollminlab/masters-league:v1.1.1` (private Harbor project) |
+| Pull secret | `harbor-vollminlab-pull`, materialized by ESO from the `Harbor Cluster Pull Robot Account` 1Password item |
+| Replicas | 2 (app), 1 (`masters-redis`, `redis:7.4.2-alpine`) |
+| Container port | 8000 (app), 6379 (Redis, ClusterIP only) |
+| Exposure | `NodePort` 32567 with `externalTrafficPolicy: Local` — reached by the HAProxy DMZ VMs (`192.168.160.2`, `192.168.160.3`) |
+| Egress | ESPN API over TCP 443, `masters-redis` on 6379, kube-dns on 53 |
+| Labels | `app: masters-league`, `env: production`, `category: apps` |
+
+**It does not use the `external-access` / `internet-egress` label pattern.** Instead it ships a
+dedicated NetworkPolicy pair in `masters-league/app/networkpolicy.yaml` that narrows ingress to the
+two HAProxy source IPs and pins egress to exactly what the app needs. Redis is locked down further:
+ingress only from `app: masters-league`, egress only to kube-dns.
+
+Use the label pattern when a service genuinely needs open internet ingress; write a dedicated policy
+when the set of callers is known and small, as it is here.
 
 ## Deploying Services
 
@@ -104,7 +136,7 @@ spec:
   ports:
     - port: 25565
       targetPort: 25565
-      nodePort: 30565        # Accessible at k8sworker05:30565
+      nodePort: 30565        # Accessible on any DMZ node, e.g. k8sworker05:30565
       protocol: TCP
 ```
 
@@ -145,13 +177,13 @@ All pods must have the following labels (enforced by Kyverno):
 
 The DMZ namespace implements multiple security layers:
 
-1. **Physical Isolation**: k8sworker05 is network-isolated in DMZ
+1. **Physical Isolation**: `k8sworker05` and `k8sworker06` are network-isolated in the DMZ
 2. **Node Taint**: `dmz=true:NoSchedule` prevents accidental scheduling
 3. **Kyverno Mutation**: Auto-adds nodeSelector + tolerations (enforces placement)
 4. **Kyverno Validation**: Blocks external access labels outside DMZ (prevents misuse)
 5. **Network Policies**: Control ingress/egress at pod level (default deny)
 6. **Namespace Labels**: Pod Security Standards enforcement (baseline+)
-7. **Storage Isolation**: `longhorn-dmz` StorageClass keeps data on DMZ node
+7. **Storage Isolation**: `longhorn-dmz` StorageClass keeps data on the DMZ nodes
 
 ## Best Practices
 
@@ -160,7 +192,7 @@ The DMZ namespace implements multiple security layers:
 3. **Health Checks**: Implement liveness and readiness probes
 4. **Security Context**: Run as non-root user when possible
 5. **Image Scanning**: Use trusted, scanned images
-6. **Secrets Management**: Use Sealed Secrets for sensitive data
+6. **Secrets Management**: Use an `ExternalSecret` — ESO materializes the Secret from 1Password. Never commit a plain `kind: Secret` (SealedSecrets are retired; the controller was removed 2026-05-31)
 7. **Labels Required**: All pods must have `app`, `env`, and `category` labels (enforced by Kyverno)
 
 ## Monitoring
@@ -172,7 +204,7 @@ The DMZ namespace implements multiple security layers:
 ## Troubleshooting
 
 ### Pod not scheduled
-- Check node taints: `kubectl describe node k8sworker05`
+- Check node taints: `kubectl describe node k8sworker05 k8sworker06`
 - Verify tolerations in pod spec
 
 ### No network connectivity


### PR DESCRIPTION
`clusters/vollminlab-cluster/dmz/README.md` documented only Minecraft. masters-league has been the DMZ's second workload for some time and is absent from the README entirely — including the fact that it deliberately does *not* use the `external-access` / `internet-egress` label pattern the README presents as the DMZ convention.

Second half of the README audit split; the first half merged as #1044. Split by file so the two PRs cannot conflict during serial merges — this PR touches `dmz/README.md` only.

## What changed

**Added** a `## Deployed Services` table (minecraft + masters-league, how each is deployed, exposed, and policed) and a `### masters-league` subsection covering the image, ESO pull secret, replicas, container ports, NodePort 32567 with `externalTrafficPolicy: Local`, egress set, and labels. Every value was read from the live manifests in `dmz/masters-league/app/` — deployment, service, networkpolicy, and externalsecret — not inferred.

**Corrected** drift predating the second DMZ node: three lines claimed pods run only on `k8sworker05` (Kyverno Result, Physical Isolation, Storage Isolation), plus a nodePort comment and the troubleshooting `describe node` command.

**Replaced** "Secrets Management: Use Sealed Secrets for sensitive data" with the ExternalSecret/ESO workflow. The SealedSecrets controller was removed 2026-05-31; that line was pointing readers at a mechanism that no longer reconciles.

## Note on the ipBlock pattern

masters-league's NetworkPolicy uses `ipBlock` for its two HAProxy sources. `.claude/rules/networkpolicy.md` warns against `ipBlock` for CP/host-IP sources under Calico IPIP — that warning is about kernel RPF dropping IPIP-decapsulated packets, which does not apply to external VMs reaching a NodePort with `externalTrafficPolicy: Local`. The README documents what is deployed and working; it does not promote `ipBlock` as a general pattern.