### PR TITLE
fix(authentik): allow cloudflared egress to ingress-nginx origin

### DIFF
--- a/.claude/rules/networkpolicy.md
+++ b/.claude/rules/networkpolicy.md
@@ -80,6 +80,7 @@ Keep this table current whenever a new NetworkPolicy namespace is added.
 | `authentik` | `server` | 9000 | authentik-server HTTP (homepage widget) | allow-homepage ingress (from homepage) |
 | `authentik` | n/a (ingress target) | 8000 | CNPG instance status API | allow-cnpg-operator ingress |
 | `authentik` | n/a (egress target) | 7844 | Cloudflare tunnel edge (QUIC UDP + http2 TCP) | allow-external-egress egress |
+| `authentik` | n/a (egress target → ingress-nginx) | 80 | cloudflared tunnel **origin** — `ingress-nginx-controller.ingress-nginx.svc:80`; svc 80→targetPort `http`→containerPort 80 | allow-cloudflared-nginx-egress egress (`app: cloudflared-authentik` only) |
 | `harbor` | n/a (ingress target) | 8000 | CNPG instance status API | allow-cnpg-operator ingress |
 | `minio` | `minio` | 9000 | S3 API — reached by the Helm post-upgrade hook pod (`app: minio-job`) to create buckets/users | allow-post-job-egress (from hook) + allow-post-job-ingress (to minio); intra-namespace |
 | `tofu` | n/a (egress target → mediastack) | 7878/8989/8787/9696 | radarr/sonarr/readarr/prowlarr API (arr Terraform providers) | allow-mediastack-arr-egress egress |
@@ -89,6 +90,15 @@ Keep this table current whenever a new NetworkPolicy namespace is added.
 
 Add a row here when writing a new NetworkPolicy with a port restriction. This is the source of
 truth — do not rely on service port numbers.
+
+**A cloudflared tunnel needs two egress rules, not one.** Reaching the Cloudflare edge (7844) and
+reaching the tunnel's *origin* are separate hops, and only the first one fails loudly — the
+Cloudflare dashboard shows the tunnel healthy while every request 502s. In a default-deny namespace
+the origin hop needs its own rule; if the origin is in another namespace (e.g.
+`ingress-nginx-controller.ingress-nginx.svc:80`), it needs a `namespaceSelector`. LAN clients
+mask this completely, because Pi-hole's A-record override sends them straight to the ingress VIP
+and never through the tunnel — so the breakage is visible only from outside. This went unnoticed
+for ~68 days between #875 and its fix.
 
 **The port trap applies to egress too.** A `tofu`-namespace example: the harbor provider dials the
 Harbor VIP on `:443`, but the LoadBalancer remaps `443→8443` and egress policy is evaluated

--- a/clusters/vollminlab-cluster/authentik/networkpolicies/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/authentik/networkpolicies/networkpolicy.yaml
@@ -240,3 +240,44 @@ spec:
     - ports:
         - protocol: TCP
           port: 465
+---
+# Allow cloudflared to reach its tunnel origin. The authentik tunnel routes
+# authentik.vollminlab.com (and the nginx tunnel routes filebrowser) to
+# http://ingress-nginx-controller.ingress-nginx.svc.cluster.local:80, which
+# is a *cross-namespace* hop the default-deny egress policy blocks.
+#
+# Regression history: #641 repointed the tunnel at ingress-nginx:80 while this
+# namespace still had no NetworkPolicies. #875 added default-deny and broke the
+# tunnel outright. #889 restored port 7844 so cloudflared could reach the
+# Cloudflare edge again — but never restored the origin hop, so every external
+# request has terminated in a 502 since then (`dial tcp <nginx-clusterip>:80:
+# i/o timeout` in the cloudflared log). LAN clients never noticed because
+# Pi-hole overrides the A record to the ingress VIP and bypasses the tunnel.
+#
+# Port 80 is correct here: the controller's http containerPort is 80 (svc
+# 80 -> targetPort http -> containerPort 80), verified against the pod. Scoped
+# to the cloudflared pod rather than podSelector: {} so authentik's own pods
+# gain no new egress.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cloudflared-nginx-egress
+  namespace: authentik
+  labels:
+    app: authentik
+    env: production
+    category: security
+spec:
+  podSelector:
+    matchLabels:
+      app: cloudflared-authentik
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 80


### PR DESCRIPTION
## Problem

`authentik.vollminlab.com` returns **502 to every external client**, and has since 2026-06-11.

The authentik tunnel routes to `http://ingress-nginx-controller.ingress-nginx.svc.cluster.local:80`, but the `authentik` namespace is default-deny and its egress allow-list only covers TCP 443, TCP+UDP 7844, TCP 587 and TCP 465. Nothing permits the cross-namespace hop to ingress-nginx on port 80.

```
dial tcp 10.106.87.122:80: i/o timeout      # cloudflared-authentik log
```

Confirmed three ways: the cloudflared log, a direct socket test from an authentik pod (ClusterIP:80 timeout ×3, ClusterIP:443 OK ×3), and a dump of all six egress-bearing policies in the namespace.

## Timeline

| PR | Date | Effect |
|----|------|--------|
| #641 | 2026-05-17 | Tunnel repointed at `ingress-nginx:80` — no NetworkPolicies existed yet, so it worked |
| #875 | 2026-06-04 | Default-deny added → tunnel dead, couldn't even reach the Cloudflare edge |
| #889 | 2026-06-11 | Port 7844 restored → tunnel reconnects to the edge, **origin :80 still blocked** |

Since #889 the Cloudflare dashboard has reported the tunnel healthy while every request 502s. Port 80 egress was never present at any point — `git log -S'port: 80'` returns only a false positive (`port: 8000` in #878).

## Why this went unnoticed for ~68 days

Pi-hole overrides the **A** record for `*.vollminlab.com` to the ingress VIP `192.168.152.244`, so LAN and VPN clients reach nginx directly and never touch the tunnel on IPv4. Only the four tunnel-exposed hosts publish a Cloudflare **AAAA** (authentik, audiobookshelf, jellyfin, filebrowser — grafana/radarr/homepage have none), so an IPv6-capable client prefers AAAA under happy-eyeballs and leaves the network even on the VPN. That is how this surfaced.

Authentik's own event log corroborates the date: over 75 days there were 347 login/authorize events, 335 from private IPs and 12 from a single public IP — and the **last public-IP event is 2026-06-04 03:21 UTC**, the day #875 merged.

## Blast radius

24h origin-error counts: audiobookshelf 0, jellyfin 0, nginx 0, **authentik 14**. External users have no IPv4 fallback. Knock-on: filebrowser external login and audiobookshelf "Login with SSO" both redirect to authentik and 502. Jellyfin local accounts and existing session cookies are unaffected.

## The change

A new `allow-cloudflared-nginx-egress` policy scoped to `app: cloudflared-authentik`, so authentik's own pods gain no new egress:

```yaml
podSelector:
  matchLabels:
    app: cloudflared-authentik
policyTypes: [Egress]
egress:
  - to:
      - namespaceSelector:
          matchLabels:
            kubernetes.io/metadata.name: ingress-nginx
    ports:
      - protocol: TCP
        port: 80
```

Port 80 is the controller's **containerPort** (`svc 80 → targetPort http → containerPort 80`), verified against the pod, not the service YAML — no port trap here.

Also adds the row to the namespace container-port table in `.claude/rules/networkpolicy.md`, plus a short note recording the durable lesson: a cloudflared tunnel needs **two** egress rules (edge *and* origin), and only the edge one fails loudly.

## Not in this PR

Pi-hole AAAA overrides (or NODATA for AAAA) on the four tunnel hosts, so LAN/VPN clients stop hairpinning out through Cloudflare. That is a Pi-hole change, outside this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uXgEor4Qp9wcQUHJ9GkkB