### PR TITLE
fix(velero): scope pvb-healer's PVB list so it stops OOMKilling

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero-pvb-healer/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/velero/velero-pvb-healer/app/cronjob.yaml
@@ -60,10 +60,15 @@ spec:
               resources:
                 requests:
                   cpu: 10m
-                  memory: 32Mi
+                  memory: 48Mi
                 limits:
                   cpu: 200m
-                  memory: 64Mi
+                  # Headroom, not the fix -- the fix is scoping the PVB list in
+                  # heal.sh. 64Mi OOMKilled every run, and because the healer had
+                  # never once completed there was no evidence 64Mi sufficed even
+                  # for a kubectl call returning a handful of objects. 128Mi
+                  # covers the Go runtime baseline with margin.
+                  memory: 128Mi
           volumes:
             - name: script
               configMap:

--- a/clusters/vollminlab-cluster/velero/velero-pvb-healer/app/heal.sh
+++ b/clusters/vollminlab-cluster/velero/velero-pvb-healer/app/heal.sh
@@ -77,15 +77,49 @@ in_cooldown() {
   [ "$delta" -lt "$cd" ]
 }
 
+# active_backups: names of Backup objects that are not in a terminal phase.
+#
+# Written as an exclusion, not an inclusion: Velero has added phases over time
+# (WaitingForPluginOperations*, Finalizing*, Queued) and a phase this script has
+# never heard of must default to "still running", or the healer would silently
+# stop watching it. An empty phase (<none>, freshly created) is active too.
+active_backups() {
+  kc get backups.velero.io -n "$PVB_NAMESPACE" --no-headers \
+    -o custom-columns='NAME:.metadata.name,PHASE:.status.phase' 2>/dev/null \
+    | while read -r bname bphase; do
+        case "$bphase" in
+          Completed|PartiallyFailed|Failed|FailedValidation|Deleting) ;;
+          *) echo "$bname" ;;
+        esac
+      done
+}
+
 # pvb_rows: one line per PodVolumeBackup -- "name phase node acceptedTimestamp".
+#
+# Scoped to the in-flight backups via the velero.io/backup-name label. This is
+# NOT an optimisation: PVBs are retained for the life of their backup (the B2
+# schedules keep 2160h), so an unscoped list is ~7,000 objects and kubectl's
+# decode OOM-killed this 64Mi container on every single run. Scoping bounds it
+# at the PVB count of one backup -- ~21 -- permanently, whereas raising the
+# memory limit only defers the same failure as the cluster grows.
+#
+# Only active backups are considered, and that is sufficient: FSB is head-of-line
+# blocked in backupper.go, so a PVB can only be stalling a backup that is still
+# running. If a backup does hit itemOperationTimeout and leaves orphaned Prepared
+# PVBs behind, the leaked node-agent slot poisons the *next* backup, whose own
+# Prepared PVB the healer then catches on the same node.
+#
 # custom-columns rather than jsonpath because it renders a missing field as
 # <none> instead of an empty string, which would shift the columns apart under
 # word splitting. The node comes from .spec.node: .status.node exists in the CRD
 # but is not populated in v1.18.1.
 pvb_rows() {
-  kc get podvolumebackups.velero.io -n "$PVB_NAMESPACE" --no-headers \
-    -o custom-columns='NAME:.metadata.name,PHASE:.status.phase,NODE:.spec.node,ACCEPTED:.status.acceptedTimestamp' \
-    2>/dev/null
+  for b in $(active_backups); do
+    kc get podvolumebackups.velero.io -n "$PVB_NAMESPACE" --no-headers \
+      -l "velero.io/backup-name=$b" \
+      -o custom-columns='NAME:.metadata.name,PHASE:.status.phase,NODE:.spec.node,ACCEPTED:.status.acceptedTimestamp' \
+      2>/dev/null
+  done
 }
 
 # busy_nodes: echo the nodes holding a legitimate datapath slot right now. A PVB

--- a/clusters/vollminlab-cluster/velero/velero-pvb-healer/app/heal_test.sh
+++ b/clusters/vollminlab-cluster/velero/velero-pvb-healer/app/heal_test.sh
@@ -43,6 +43,48 @@ assert_eq "$(busy_nodes "$ROWS_MIXED")" "k8sworker03" "busy_nodes finds the InPr
 node_is_busy k8sworker03 "$(busy_nodes "$ROWS_MIXED")"; assert_rc "$?" "0" "node_is_busy true for the busy node"
 node_is_busy k8sworker01 "$(busy_nodes "$ROWS_MIXED")"; assert_rc "$?" "1" "node_is_busy false for an idle node"
 
+# --- active_backups / pvb_rows scoping ---
+# This is the OOM guard. PVBs live as long as their backup's TTL (2160h on the
+# B2 schedules), so an unscoped `kubectl get podvolumebackups` decodes thousands
+# of objects and OOM-kills the 64Mi healer pod before it does any work. The list
+# must be narrowed to the backups that are actually running.
+BACKUP_ROWS='velero-daily-full-20260811030048   Completed
+velero-daily-b2-20260811040048     InProgress
+velero-monthly-b2-20260801060032   PartiallyFailed
+velero-daily-full-20260810030041   Failed
+bad-backup                         FailedValidation
+old-backup                         Deleting
+fresh-backup                       <none>
+weird-backup                       SomePhaseFromTheFuture'
+
+# Echoes the label selector back so the assertions also prove pvb_rows really
+# passes -l velero.io/backup-name=<name> rather than listing everything.
+kc() {
+  case "$*" in
+    "get backups.velero.io"*) echo "$BACKUP_ROWS" ;;
+    "get podvolumebackups.velero.io"*)
+      for a in "$@"; do
+        case "$a" in
+          velero.io/backup-name=*)
+            printf 'pvb@%s   Prepared   k8sworker03   2026-08-11T02:40:00Z\n' "${a#*=}" ;;
+        esac
+      done ;;
+  esac
+}
+
+assert_eq "$(active_backups)" 'velero-daily-b2-20260811040048
+fresh-backup
+weird-backup' "active_backups keeps running backups and drops the terminal ones"
+
+assert_eq "$(pvb_rows)" 'pvb@velero-daily-b2-20260811040048   Prepared   k8sworker03   2026-08-11T02:40:00Z
+pvb@fresh-backup   Prepared   k8sworker03   2026-08-11T02:40:00Z
+pvb@weird-backup   Prepared   k8sworker03   2026-08-11T02:40:00Z' "pvb_rows lists per active backup via the backup-name label"
+
+# Nothing running -> no PVB list is issued at all.
+BACKUP_ROWS='velero-daily-full-20260811030048   Completed'
+assert_eq "$(active_backups)" "" "active_backups is empty when every backup is terminal"
+assert_eq "$(pvb_rows)" "" "pvb_rows issues no PVB query when no backup is running"
+
 # --- find_and_heal_one: stub the clock, the row source and the action ---
 # 2026-08-11T03:02:59Z. Fixtures are dated relative to it:
 #   02:40:00Z -> 1379s old (stalled, > STALL_SECONDS=900)

--- a/clusters/vollminlab-cluster/velero/velero-pvb-healer/app/rbac.yaml
+++ b/clusters/vollminlab-cluster/velero/velero-pvb-healer/app/rbac.yaml
@@ -26,6 +26,12 @@ rules:
     # looping on a PVB that is stuck for some reason a node-agent restart
     # cannot fix.
     verbs: ["get", "list", "patch"]
+  - apiGroups: ["velero.io"]
+    resources: ["backups"]
+    # Read-only. Used to narrow the podvolumebackups list to the backups that are
+    # still running -- an unscoped PVB list is thousands of objects and OOM-kills
+    # the healer pod before it does any work.
+    verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["pods"]
     # delete is scoped by the -l name=node-agent selector in the script; RBAC


### PR DESCRIPTION
## The problem

The PVB healer merged in #1054/#1055 **has never completed a single run.** Every pod dies with exit 137 / OOMKilled immediately after logging its start line, so the stall protection those PRs were supposed to add is not actually in place.

`pvb_rows()` listed every `PodVolumeBackup` in the namespace. PVBs are retained for their backup's TTL — 2160h on the B2 schedules — so that list is currently **7,177 objects**. kubectl's decode alone exceeds the 64Mi container limit before the script does any work.

## The fix

Scope the list rather than raise the limit:

1. `active_backups()` — list `Backups` and keep the ones not in a terminal phase.
2. `pvb_rows()` — list PVBs per active backup via `-l velero.io/backup-name=<name>`.

**21 objects vs 7,177**, and it stays bounded as the cluster grows — which a bigger memory limit would not.

Only looking at running backups is sufficient: FSB is head-of-line blocked in `backupper.go`, so a stalled PVB is always blocking a backup that is still running. If a backup does hit `itemOperationTimeout` and leaves orphaned `Prepared` PVBs behind, the leaked node-agent datapath slot poisons the *next* backup — whose own `Prepared` PVB the healer catches on that same node.

`active_backups()` filters by **exclusion**, not inclusion. Velero has added Backup phases over time; an unrecognised phase must default to "still running", or the healer would silently stop watching it.

## Also in this PR

- `velero.io/backups` `get,list` added to the Role (read-only, still namespace-scoped).
- Memory limit 64Mi → 128Mi as headroom. This is **not** the fix — but since the healer had never completed a run, there was no evidence 64Mi sufficed even for a response of a handful of objects.

## Tests

27 assertions (4 new), including one that proves `pvb_rows` really passes the label selector rather than listing everything. Passes under both `dash` and `busybox ash` (the container is alpine).

```
sh clusters/vollminlab-cluster/velero/velero-pvb-healer/app/heal_test.sh
```