### PR TITLE
chore(vollmint): bump OCIRepository 0.3.2 -> 0.4.0 (net worth)

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/vollmint-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/vollmint-ocirepository.yaml
@@ -11,6 +11,6 @@ spec:
   interval: 1h
   url: oci://harbor.vollminlab.com/vollminlab/charts/vollmint
   ref:
-    tag: "0.3.2"
+    tag: "0.4.0"
   secretRef:
     name: harbor-vollminlab-pull


### PR DESCRIPTION
Rolls out vollmint **v0.4.0** — the Net Worth feature (daily balance snapshots,
manual accounts, net-worth page). Shipped in vollmint PR #11 (merged); image +
chart `0.4.0` already published to Harbor by the `v0.4.0` tag build.

- `vollmint-ocirepository.yaml`: `tag 0.3.2 → 0.4.0`

After merge, Flux pulls chart 0.4.0 and the HelmRelease upgrades. Migration 0004
runs on start (adds `account_balance_snapshots` + `accounts.is_manual`). Brief
Recreate-rollout gap is expected. Snapshot history begins accruing at the first
post-deploy sync; manual accounts give day-one net-worth totals.

Spec + plan: k8s PR #1052.

🤖 Generated with [Claude Code](https://claude.com/claude-code)