### PR TITLE
fix(velero): set namespace on the pvb-healer kustomization

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero-pvb-healer/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/velero/velero-pvb-healer/app/kustomization.yaml
@@ -2,6 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 metadata:
   name: velero-pvb-healer
+# Required: configMapGenerator emits a ConfigMap with no namespace, and unlike
+# kube-system the velero Flux Kustomization sets no targetNamespace, so the
+# generated ConfigMap is rejected with "namespace not specified" and takes the
+# whole velero Kustomization down with it. rbac.yaml and cronjob.yaml already
+# carry namespace: velero explicitly; this makes the generated object match.
+namespace: velero
 resources:
   - rbac.yaml
   - cronjob.yaml


### PR DESCRIPTION
Follow-up to #1054, which left the **entire velero Flux Kustomization at `READY=False`**:

```
ConfigMap/velero-pvb-healer-script namespace not specified:
the server could not find the requested resource
```

`configMapGenerator` emits a ConfigMap with no namespace. `longhorn-mount-healer` gets away with the identical layout only because the **kube-system** Flux Kustomization sets `targetNamespace: kube-system`. The velero one does not — so the generated object arrives namespace-less, the server rejects it, and every resource in the kustomization is blocked behind it.

Fixed at the app kustomization level rather than by adding `targetNamespace: velero` to the Flux Kustomization, which would rewrite the namespace on every velero resource including `namespace.yaml` itself.

`rbac.yaml` and `cronjob.yaml` already carry `namespace: velero` explicitly, so this only changes the generated ConfigMap. Verified with `kubectl kustomize` — all five healer objects now render with `namespace: velero`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uXgEor4Qp9wcQUHJ9GkkB