### PR TITLE
fix(velero): skip all emptyDir volumes from filesystem backup

### DIFF
--- a/.claude/rules/velero.md
+++ b/.claude/rules/velero.md
@@ -2,12 +2,71 @@
 
 ## Current configuration
 
-- **Schedules:** `daily-full` (2am → MinIO BSL), `daily-b2` (4am → Backblaze B2 BSL)
-- **FSB:** `defaultVolumesToFsBackup: true` on both schedules
-- **Excluded from both:** `minio` namespace (see below)
-- **Resource policy:** `velero-skip-smb-policy` — skips `smb` StorageClass volumes (NAS shares)
-- **Node-agents:** deployed as DaemonSet with DMZ toleration; healthy on all 6 nodes
+- **Schedules (4):**
+  | Schedule | Cron (UTC) | BSL | TTL |
+  |---|---|---|---|
+  | `velero-daily-full` | `0 3 * * *` | MinIO | 96h |
+  | `velero-daily-b2` | `0 4 * * *` | Backblaze B2 | 2160h |
+  | `velero-victoria-metrics-b2` | `0 5 * * *` | Backblaze B2 | 2160h |
+  | `velero-monthly-b2` | `0 6 1 * *` | Backblaze B2 | 8760h |
+
+  Schedules run **serially** — a backup created while another is running goes to
+  `Queued`. There is no cancel field; `itemOperationTimeout` (4h) drains the queue.
+- **FSB:** `defaultVolumesToFsBackup: true` on all four, `parallelFilesUpload: 2`
+- **Excluded namespaces:** `kyverno`, `longhorn-system`, `metallb-system`, `minio`,
+  `monitoring`, `tofu`, `trivy-system`, `velero`
+- **Resource policy:** `velero-skip-smb-policy` — skips `smb` StorageClass volumes (NAS
+  shares) **and all `emptyDir` volumes**. Applied to `daily-full`, `daily-b2` and
+  `monthly-b2`; `victoria-metrics-b2` has none. Name is historical, scope is wider.
+- **Node-agents:** DaemonSet with DMZ toleration; 9 pods (6 workers + 3 CPs)
+- **`loadConcurrency` is pinned at the default 1 per node — do not raise it.** All worker
+  VMDKs share one datastore; a full FSB pass already drives PSI full I/O-stall to 26-48%
+  on every general worker. `parallelFilesUpload: 2` is the only remaining throttle.
 - **BackupRepository CRs:** recreated automatically on first backup after any wipe
+
+## Never FSB-back-up an emptyDir
+
+The kubelet deletes an `emptyDir` when its pod is removed, so a restored pod can never
+receive the contents — the backup is unrecoverable by construction. Worse, it is the
+dominant PVB failure source: when a pod goes away mid-run (CNPG failover, Job completion),
+every one of its volumes fails with `error identifying unique volume path on host` or
+`pods "<x>" not found`.
+
+This is handled **globally** by the `volumeTypes: [emptyDir]` skip in
+`velero-skip-smb-policy`. Do **not** add new per-app
+`backup.velero.io/backup-volumes-excludes` annotations for emptyDirs — that was the old
+whack-a-mole approach (PRs #1009, #1033, #1034, #1035) and it is superseded.
+
+Velero's FSB path already skips `hostPath`, `secret`, `configMap`, `projected` and
+`downwardAPI` unconditionally, so those never need a policy entry.
+
+## Recipe: a PVB frozen in `Prepared` (node-agent datapath-slot leak)
+
+**Symptom.** One PVB sits at `Prepared` for tens of minutes with no error anywhere. Its
+exposer pod (same name as the PVB, in `velero`) is `1/1 Running`, 0 restarts, and its log
+stops dead at `Running data path service`. The velero server pod is parked at
+`backupper.go:235` naming that pod — FSB is **head-of-line blocked**, so the whole backup
+stalls until `itemOperationTimeout` expires 4h later.
+
+**Fingerprint.** The node's node-agent re-emits `pod_volume_backup_controller.go:278` /
+`exposer/pod_volume.go:253` / `pod_volume_backup_controller.go:303` on an exact **5-second
+cadence** with zero error lines. That 5s requeue is the `ConcurrentLimitExceed` branch,
+which logs only at Debug — the node-agent's in-memory datapath slot has leaked, so with
+`loadConcurrency=1` no PVB on that node can ever acquire one again.
+
+**Fix — restart the node-agent on that node.** State is in-memory only; the PVB completes
+within seconds and the backup resumes.
+
+```bash
+# Find the stuck PVB and its node (.status.node is NOT populated — use .spec.node)
+kubectl get podvolumebackups.velero.io -n velero \
+  -o custom-columns='NAME:.metadata.name,PHASE:.status.phase,NODE:.spec.node,POD:.spec.pod.name' \
+  | grep -Ev 'Completed|Failed'
+
+kubectl delete pod -n velero -l name=node-agent --field-selector spec.nodeName=<node>
+```
+
+There is no upstream fix as of v1.18.2 — the changelog contains no node-agent datapath work.
 
 ## Hard rule: measure before you act
 

--- a/clusters/vollminlab-cluster/velero/velero/app/resource-policy-configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/resource-policy-configmap.yaml
@@ -1,6 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  # Name is historical — this policy now covers more than SMB. Renaming it would
+  # require updating the three `resourcePolicy.name` refs in configmap.yaml in
+  # lockstep, so the name is kept and the scope documented here instead.
   name: velero-skip-smb-policy
   namespace: velero
   labels:
@@ -11,8 +14,44 @@ data:
   policy.yaml: |
     version: v1
     volumePolicies:
+      # NAS shares — backed up by TrueNAS itself, not by Velero.
       - conditions:
           storageClass:
             - smb
+        action:
+          type: skip
+
+      # emptyDir is scratch space by definition: the kubelet deletes it when the
+      # pod is removed, so a restored pod can never receive its contents. Backing
+      # it up produces no recoverable data and is the single largest source of
+      # PodVolumeBackup failures on this cluster:
+      #
+      #   * "error identifying unique volume path on host" — the pod's
+      #     /host_pods/<uid> tree disappears mid-run (CNPG failovers, tf-runner
+      #     Jobs completing). Every volume of that pod fails together.
+      #   * "pods <x> not found" — same cause, later in the sequence.
+      #
+      # Measured 2026-08-11: of the FSB volumes Velero would attempt cluster-wide,
+      # 27 are live emptyDir and ~48 more are emptyDir already suppressed by
+      # per-app `backup.velero.io/backup-volumes-excludes` annotations, against
+      # 44 real PVCs. So ~63% of all FSB work was ephemeral scratch. Removing it
+      # also shortens the backup window, which is the mitigation for the nightly
+      # PSI I/O-stall (node-agent loadConcurrency is already pinned at 1 — see
+      # configmap.yaml).
+      #
+      # This supersedes the per-app annotation approach used in PRs #1009, #1033,
+      # #1034 and #1035. Those annotations are now redundant but harmless; leave
+      # them until a separate cleanup PR.
+      #
+      # Only emptyDir is listed. Velero's FSB path already skips hostPath, secret,
+      # configMap, projected and downwardAPI volumes unconditionally
+      # (pkg/util/podvolume/pod_volume.go GetVolumesByPod, v1.18.1), so listing
+      # them here would be dead configuration.
+      #
+      # PVC-backed volumes are deliberately NOT skipped — pgdata, registry-data,
+      # config, metadata, media, backupdir and datadir hold real state.
+      - conditions:
+          volumeTypes:
+            - emptyDir
         action:
           type: skip


### PR DESCRIPTION
## Problem

`daily-full` and `daily-b2` have been `PartiallyFailed` every night — **~31 errors / 47 warnings**, and each run burns 03:00→07:00 waiting out `itemOperationTimeout`.

The dominant failure class is emptyDir:

| Error | Cause |
|---|---|
| `error identifying unique volume path on host` (21) | the pod's `/host_pods/<uid>` tree vanished mid-run |
| `pods "<x>" not found` | same cause, later in the sequence |

When a pod goes away during a 4-hour run — CNPG failover, `tf-runner` Job completing, a Deployment rollout — **every volume of that pod fails together**. harbor-db, jellystat-db, shlink-db, vollmint-db, the tofu runners, harbor-core/jobservice/registry, homepage, prowlarr and more all show this shape.

## Why emptyDir should never have been backed up

The kubelet deletes an `emptyDir` when the pod is removed. A restored pod **cannot** receive the contents — the backup is unrecoverable by construction. It is pure I/O cost and pure failure surface.

## Scale

Measured cluster-wide 2026-08-11, counting only volumes Velero's FSB path would actually attempt:

| Type | Count |
|---|---|
| persistentVolumeClaim | 44 |
| emptyDir (live) | 27 |
| emptyDir (already suppressed by per-app annotations) | 48 |

**~63% of all FSB work is ephemeral scratch.** Removing it also shortens the backup window — the standing mitigation for the nightly PSI I/O stall, since node-agent `loadConcurrency` is already pinned at its minimum of 1.

## Change

One `volumePolicies` entry added to the existing `velero-skip-smb-policy` ConfigMap, which `daily-full`, `daily-b2` and `monthly-b2` already reference — so all three are covered without touching schedule config.

```yaml
- conditions:
    volumeTypes:
      - emptyDir
  action:
    type: skip
```

## Verified against velero v1.18.1 source, not assumed

- `volumeTypes` is a supported condition — `internal/resourcepolicies/volume_resources_validator.go`, registered at `resource_policies.go:147`
- it is evaluated **on the pod-volume (FSB) path** — `pkg/podvolume/backupper.go:329` calls `getMatchAction` per volume, `:332` honours `Skip`
- exact constant strings from `volume_types_conditions.go` (the published docs example uses lowercase `configmap`; the constant is `configMap` — trusted the source)
- only `emptyDir` is listed: `hostPath`, `secret`, `configMap`, `projected` and `downwardAPI` are already skipped unconditionally by `GetVolumesByPod` in `pkg/util/podvolume/pod_volume.go`, so listing them would be dead config

PVC-backed volumes are deliberately untouched — `pgdata`, `registry-data`, `config`, `metadata`, `media`, `backupdir`, `datadir` hold real state.

## Supersedes the whack-a-mole

This replaces the per-app `backup.velero.io/backup-volumes-excludes` annotation approach used in #1009, #1033, #1034 and #1035. Those annotations become redundant but stay harmless; removing them is a separate cleanup.

The ConfigMap name `velero-skip-smb-policy` is now a misnomer. Renaming it would require updating three `resourcePolicy.name` refs in `configmap.yaml` in lockstep, so the name is kept and the widened scope is documented in the file.

## Also: `.claude/rules/velero.md` refresh

It had drifted badly — 2 schedules listed instead of 4, `daily-full` at 2am instead of 3am, 6 node-agents instead of 9. Adds:

- the full schedule table and the serial-execution/`Queued` behaviour
- the "never FSB an emptyDir" rule, so the annotation pattern doesn't get reintroduced
- the `loadConcurrency=1` constraint written down as a hard rule
- a recovery recipe for a **PVB frozen in `Prepared`** — the node-agent datapath-slot leak that stalled this morning's run for 33 minutes. Fingerprint is a 5-second requeue cadence with zero error lines (`ConcurrentLimitExceed` logs only at Debug); fix is restarting the node-agent on `.spec.node`. No upstream fix as of v1.18.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uXgEor4Qp9wcQUHJ9GkkB