### PR TITLE
feat(authentik): add rjutkiewicz user with Audiobookshelf access

### DIFF
--- a/terraform/authentik/groups.tf
+++ b/terraform/authentik/groups.tf
@@ -5,7 +5,7 @@ resource "authentik_group" "audiobookshelf_admins" {
 
 resource "authentik_group" "audiobookshelf_users" {
   name  = "Audiobookshelf Users"
-  users = toset([authentik_user.jvollmin.id, authentik_user.gkroner.id, authentik_user.chavelock.id, authentik_user.jkvedaras.id])
+  users = toset([authentik_user.jvollmin.id, authentik_user.gkroner.id, authentik_user.chavelock.id, authentik_user.jkvedaras.id, authentik_user.rjutkiewicz.id])
 }
 
 resource "authentik_group" "filebrowser_users" {

--- a/terraform/authentik/users.tf
+++ b/terraform/authentik/users.tf
@@ -54,3 +54,14 @@ resource "authentik_user" "chavelock" {
     ignore_changes = [password, groups]
   }
 }
+
+resource "authentik_user" "rjutkiewicz" {
+  username  = "rjutkiewicz"
+  name      = "Rickie Jutkiewicz"
+  email     = "ricotheheavy@gmail.com"
+  is_active = true
+
+  lifecycle {
+    ignore_changes = [password, groups]
+  }
+}


### PR DESCRIPTION
## What

Adds `rjutkiewicz` (Rickie Jutkiewicz, ricotheheavy@gmail.com) as an Authentik user and adds them to the **Audiobookshelf Users** group.

## Why

Grants a friend access to Audiobookshelf, mirroring how `jvollmin`, `gkroner`, `chavelock` and `jkvedaras` are already set up.

## How it grants access

`terraform/authentik/scope_mappings.tf` maps group membership to an Audiobookshelf role:

- `Audiobookshelf Admins` → `admin`
- `Audiobookshelf Users` → `user`  ← this PR

Audiobookshelf-only. Not added to `Jellyfin Users` or `FileBrowser Users`.

## Notes

- **No import block.** The existing users in `imports.tf` were adopted from pre-existing Authentik objects; this account is created by tofu, so it must not be imported.
- **Password is unmanaged** (`ignore_changes = [password]`, matching every other user). After apply, the account needs an Authentik recovery link to set its own password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHsWUQGkdiXaBh7tAudBfg