### PR TITLE
fix(velero): auto-heal node-agent datapath-slot leak that freezes PVBs

### DIFF
--- a/clusters/vollminlab-cluster/velero/kustomization.yaml
+++ b/clusters/vollminlab-cluster/velero/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - velero/app
+  - velero-pvb-healer/app

--- a/clusters/vollminlab-cluster/velero/velero-pvb-healer/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/velero/velero-pvb-healer/app/cronjob.yaml
@@ -1,0 +1,70 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: velero-pvb-healer
+  namespace: velero
+  labels:
+    app: velero-pvb-healer
+    env: production
+    category: storage
+spec:
+  # 10 min tick + a 15 min stall threshold => worst-case detection ~25 min,
+  # against the 4h itemOperationTimeout that is the only thing currently
+  # breaking the deadlock.
+  schedule: "*/10 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 3600
+      # backoffLimit 2 (not 0): the script never self-fails — every path returns
+      # 0 — so a Failed job means the pod died externally, usually the
+      # descheduler evicting this tiny Burstable pod off a hot node. With
+      # backoffLimit 0 that eviction alone would raise KubeJobFailed. Retrying is
+      # safe: the run is stateless and the cooldown annotation is written before
+      # the delete, so a retry cannot double-heal.
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app: velero-pvb-healer
+            env: production
+            category: storage
+        spec:
+          serviceAccountName: velero-pvb-healer
+          restartPolicy: Never
+          containers:
+            - name: velero-pvb-healer
+              image: docker.io/alpine/kubectl:1.33.4
+              command: ["/bin/sh", "/scripts/heal.sh"]
+              env:
+                - name: PVB_NAMESPACE
+                  value: "velero"
+                # 15 min. Normal Prepared -> InProgress is seconds; the longest
+                # legitimate wait is a sibling PVB holding the node's single
+                # datapath slot, and that case is excluded by the InProgress
+                # guard rather than by this threshold.
+                - name: STALL_SECONDS
+                  value: "900"
+                - name: COOLDOWN_SECONDS
+                  value: "3600"
+                - name: NODE_AGENT_SELECTOR
+                  value: "name=node-agent"
+                - name: DRY_RUN
+                  value: "false"
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+                  readOnly: true
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 200m
+                  memory: 64Mi
+          volumes:
+            - name: script
+              configMap:
+                name: velero-pvb-healer-script

--- a/clusters/vollminlab-cluster/velero/velero-pvb-healer/app/heal.sh
+++ b/clusters/vollminlab-cluster/velero/velero-pvb-healer/app/heal.sh
@@ -1,0 +1,208 @@
+#!/bin/sh
+# velero-pvb-healer: clear the node-agent datapath-slot leak that freezes a
+# PodVolumeBackup in `Prepared` forever.
+#
+# In Velero v1.18's micro-service data mover, a PVB is run by a per-PVB exposer
+# pod that waits for node-agent to flip the PVB to InProgress. node-agent only
+# does that after it creates a datapath routine for the PVB. When the in-memory
+# datapath slot leaks, every attempt returns ConcurrentLimitExceed -- which is
+# logged at Debug only -- and the controller just requeues on a 5s cadence. Both
+# sides then wait forever with no error emitted anywhere.
+#
+# Because loadConcurrency is pinned at 1 on this cluster (worker VMDKs share one
+# datastore), a single leaked slot wedges every remaining PVB on that node. FSB
+# is head-of-line blocked in backupper.go, so the whole backup stalls until
+# itemOperationTimeout expires 4h later and the run lands PartiallyFailed.
+#
+# The state is in-memory only: deleting the node-agent pod on that node releases
+# it and the frozen PVB completes within seconds. That is exactly what this
+# script automates.
+set -u
+
+# --- tunables (overridable via env in the CronJob) ---
+PVB_NAMESPACE="${PVB_NAMESPACE:-velero}"
+STALL_SECONDS="${STALL_SECONDS:-900}"
+COOLDOWN_SECONDS="${COOLDOWN_SECONDS:-3600}"
+NODE_AGENT_SELECTOR="${NODE_AGENT_SELECTOR:-name=node-agent}"
+DRY_RUN="${DRY_RUN:-false}"
+
+ANN_LAST="pvb-healer.vollminlab.com/last-healed"
+# jsonpath-escaped annotation key (dots escaped)
+JP_LAST='pvb-healer\.vollminlab\.com/last-healed'
+
+# Single kubectl entry point so tests can stub it.
+kc() { kubectl "$@"; }
+
+log() { echo "[$(date -u +%FT%TZ)] $*"; }
+
+# strip_zero: echo a numeric field without its leading zero. "08" is an invalid
+# octal literal in ash/dash arithmetic, so every parsed field goes through this.
+strip_zero() {
+  v="${1#0}"
+  [ -n "$v" ] || v=0
+  echo "$v"
+}
+
+# rfc3339_to_epoch: convert 2026-08-11T03:02:59Z to unix seconds via the
+# days-from-civil algorithm. Kubernetes timestamps are always UTC, but busybox
+# `date` and GNU `date` disagree on how to parse this format (-D vs -d), so the
+# arithmetic is done here to keep the script portable and unit-testable.
+# $1=timestamp. Returns 1 on anything that is not an RFC3339 UTC stamp.
+rfc3339_to_epoch() {
+  ts="$1"
+  case "$ts" in *T*Z) ;; *) return 1 ;; esac
+  y=$(strip_zero "${ts%%-*}");    rest="${ts#*-}"
+  mo=$(strip_zero "${rest%%-*}"); rest="${rest#*-}"
+  d=$(strip_zero "${rest%%T*}");  rest="${rest#*T}"
+  h=$(strip_zero "${rest%%:*}");  rest="${rest#*:}"
+  mi=$(strip_zero "${rest%%:*}"); rest="${rest#*:}"
+  s=$(strip_zero "${rest%%[.Z]*}")
+
+  # civil_from_days, shifted so the year starts in March (Feb is then last)
+  [ "$mo" -le 2 ] && y=$((y - 1))
+  era=$((y / 400))
+  yoe=$((y - era * 400))
+  if [ "$mo" -gt 2 ]; then mp=$((mo - 3)); else mp=$((mo + 9)); fi
+  doy=$(((153 * mp + 2) / 5 + d - 1))
+  doe=$((yoe * 365 + yoe / 4 - yoe / 100 + doy))
+  days=$((era * 146097 + doe - 719468))
+  echo $((days * 86400 + h * 3600 + mi * 60 + s))
+}
+
+# in_cooldown: exit 0 if (now - last) < cooldown. $1=last(may be empty) $2=now $3=cooldown
+in_cooldown() {
+  last="$1"; now="$2"; cd="$3"
+  [ -n "$last" ] || return 1
+  delta=$((now - last))
+  [ "$delta" -lt "$cd" ]
+}
+
+# pvb_rows: one line per PodVolumeBackup -- "name phase node acceptedTimestamp".
+# custom-columns rather than jsonpath because it renders a missing field as
+# <none> instead of an empty string, which would shift the columns apart under
+# word splitting. The node comes from .spec.node: .status.node exists in the CRD
+# but is not populated in v1.18.1.
+pvb_rows() {
+  kc get podvolumebackups.velero.io -n "$PVB_NAMESPACE" --no-headers \
+    -o custom-columns='NAME:.metadata.name,PHASE:.status.phase,NODE:.spec.node,ACCEPTED:.status.acceptedTimestamp' \
+    2>/dev/null
+}
+
+# busy_nodes: echo the nodes holding a legitimate datapath slot right now. A PVB
+# in InProgress means the slot on that node is genuinely in use, so any sibling
+# PVB sitting at Prepared there is just queued behind it -- normal with
+# loadConcurrency=1, and NOT a leak. $1=rows
+busy_nodes() {
+  echo "$1" | while read -r _name phase node _accepted; do
+    [ "$phase" = "InProgress" ] || continue
+    echo "$node"
+  done
+}
+
+# node_is_busy: $1=node $2=space/newline separated busy node list
+node_is_busy() {
+  for b in $2; do
+    [ "$b" = "$1" ] && return 0
+  done
+  return 1
+}
+
+# emit_event: best-effort core/v1 Event on the PVB. Never fails the run.
+# $1=pvb $2=reason $3=type(Normal|Warning) $4=message
+emit_event() {
+  epvb="$1"; ereason="$2"; etype="$3"; emsg="$4"
+  euid=$(kc get podvolumebackups.velero.io "$epvb" -n "$PVB_NAMESPACE" -o jsonpath='{.metadata.uid}' 2>/dev/null)
+  ets=$(date -u +%FT%TZ)
+  ename="${epvb}.$(date -u +%s)"
+  kc create -f - >/dev/null 2>&1 <<EOF || log "WARN: event emit failed for $epvb"
+apiVersion: v1
+kind: Event
+metadata:
+  name: ${ename}
+  namespace: ${PVB_NAMESPACE}
+involvedObject:
+  apiVersion: velero.io/v1
+  kind: PodVolumeBackup
+  name: ${epvb}
+  namespace: ${PVB_NAMESPACE}
+  uid: ${euid}
+reason: ${ereason}
+message: "${emsg}"
+type: ${etype}
+source:
+  component: velero-pvb-healer
+firstTimestamp: ${ets}
+lastTimestamp: ${ets}
+count: 1
+EOF
+}
+
+# heal_node: release the leaked slot by restarting node-agent on that node.
+# $1=node $2=pvb $3=age_seconds
+heal_node() {
+  node="$1"; pvb="$2"; age="$3"
+  if [ "$DRY_RUN" = "true" ]; then
+    log "DRY_RUN: would delete node-agent on $node (pvb=$pvb stalled ${age}s)"
+    return 0
+  fi
+  # Stamp the cooldown BEFORE deleting, so a healer pod that dies mid-heal still
+  # leaves a record and cannot loop on the same PVB every 10 minutes.
+  kc annotate podvolumebackups.velero.io "$pvb" -n "$PVB_NAMESPACE" \
+    "$ANN_LAST=$(date -u +%s)" --overwrite
+  log "healing $node: deleting node-agent (pvb=$pvb stalled ${age}s)"
+  kc delete pod -n "$PVB_NAMESPACE" -l "$NODE_AGENT_SELECTOR" \
+    --field-selector "spec.nodeName=$node"
+  emit_event "$pvb" HealedStalledPodVolumeBackup Normal \
+    "PVB stalled in Prepared for ${age}s with no InProgress PVB on $node; restarted node-agent to release the leaked datapath slot"
+}
+
+# find_and_heal_one: heal at most ONE node per run. Two nodes leaking at once is
+# not a case that has been seen, and FSB is head-of-line blocked on a single pod
+# anyway, so the second one can wait for the next tick.
+find_and_heal_one() {
+  rows=$(pvb_rows)
+  [ -n "$rows" ] || { log "no PodVolumeBackups found"; return 0; }
+  busy=$(busy_nodes "$rows")
+  now=$(date -u +%s)
+  healed=0
+
+  # Fed by here-doc, not a pipe: a `while` on the right of a pipe runs in a
+  # subshell, and $healed would not survive the loop.
+  while read -r name phase node accepted; do
+    [ "$phase" = "Prepared" ] || continue
+    [ "$node" != "<none>" ] || continue
+    [ "$accepted" != "<none>" ] || continue
+
+    accepted_epoch=$(rfc3339_to_epoch "$accepted") || continue
+    age=$((now - accepted_epoch))
+    [ "$age" -ge "$STALL_SECONDS" ] || continue
+
+    if node_is_busy "$node" "$busy"; then
+      log "skip $name: $node has a PVB InProgress (queued, not leaked)"
+      continue
+    fi
+
+    last=$(kc get podvolumebackups.velero.io "$name" -n "$PVB_NAMESPACE" \
+      -o jsonpath="{.metadata.annotations.$JP_LAST}" 2>/dev/null)
+    if in_cooldown "$last" "$now" "$COOLDOWN_SECONDS"; then
+      log "skip $name: in cooldown (last-healed=$last)"
+      continue
+    fi
+
+    heal_node "$node" "$name" "$age"
+    healed=1
+    break
+  done <<EOF
+$rows
+EOF
+
+  [ "$healed" = 1 ] || log "no stalled PodVolumeBackups"
+}
+
+main() {
+  log "velero-pvb-healer start (ns=$PVB_NAMESPACE stall=${STALL_SECONDS}s dry_run=$DRY_RUN)"
+  find_and_heal_one
+  log "velero-pvb-healer done"
+}
+
+[ -n "${HEAL_TEST:-}" ] || main "$@"

--- a/clusters/vollminlab-cluster/velero/velero-pvb-healer/app/heal_test.sh
+++ b/clusters/vollminlab-cluster/velero/velero-pvb-healer/app/heal_test.sh
@@ -1,0 +1,113 @@
+#!/bin/sh
+# Unit tests for heal.sh. Run: sh heal_test.sh
+# Sources heal.sh with HEAL_TEST=1 so main() does not run, then stubs kc,
+# pvb_rows, heal_node and date per-test.
+set -u
+HERE=$(dirname "$0")
+HEAL_TEST=1 . "$HERE/heal.sh"
+
+FAILS=0
+assert_eq() { # $1=actual $2=expected $3=msg
+  if [ "$1" = "$2" ]; then printf 'ok   - %s\n' "$3"
+  else printf 'FAIL - %s (got [%s] want [%s])\n' "$3" "$1" "$2"; FAILS=$((FAILS+1)); fi
+}
+assert_rc() { # $1=actual_rc $2=expected_rc $3=msg
+  if [ "$1" = "$2" ]; then printf 'ok   - %s\n' "$3"
+  else printf 'FAIL - %s (rc got [%s] want [%s])\n' "$3" "$1" "$2"; FAILS=$((FAILS+1)); fi
+}
+
+# --- strip_zero ---
+assert_eq "$(strip_zero 08)" "8" "strip_zero drops the octal-poisoning zero"
+assert_eq "$(strip_zero 00)" "0" "strip_zero of 00 is 0"
+assert_eq "$(strip_zero 2026)" "2026" "strip_zero leaves a 4-digit year alone"
+
+# --- rfc3339_to_epoch (cross-checked against `date -u -d <ts> +%s`) ---
+assert_eq "$(rfc3339_to_epoch 1970-01-01T00:00:00Z)" "0" "epoch zero"
+assert_eq "$(rfc3339_to_epoch 2026-01-01T00:00:00Z)" "1767225600" "new year 2026"
+assert_eq "$(rfc3339_to_epoch 2026-08-11T03:02:59Z)" "1786417379" "the stall that started this"
+assert_eq "$(rfc3339_to_epoch 2024-02-29T12:00:00Z)" "1709208000" "leap day"
+assert_eq "$(rfc3339_to_epoch 2026-08-11T03:02:59.123456Z)" "1786417379" "fractional seconds ignored"
+rfc3339_to_epoch "<none>"; assert_rc "$?" "1" "rejects <none>"
+rfc3339_to_epoch ""; assert_rc "$?" "1" "rejects empty"
+
+# --- in_cooldown ---
+in_cooldown "100" "150" "60"; assert_rc "$?" "0" "in_cooldown true when delta<cooldown"
+in_cooldown "100" "200" "60"; assert_rc "$?" "1" "in_cooldown false when delta>cooldown"
+in_cooldown "" "200" "60";    assert_rc "$?" "1" "in_cooldown false when never healed"
+
+# --- busy_nodes / node_is_busy ---
+ROWS_MIXED='pvb-a   Prepared     k8sworker03   2026-08-11T02:40:00Z
+pvb-b   InProgress   k8sworker03   2026-08-11T02:55:00Z
+pvb-c   Completed    k8sworker01   2026-08-11T02:10:00Z'
+assert_eq "$(busy_nodes "$ROWS_MIXED")" "k8sworker03" "busy_nodes finds the InProgress node"
+node_is_busy k8sworker03 "$(busy_nodes "$ROWS_MIXED")"; assert_rc "$?" "0" "node_is_busy true for the busy node"
+node_is_busy k8sworker01 "$(busy_nodes "$ROWS_MIXED")"; assert_rc "$?" "1" "node_is_busy false for an idle node"
+
+# --- find_and_heal_one: stub the clock, the row source and the action ---
+# 2026-08-11T03:02:59Z. Fixtures are dated relative to it:
+#   02:40:00Z -> 1379s old (stalled, > STALL_SECONDS=900)
+#   03:00:00Z ->  179s old (fresh)
+NOW_EPOCH=1786417379
+date() {
+  case "$*" in
+    "-u +%s") echo "$NOW_EPOCH" ;;
+    *) echo "2026-08-11T03:02:59Z" ;;
+  esac
+}
+
+HEALED=""
+heal_node() { HEALED="$1 $2 $3"; }
+
+LAST_HEALED_COOL=""
+kc() {
+  case "$*" in
+    *pvb-cool*annotations*) echo "$LAST_HEALED_COOL" ;;
+    *) echo "" ;;
+  esac
+}
+
+run_case() { # $1=rows -> sets HEALED
+  HEALED=""
+  # via a global, not "$1": inside pvb_rows, $1 would be pvb_rows' own argument.
+  ROWS="$1"
+  pvb_rows() { echo "$ROWS"; }
+  find_and_heal_one >/dev/null
+}
+
+# 1. Stalled Prepared, nothing running on that node -> the leak. Heal it.
+run_case 'pvb-a   Prepared   k8sworker03   2026-08-11T02:40:00Z'
+assert_eq "$HEALED" "k8sworker03 pvb-a 1379" "stalled Prepared on an idle node is healed"
+
+# 2. Same PVB, but a sibling is genuinely running on that node. With
+#    loadConcurrency=1 that is an ordinary queue wait -- killing node-agent here
+#    would abort a healthy in-flight backup. This guard is the whole ballgame.
+run_case "$ROWS_MIXED"
+assert_eq "$HEALED" "" "Prepared behind an InProgress PVB on the same node is left alone"
+
+# 3. Prepared but only 179s old -> still inside normal setup time.
+run_case 'pvb-a   Prepared   k8sworker03   2026-08-11T03:00:00Z'
+assert_eq "$HEALED" "" "young Prepared PVB is left alone"
+
+# 4. Stalled, idle node, but healed 10 minutes ago -> cooldown holds, so a PVB
+#    that is broken for some other reason cannot loop node-agent every 10 min.
+LAST_HEALED_COOL=$((NOW_EPOCH - 600))
+run_case 'pvb-cool   Prepared   k8sworker03   2026-08-11T02:40:00Z'
+assert_eq "$HEALED" "" "cooldown suppresses a repeat heal"
+
+# 5. Same, but the cooldown has expired.
+LAST_HEALED_COOL=$((NOW_EPOCH - 7200))
+run_case 'pvb-cool   Prepared   k8sworker03   2026-08-11T02:40:00Z'
+assert_eq "$HEALED" "k8sworker03 pvb-cool 1379" "expired cooldown allows a heal"
+
+# 6. Other phases are never touched.
+run_case 'pvb-x   Completed   k8sworker03   2026-08-11T02:40:00Z
+pvb-y   Canceled    k8sworker02   2026-08-11T02:40:00Z
+pvb-z   Accepted    k8sworker01   2026-08-11T02:40:00Z'
+assert_eq "$HEALED" "" "Completed/Canceled/Accepted PVBs are ignored"
+
+# 7. Unscheduled PVB (no node yet) is ignored.
+run_case 'pvb-n   Prepared   <none>   2026-08-11T02:40:00Z'
+assert_eq "$HEALED" "" "PVB without a node is ignored"
+
+if [ "$FAILS" -gt 0 ]; then printf '\n%s test(s) failed\n' "$FAILS"; exit 1; fi
+printf '\nall tests passed\n'

--- a/clusters/vollminlab-cluster/velero/velero-pvb-healer/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/velero/velero-pvb-healer/app/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: velero-pvb-healer
+resources:
+  - rbac.yaml
+  - cronjob.yaml
+configMapGenerator:
+  - name: velero-pvb-healer-script
+    files:
+      - heal.sh
+generatorOptions:
+  disableNameSuffixHash: true
+  labels:
+    app: velero-pvb-healer
+    env: production
+    category: storage

--- a/clusters/vollminlab-cluster/velero/velero-pvb-healer/app/rbac.yaml
+++ b/clusters/vollminlab-cluster/velero/velero-pvb-healer/app/rbac.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: velero-pvb-healer
+  namespace: velero
+  labels:
+    app: velero-pvb-healer
+    env: production
+    category: storage
+---
+# Role, not ClusterRole: everything the healer touches — PodVolumeBackups and
+# the node-agent DaemonSet pods — lives in the velero namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: velero-pvb-healer
+  namespace: velero
+  labels:
+    app: velero-pvb-healer
+    env: production
+    category: storage
+rules:
+  - apiGroups: ["velero.io"]
+    resources: ["podvolumebackups"]
+    # patch is for the cooldown annotation, which is what stops the healer
+    # looping on a PVB that is stuck for some reason a node-agent restart
+    # cannot fix.
+    verbs: ["get", "list", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    # delete is scoped by the -l name=node-agent selector in the script; RBAC
+    # cannot express that, so the Role is namespace-bound instead.
+    verbs: ["get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: velero-pvb-healer
+  namespace: velero
+  labels:
+    app: velero-pvb-healer
+    env: production
+    category: storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: velero-pvb-healer
+subjects:
+  - kind: ServiceAccount
+    name: velero-pvb-healer
+    namespace: velero


### PR DESCRIPTION
## The bug

A `PodVolumeBackup` can sit in `Prepared` **forever**.

In Velero v1.18's micro-service data mover, a PVB is run by a per-PVB exposer pod that waits for node-agent to flip the PVB to `InProgress`. node-agent only does that once it has created a datapath routine for the PVB. When the in-memory datapath slot leaks, every attempt returns `ConcurrentLimitExceed` — which `pod_volume_backup_controller.go` logs at **Debug only** — and the controller returns `RequeueAfter: 5s`. Both sides then wait forever. At INFO the only symptom is three log sites re-emitting on an exact 5-second cadence with zero error or warning lines.

`loadConcurrency` is pinned at **1** on this cluster (all worker VMDKs share one datastore; a full FSB pass already drives PSI full-I/O-stall to 26–48% on every general worker), so a single leaked slot wedges every remaining PVB on that node. FSB is head-of-line blocked in `backupper.go:235`, so the entire backup stalls until `itemOperationTimeout` fires 4h later and the run lands `PartiallyFailed`.

That is the chronic `PartiallyFailed` pattern from 08-05 through 08-10.

## Why a healer rather than an upstream fix

The state is in-memory only — deleting the node-agent pod on the affected node releases the slot and the frozen PVB completes within seconds. That manual delete is exactly what produced last night's clean `velero-daily-full-20260811030048` (Completed, 0 errors, 50/50 PVBs). There is no upstream fix as of v1.18.2, and raising `loadConcurrency` is ruled out by the I/O-contention constraint.

## What it does

A CronJob (`*/10 * * * *`) that deletes node-agent on a node only when **all** of these hold:

- a PVB has been in `Prepared` for ≥ `STALL_SECONDS` (900)
- **no PVB is `InProgress` on that node** — with `loadConcurrency=1` a sibling sitting at `Prepared` is an ordinary queue wait, and killing node-agent there would abort a healthy in-flight backup. This guard is the one that matters.
- that PVB was not already healed within `COOLDOWN_SECONDS` (3600)

At most one node per run. Worst-case detection ≈ 25 min (15 min threshold + 10 min tick), against the current silent 4-hour stall.

The cooldown annotation is written **before** the delete, so a healer pod that dies mid-heal still leaves a record and cannot loop on the same PVB every 10 minutes.

## Notes

- RBAC is a namespace `Role`, not a `ClusterRole` — PVBs and node-agent pods both live in `velero`.
- Node comes from `.spec.node`: `.status.node` exists in the CRD but is not populated in v1.18.1.
- `rfc3339_to_epoch` is pure shell (days-from-civil) because busybox `date -D` and GNU `date -d` disagree on parsing, and `08` is an invalid octal literal in ash arithmetic.
- `heal_test.sh` — 23 assertions, run manually with `sh heal_test.sh`. Not wired into CI, matching `longhorn-mount-healer`.
- Independent of #1051. That one cuts the *error volume* (skip emptyDir from FSB); this one cuts the *stall*. Different mechanism, separately revertable.
- No `NetworkPolicy` work needed — the `velero` namespace has none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uXgEor4Qp9wcQUHJ9GkkB