### PR TITLE
feat(monitoring): detect silent data loss on PVCs and filesystem corruption

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - grafana-admin-credentials-externalsecret.yaml
   - prometheusrule-custom.yaml
   - prometheusrule-cnpg.yaml
+  - prometheusrule-data-loss.yaml
   - prometheusrule-eso.yaml
   - prometheusrule-gitops.yaml
   - prometheusrule-victoria-metrics.yaml

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-data-loss.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-data-loss.yaml
@@ -1,0 +1,105 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: vollminlab-data-loss-rules
+  namespace: monitoring
+  labels:
+    app: kube-prometheus-stack
+    env: production
+    category: observability
+    release: kube-prometheus-stack
+spec:
+  groups:
+    # Silent data loss detection.
+    #
+    # On 2026-07-02 an e2fsck on pvc-audiobookshelf-metadata cleared inodes damaged by
+    # ext4 metadata corruption, destroying ~200 cover images. Nothing alerted: Longhorn
+    # reported the volume `healthy` throughout (it compares replicas to each other, not
+    # to a filesystem), VolSync kept backing the volume up successfully, and the loss was
+    # only noticed six weeks later when a human looked at the UI. By then the last good
+    # restic snapshot was one day from falling out of the 7-daily/4-weekly/3-monthly
+    # retention window.
+    #
+    # These two rules catch that class of event. They are deliberately narrow: an alert
+    # that cries wolf gets muted, and a muted alert is worth nothing six weeks later.
+    - name: data-loss
+      rules:
+        # A PVC losing more than half its content in an hour is either a deletion nobody
+        # intended or a filesystem repair that discarded data. Legitimate large deletions
+        # exist on this cluster, so the PVCs that churn by design are excluded by name
+        # rather than by raising the threshold — raising it would also hide real events.
+        #
+        # Excluded, with the reason each one churns:
+        #   storage-loki-0            — compactor retention deletes (720h)
+        #   prometheus-.*             — TSDB block compaction
+        #   server-volume-victoria-.* — VM retention merges
+        #   harbor-registry           — registry garbage collection
+        #   pvc-incomplete-downloads  — download staging, empties on completion
+        #   pvc-completed-downloads   — import moves files out to the media shares
+        #   minio                     — object store, holds the backups themselves
+        #
+        # Validated against 30 days of history (2026-07-13 .. 2026-08-12): with these
+        # exclusions the rule fires zero times. Replayed against the real event window it
+        # fires on mediastack/pvc-audiobookshelf-metadata at 12:30 UTC on 2026-07-02,
+        # 28 minutes after the fsck (210.39 MiB -> 82.39 MiB, a 60.8% drop).
+        #
+        # The 100Mi floor keeps small config volumes from alerting on ordinary rotation,
+        # where a few MiB of movement is a large percentage.
+        - alert: PVCUsageCliff
+          expr: |
+            (
+              kubelet_volume_stats_used_bytes{persistentvolumeclaim!~"storage-loki-0|prometheus-.*|server-volume-victoria-metrics-.*|harbor-registry|pvc-incomplete-downloads|pvc-completed-downloads|minio"}
+              /
+              (kubelet_volume_stats_used_bytes{persistentvolumeclaim!~"storage-loki-0|prometheus-.*|server-volume-victoria-metrics-.*|harbor-registry|pvc-incomplete-downloads|pvc-completed-downloads|minio"} offset 1h)
+            ) < 0.5
+            and
+            (
+              kubelet_volume_stats_used_bytes{persistentvolumeclaim!~"storage-loki-0|prometheus-.*|server-volume-victoria-metrics-.*|harbor-registry|pvc-incomplete-downloads|pvc-completed-downloads|minio"} offset 1h
+            ) > 104857600
+          # Long enough to ride out a single bad scrape, short enough that the alert
+          # arrives while the data is still in every backup. The measured event held the
+          # condition for at least 30 minutes.
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "PVC {{ $labels.persistentvolumeclaim }} in {{ $labels.namespace }} lost over half its data in an hour"
+            description: >-
+              {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} is now at
+              {{ $value | humanizePercentage }} of its usage one hour ago. Nothing on this
+              cluster deletes that much at once by design. Check for a filesystem repair
+              (`dumpe2fs -h` on the Longhorn volume — a recent "Last checked" means fsck
+              ran and discarded data) before the current backups age out the last good
+              copy. Runbook: docs/runbooks/longhorn-ext4-corruption.md
+
+        # The same class of loss seen from the backup side.
+        #
+        # A VolSync restic snapshot that suddenly holds far less than the volume it came
+        # from means the loss already reached the backups. This is the last line of
+        # defence: it fires after the data is gone, but while older snapshots may still
+        # hold a good copy. Deliberately generous (24h, 50%) because VolSync runs daily
+        # and a missed run must not alert on its own.
+        - alert: PVCUsageCliffSustained
+          expr: |
+            (
+              kubelet_volume_stats_used_bytes{persistentvolumeclaim!~"storage-loki-0|prometheus-.*|server-volume-victoria-metrics-.*|harbor-registry|pvc-incomplete-downloads|pvc-completed-downloads|minio"}
+              /
+              (kubelet_volume_stats_used_bytes{persistentvolumeclaim!~"storage-loki-0|prometheus-.*|server-volume-victoria-metrics-.*|harbor-registry|pvc-incomplete-downloads|pvc-completed-downloads|minio"} offset 24h)
+            ) < 0.5
+            and
+            (
+              kubelet_volume_stats_used_bytes{persistentvolumeclaim!~"storage-loki-0|prometheus-.*|server-volume-victoria-metrics-.*|harbor-registry|pvc-incomplete-downloads|pvc-completed-downloads|minio"} offset 24h
+            ) > 104857600
+          # 6h means this only fires once the shrunken state has persisted well past any
+          # transient dip, so it does not simply duplicate PVCUsageCliff above.
+          for: 6h
+          labels:
+            severity: warning
+          annotations:
+            summary: "PVC {{ $labels.persistentvolumeclaim }} in {{ $labels.namespace }} has stayed far below yesterday's size"
+            description: >-
+              {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} has held at
+              {{ $value | humanizePercentage }} of its size 24h ago for six hours. If
+              PVCUsageCliff did not already fire, this loss predates the alert or happened
+              gradually. Check whether the current VolSync snapshot still contains the
+              missing data before retention discards the last good one.

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-data-loss.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-data-loss.yaml
@@ -48,13 +48,19 @@ spec:
         - alert: PVCUsageCliff
           expr: |
             (
-              kubelet_volume_stats_used_bytes{persistentvolumeclaim!~"storage-loki-0|prometheus-.*|server-volume-victoria-metrics-.*|harbor-registry|pvc-incomplete-downloads|pvc-completed-downloads|minio"}
+              kubelet_volume_stats_used_bytes{
+                persistentvolumeclaim!~"storage-loki-0|prometheus-.*|server-volume-victoria-metrics-.*|harbor-registry|pvc-incomplete-downloads|pvc-completed-downloads|minio"
+              }
               /
-              (kubelet_volume_stats_used_bytes{persistentvolumeclaim!~"storage-loki-0|prometheus-.*|server-volume-victoria-metrics-.*|harbor-registry|pvc-incomplete-downloads|pvc-completed-downloads|minio"} offset 1h)
+              kubelet_volume_stats_used_bytes{
+                persistentvolumeclaim!~"storage-loki-0|prometheus-.*|server-volume-victoria-metrics-.*|harbor-registry|pvc-incomplete-downloads|pvc-completed-downloads|minio"
+              } offset 1h
             ) < 0.5
             and
             (
-              kubelet_volume_stats_used_bytes{persistentvolumeclaim!~"storage-loki-0|prometheus-.*|server-volume-victoria-metrics-.*|harbor-registry|pvc-incomplete-downloads|pvc-completed-downloads|minio"} offset 1h
+              kubelet_volume_stats_used_bytes{
+                persistentvolumeclaim!~"storage-loki-0|prometheus-.*|server-volume-victoria-metrics-.*|harbor-registry|pvc-incomplete-downloads|pvc-completed-downloads|minio"
+              } offset 1h
             ) > 104857600
           # Long enough to ride out a single bad scrape, short enough that the alert
           # arrives while the data is still in every backup. The measured event held the
@@ -82,13 +88,19 @@ spec:
         - alert: PVCUsageCliffSustained
           expr: |
             (
-              kubelet_volume_stats_used_bytes{persistentvolumeclaim!~"storage-loki-0|prometheus-.*|server-volume-victoria-metrics-.*|harbor-registry|pvc-incomplete-downloads|pvc-completed-downloads|minio"}
+              kubelet_volume_stats_used_bytes{
+                persistentvolumeclaim!~"storage-loki-0|prometheus-.*|server-volume-victoria-metrics-.*|harbor-registry|pvc-incomplete-downloads|pvc-completed-downloads|minio"
+              }
               /
-              (kubelet_volume_stats_used_bytes{persistentvolumeclaim!~"storage-loki-0|prometheus-.*|server-volume-victoria-metrics-.*|harbor-registry|pvc-incomplete-downloads|pvc-completed-downloads|minio"} offset 24h)
+              kubelet_volume_stats_used_bytes{
+                persistentvolumeclaim!~"storage-loki-0|prometheus-.*|server-volume-victoria-metrics-.*|harbor-registry|pvc-incomplete-downloads|pvc-completed-downloads|minio"
+              } offset 24h
             ) < 0.5
             and
             (
-              kubelet_volume_stats_used_bytes{persistentvolumeclaim!~"storage-loki-0|prometheus-.*|server-volume-victoria-metrics-.*|harbor-registry|pvc-incomplete-downloads|pvc-completed-downloads|minio"} offset 24h
+              kubelet_volume_stats_used_bytes{
+                persistentvolumeclaim!~"storage-loki-0|prometheus-.*|server-volume-victoria-metrics-.*|harbor-registry|pvc-incomplete-downloads|pvc-completed-downloads|minio"
+              } offset 24h
             ) > 104857600
           # 6h means this only fires once the shrunken state has persisted well past any
           # transient dip, so it does not simply duplicate PVCUsageCliff above.

--- a/clusters/vollminlab-cluster/monitoring/loki/app/loki-ruler-rules-configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/loki/app/loki-ruler-rules-configmap.yaml
@@ -29,3 +29,66 @@ data:
             annotations:
               summary: "Homepage widget {{ $labels.widget }} returning persistent HTTP 500 errors"
               description: "{{ $value | humanize }} HTTP 500 errors from {{ $labels.widget }} in the last 10 minutes. A backend service is likely down or unreachable."
+  filesystem-corruption-alerts.yaml: |
+    groups:
+      # Filesystem corruption, caught at the moment an application trips over it.
+      #
+      # This is the earliest signal the ext4 corruption on pvc-audiobookshelf-metadata
+      # ever produced. Audiobookshelf crashed twice reading its own cover directory —
+      # 2026-06-29 with errno -74 (EBADMSG) and 2026-07-01 with errno -117 (EUCLEAN) —
+      # three days before the e2fsck that cleared the damaged inodes and destroyed ~200
+      # covers. Both crashes were in the logs. Nothing was watching them.
+      #
+      # Longhorn cannot supply this signal: it compares replicas to each other, not to a
+      # filesystem, so a volume whose replicas all hold identical corruption still reports
+      # `healthy`. The application hitting EIO on a read is the only thing that knows.
+      - name: filesystem-corruption
+        rules:
+          # Matched against every stream because corruption is not confined to one app,
+          # and there is no way to predict which workload lands on a damaged volume.
+          #
+          # The pattern set is deliberately restricted to errors that mean *the filesystem
+          # metadata is wrong*:
+          #   structure needs cleaning / EUCLEAN / system error -117 — ext4 has marked the
+          #     directory or inode unusable; this is the exact error ABS died on
+          #   EBADMSG / system error -74 — checksum mismatch on a metadata block
+          #
+          # `Input/output error` (EIO) is deliberately NOT in the set. On this cluster EIO
+          # is the signature of a stale Longhorn mount after a node event — common, benign
+          # once the pod restarts, and covered by the longhorn-mount-healer. Including it
+          # would bury the real signal in noise, and a noisy alert gets muted.
+          #
+          # `pod!~"loki-.*"` is not optional — without it this rule alerts on itself
+          # forever. Loki logs the text of every query it serves, once per split/shard, so
+          # each evaluation writes ~1200 lines containing this rule's own regex, which the
+          # next evaluation then matches. Measured directly: 1239 self-matches in 24h from
+          # monitoring/loki-0 during development. Excluding the stream costs nothing —
+          # Loki is not a workload that mounts a Longhorn data volume.
+          #
+          # Validated over the 7 days to 2026-08-12: zero matches on every day except the
+          # one on which these probe queries ran, and that day's only source was loki-0.
+          - alert: FilesystemCorruptionDetected
+            expr: |
+              sum by (namespace, pod) (
+                count_over_time(
+                  {job=~".+", pod!~"loki-.*"}
+                    |~ `(?i)(structure needs cleaning|EUCLEAN|EBADMSG|system error -117|system error -74)`
+                    [1h]
+                )
+              ) > 0
+            # No `for` grace period beyond a single evaluation: these errors do not appear
+            # transiently. One occurrence is worth investigating, and the window between
+            # first error and the fsck that discards data is measured in days, not weeks.
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Filesystem corruption errors from {{ $labels.namespace }}/{{ $labels.pod }}"
+              description: >-
+                {{ $value | humanize }} ext4 metadata errors logged by
+                {{ $labels.namespace }}/{{ $labels.pod }} in the last hour. The volume's
+                replicas are consistent with each other but the filesystem on them is not
+                intact, so Longhorn will keep reporting `healthy`. Do NOT let this volume
+                cold-remount before investigating: the CSI driver runs `fsck -a` on mount,
+                and that repair is what destroys data. Take a VolSync snapshot first.
+                Runbook: docs/runbooks/longhorn-ext4-corruption.md


### PR DESCRIPTION
## Why

On 2026-07-02 an `e2fsck` on `pvc-audiobookshelf-metadata` cleared inodes damaged by ext4 metadata corruption, destroying ~200 cover images. **Nothing alerted.**

- Longhorn reported the volume `healthy` throughout — it compares replicas to each other, not to a filesystem, so identical corruption on every replica reads as consistent.
- VolSync kept backing the volume up successfully, faithfully copying the damage forward.
- The loss was found six weeks later by a human noticing blank covers in the UI, **one day** before the last good restic snapshot (`595c84ff`, 2026-06-30) aged out of the 7-daily/4-weekly/3-monthly retention window.

The covers have since been restored from that snapshot. This PR closes the detection gap that let it go unnoticed.

## What

Two independent detectors, at different layers, both validated against real history rather than picked by intuition.

### `PVCUsageCliff` / `PVCUsageCliffSustained` — Prometheus

`kubelet_volume_stats_used_bytes` halving over 1h (critical) or staying halved for 6h vs. 24h ago (warning).

| Check | Result |
|---|---|
| Replayed against the real event | Fires on `mediastack/pvc-audiobookshelf-metadata` at 12:30 UTC 2026-07-02 — 28 min after the fsck (210.39 MiB → 82.39 MiB, −60.8%) |
| 30 days of history, no exclusions | 21 episodes across 4 PVCs |
| 30 days of history, with exclusions | **zero** |

Seven PVCs that churn by design are excluded **by name** — loki compaction, Prometheus TSDB, VM retention merges, Harbor GC, the two download-staging volumes, and MinIO itself. Excluding by name rather than raising the threshold is deliberate: a higher threshold would also have hidden the real event, which was only a 60.8% drop.

The 100Mi floor keeps small config volumes from alerting on ordinary log rotation, where a few MiB is a large percentage.

### `FilesystemCorruptionDetected` — Loki ruler

ext4 metadata errors at the moment an application trips over them. This is the **earliest signal the incident ever produced**: audiobookshelf crashed on 2026-06-29 with errno −74 (`EBADMSG`) and again on 2026-07-01 with errno −117 (`EUCLEAN`), both on `scandir '/metadata/cache/covers'` — three days before the repair that discarded the data. Both crashes were in the logs and nothing was reading them.

Two deliberate choices worth reviewing:

- **`Input/output error` (EIO) is not in the pattern set.** On this cluster EIO is the signature of a stale Longhorn mount after a node event — common, benign after a pod restart, and already handled by `longhorn-mount-healer`. Including it would bury the real signal, and a noisy critical alert gets muted.
- **`pod!~"loki-.*"` is load-bearing, not tidiness.** Loki logs the text of every query it serves, once per split and shard, so without the exclusion each evaluation writes ~1200 lines containing this rule's own regex and matches them on the next pass — a permanent self-triggering critical → Pushover loop. Measured at **1239 self-matches in 24h** during development; the same query with the exclusion, over the same window and the same 11.4M lines, returns **zero**.

Promtail scrapes pod logs only, not journald, so kernel `EXT4-fs error` lines aren't available — application-level errno is the only catchable form. Loki retention is 720h, so the original June/July crash lines have expired and this rule can't be replayed against the real event the way the Prometheus one can.

## False-positive scan

Seven days to 2026-08-12, one query per day, `sum by (namespace, pod)`:

| Day | Result |
|---|---|
| 2026-08-12 | `monitoring/loki-0` — 1239 (the self-reference above; zero after exclusion) |
| 2026-08-11 → 2026-08-06 | no hits |

Both alerts route `severity: critical` → Pushover priority 1. The Loki ruler is already wired to Alertmanager, so no new infrastructure — `FilesystemCorruptionDetected` is a second key in the existing `loki-ruler-rules` ConfigMap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uXgEor4Qp9wcQUHJ9GkkB
