### PR TITLE
feat(authentik): add recovery flow, adopt force-password-reset into tofu

### DIFF
--- a/terraform/authentik/brand.tf
+++ b/terraform/authentik/brand.tf
@@ -1,0 +1,22 @@
+# The default brand. Adopted via import purely so flow_recovery can be set —
+# that field is what makes "Create recovery link" work in the admin UI.
+#
+# READ BEFORE EDITING: every flow_* and branding_* field below is spelled out on
+# purpose. The provider sends the whole object on update, so a field omitted here
+# is written back as null/default. Dropping flow_authentication would leave the
+# instance with no login flow. Values match the live object as of 2026-08-13;
+# the branding_* ones are authentik's own defaults, restated rather than inferred.
+resource "authentik_brand" "default" {
+  domain  = "authentik-default"
+  default = true
+
+  flow_authentication = data.authentik_flow.default_authentication.id
+  flow_invalidation   = data.authentik_flow.default_invalidation.id
+  flow_user_settings  = data.authentik_flow.default_user_settings.id
+  flow_recovery       = authentik_flow.recovery.uuid
+
+  branding_title                   = "authentik"
+  branding_logo                    = "/static/dist/assets/icons/icon_left_brand.svg"
+  branding_favicon                 = "/static/dist/assets/icons/icon.png"
+  branding_default_flow_background = "/static/dist/assets/images/flow_background.jpg"
+}

--- a/terraform/authentik/data.tf
+++ b/terraform/authentik/data.tf
@@ -2,6 +2,21 @@ data "authentik_flow" "default_authorization_implicit" {
   slug = "default-provider-authorization-implicit-consent"
 }
 
+# Referenced by authentik_brand.default. These are authentik built-ins; the brand
+# resource takes flow UUIDs, and omitting any of them on the brand would null it
+# out in-place — which would leave the instance with no login flow.
+data "authentik_flow" "default_authentication" {
+  slug = "default-authentication-flow"
+}
+
+data "authentik_flow" "default_invalidation" {
+  slug = "default-invalidation-flow"
+}
+
+data "authentik_flow" "default_user_settings" {
+  slug = "default-user-settings-flow"
+}
+
 data "authentik_flow" "default_provider_invalidation" {
   slug = "default-provider-invalidation-flow"
 }

--- a/terraform/authentik/flows.tf
+++ b/terraform/authentik/flows.tf
@@ -1,0 +1,66 @@
+# Password-recovery flow.
+#
+# Exists so an admin can generate a one-time recovery link from the Authentik
+# admin UI (Users -> a user -> Create recovery link) and hand it to the person
+# out of band. They set their own password; no temporary password is ever
+# transmitted.
+#
+# Deliberately NOT wired into the login page: the identification stage
+# (default-authentication-identification) has recovery_flow = null, so no
+# "Forgot password?" link is rendered. Self-service recovery would need an email
+# stage, and this instance has no SMTP configured.
+#
+# authentication = require_unauthenticated matches how recovery links are used
+# (opened by a logged-out user). Note the side effect: an admin who is already
+# signed in cannot open the link to test it — use a private window.
+resource "authentik_flow" "recovery" {
+  name           = "recovery-flow"
+  title          = "Reset your password"
+  slug           = "recovery-flow"
+  designation    = "recovery"
+  authentication = "require_unauthenticated"
+}
+
+resource "authentik_flow_stage_binding" "recovery_prompt" {
+  target = authentik_flow.recovery.uuid
+  stage  = authentik_stage_prompt.recovery_password.id
+  order  = 10
+}
+
+resource "authentik_flow_stage_binding" "recovery_write" {
+  target = authentik_flow.recovery.uuid
+  stage  = authentik_stage_user_write.recovery_password.id
+  order  = 20
+}
+
+# --- Existing force-password-reset machinery on the login flow -----------------
+#
+# These two bindings already exist in the live instance and are adopted via
+# import blocks; they are not new. Together with the policies in policies.tf they
+# implement: set a temp password + user.attributes.reset_password = true, and the
+# user is forced to change it at next login.
+#
+# evaluate_on_plan / re_evaluate_policies are pinned to the live values because
+# both differ from the provider defaults, and both matter. The gating policies
+# read request.context["pending_user"], which is not populated at flow-plan time
+# — evaluating on plan would decide the stage's fate before the user has been
+# identified. They must be evaluated when the stage is reached instead.
+resource "authentik_flow_stage_binding" "force_password_reset_prompt" {
+  target                  = data.authentik_flow.default_authentication.id
+  stage                   = authentik_stage_prompt.force_password_reset.id
+  order                   = 25
+  evaluate_on_plan        = false
+  re_evaluate_policies    = true
+  policy_engine_mode      = "any"
+  invalid_response_action = "retry"
+}
+
+resource "authentik_flow_stage_binding" "force_password_reset_write" {
+  target                  = data.authentik_flow.default_authentication.id
+  stage                   = authentik_stage_user_write.force_password_reset.id
+  order                   = 26
+  evaluate_on_plan        = false
+  re_evaluate_policies    = true
+  policy_engine_mode      = "any"
+  invalid_response_action = "retry"
+}

--- a/terraform/authentik/imports.tf
+++ b/terraform/authentik/imports.tf
@@ -24,6 +24,60 @@ import {
   id = "13"
 }
 
+# Brand
+# Adopted so flow_recovery can be managed. See brand.tf before touching this.
+import {
+  to = authentik_brand.default
+  id = "927170f2-2f03-4a38-a93d-7dc78ab2ce61"
+}
+
+# Force-password-reset machinery on default-authentication-flow.
+# Pre-existing live configuration, previously untracked by tofu.
+import {
+  to = authentik_policy_expression.reset_password_check
+  id = "69de4175-d6d4-4ab5-98d5-28a579e2f40b"
+}
+
+import {
+  to = authentik_policy_expression.reset_password_update
+  id = "2155711f-90a7-4df7-94f0-3ee4cbfc75e2"
+}
+
+import {
+  to = authentik_stage_prompt_field.reset_password_banner
+  id = "7d626c05-cca7-4d33-a899-81313c92c0b7"
+}
+
+import {
+  to = authentik_stage_prompt.force_password_reset
+  id = "84da7a0e-72ad-4963-9f75-6e65c7e74bef"
+}
+
+import {
+  to = authentik_stage_user_write.force_password_reset
+  id = "0edaaf79-4b1c-4beb-aa64-95dd687909f2"
+}
+
+import {
+  to = authentik_flow_stage_binding.force_password_reset_prompt
+  id = "853fe153-b1fa-45e5-a21d-53efe39eb529"
+}
+
+import {
+  to = authentik_flow_stage_binding.force_password_reset_write
+  id = "a0386916-df68-4349-b061-bc4aa79c8355"
+}
+
+import {
+  to = authentik_policy_binding.reset_password_check
+  id = "1572a181-c15d-4529-a86e-c0676dc24789"
+}
+
+import {
+  to = authentik_policy_binding.reset_password_update
+  id = "321ade2c-adbc-47c0-8ccd-24761f62c957"
+}
+
 # Groups
 import {
   to = authentik_group.audiobookshelf_admins

--- a/terraform/authentik/locals.tf
+++ b/terraform/authentik/locals.tf
@@ -1,0 +1,25 @@
+locals {
+  # Authentik built-in objects referenced by the password stages below.
+  #
+  # All three are pinned by UUID rather than looked up, for two reasons:
+  #
+  #   1. The provider pinned in versions.tf (goauthentik/authentik 2026.2.1) has
+  #      no data source for either kind. authentik_stage_prompt_field exists as a
+  #      data source only on the provider's main branch, and password policies
+  #      have never had one (authentik_policy_expression covers expression
+  #      policies only, and this is a PasswordPolicy).
+  #   2. All three are shared with authentik's own default-password-change flow.
+  #      Managing them as resources here would mean an edit aimed at our stages
+  #      silently rewrote a built-in flow.
+  #
+  # Captured from the live instance 2026-08-13. If these ever drift, re-read them
+  # with: ak shell -c "from authentik.stages.prompt.models import Prompt; ..."
+  #
+  # The gitleaks:allow markers are required, not cosmetic. These are public
+  # object IDs, but the generic-api-key rule fires on any high-entropy value on a
+  # line whose name contains "password". The same UUIDs already appear throughout
+  # imports.tf without tripping it, because `id = "..."` carries no trigger word.
+  password_policy_id        = "878c9441-9a33-418c-b205-9d3f30101154" # default-password-change-password-policy gitleaks:allow
+  prompt_field_password     = "b27678a9-cc84-43b7-ac17-5de7e809e597" # default-password-change-field-password gitleaks:allow
+  prompt_field_password_rpt = "887b0965-339c-4870-adae-3ed9ffb68135" # default-password-change-field-password-repeat gitleaks:allow
+}

--- a/terraform/authentik/policies.tf
+++ b/terraform/authentik/policies.tf
@@ -1,0 +1,50 @@
+# Forced password reset on next login.
+#
+# Existing live configuration, adopted via import blocks — this is not a new
+# behaviour. The mechanism:
+#
+#   1. an admin sets a temporary password on the user and sets the custom
+#      attribute  reset_password: true
+#   2. at next login, reset-password-check gates the extra prompt stage into the
+#      authentication flow (order 25), forcing a password change
+#   3. reset-password-update gates the user-write stage (order 26) and clears the
+#      attribute, so the prompt appears exactly once
+#
+# Both expressions return False when pending_user is absent, which is why the
+# bindings in flows.tf must evaluate policies at stage time rather than at plan
+# time — see the comment there.
+
+resource "authentik_policy_expression" "reset_password_check" {
+  name       = "reset-password-check"
+  expression = <<-EOT
+    pending_user = request.context.get("pending_user")
+    if pending_user is None:
+        return False
+    return pending_user.attributes.get("reset_password", False) == True
+  EOT
+}
+
+resource "authentik_policy_expression" "reset_password_update" {
+  name       = "reset-password-update"
+  expression = <<-EOT
+    pending_user = request.context.get("pending_user")
+    if pending_user is None:
+        return False
+    if not pending_user.attributes.get("reset_password", False):
+        return False
+    pending_user.attributes["reset_password"] = False
+    return True
+  EOT
+}
+
+resource "authentik_policy_binding" "reset_password_check" {
+  target = authentik_flow_stage_binding.force_password_reset_prompt.id
+  policy = authentik_policy_expression.reset_password_check.id
+  order  = 0
+}
+
+resource "authentik_policy_binding" "reset_password_update" {
+  target = authentik_flow_stage_binding.force_password_reset_write.id
+  policy = authentik_policy_expression.reset_password_update.id
+  order  = 0
+}

--- a/terraform/authentik/stages.tf
+++ b/terraform/authentik/stages.tf
@@ -5,3 +5,55 @@ resource "authentik_stage_user_login" "default_authentication_login" {
   network_binding    = "no_binding"
   geoip_binding      = "no_binding"
 }
+
+# --- Recovery flow stages (new) -----------------------------------------------
+
+# Reuses authentik's built-in password prompt fields rather than declaring its
+# own, so the recovery form and the forced-reset form stay identical.
+resource "authentik_stage_prompt" "recovery_password" {
+  name = "recovery-password-prompt"
+  fields = [
+    local.prompt_field_password,
+    local.prompt_field_password_rpt,
+  ]
+  validation_policies = [local.password_policy_id]
+}
+
+# never_create: a recovery link always carries an existing pending_user. This
+# stage must never be able to bring a new account into existence.
+resource "authentik_stage_user_write" "recovery_password" {
+  name               = "recovery-password-write"
+  user_creation_mode = "never_create"
+  user_type          = "internal"
+}
+
+# --- Force-password-reset stages (existing, adopted via import) ---------------
+
+# The static banner shown above the password fields. Unlike the two password
+# fields this one is ours, not an authentik built-in, so it is managed here.
+resource "authentik_stage_prompt_field" "reset_password_banner" {
+  name          = "reset-password"
+  field_key     = "password-reset-prompt"
+  label         = "Reset Password"
+  type          = "static"
+  required      = false
+  order         = 0
+  placeholder   = "Please reset your password."
+  initial_value = "Please reset your password."
+}
+
+resource "authentik_stage_prompt" "force_password_reset" {
+  name = "force-password-reset-prompt"
+  fields = [
+    authentik_stage_prompt_field.reset_password_banner.id,
+    local.prompt_field_password,
+    local.prompt_field_password_rpt,
+  ]
+  validation_policies = [local.password_policy_id]
+}
+
+resource "authentik_stage_user_write" "force_password_reset" {
+  name               = "force-password-reset-user-write"
+  user_creation_mode = "never_create"
+  user_type          = "internal"
+}


### PR DESCRIPTION
## Two halves of one story: how a user gets their first password

### New — recovery flow

There is currently **no** flow with `designation=recovery` in the live instance and `brand.flow_recovery` is `null`, so the admin UI's "Create recovery link" button cannot work. This adds:

- `authentik_flow.recovery` (`designation=recovery`, `authentication=require_unauthenticated`)
- a prompt stage + user-write stage pair, bound at order 10 / 20
- `brand.flow_recovery` pointed at it

Result: a new user can be handed a one-time link and set their own password — no temporary password is transmitted.

**Not exposed on the login page.** `default-authentication-identification.recovery_flow` is `null`, so no "Forgot password?" link renders. Self-service recovery would need an email stage, and this instance has no SMTP configured (`EMAIL_HOST` is the unconfigured `localhost` default, zero `EmailStage` objects).

### Adopted — force-password-reset

The temp-password + `reset_password` attribute mechanism already exists live and was tracked nowhere. Nine objects imported as-is, no behaviour change:

| Object | Kind |
|---|---|
| `reset-password-check`, `reset-password-update` | ExpressionPolicy |
| 2× policy binding | PolicyBinding |
| `reset-password` (static banner) | Prompt field |
| `force-password-reset-prompt` | PromptStage |
| `force-password-reset-user-write` | UserWriteStage |
| 2× stage binding on `default-authentication-flow` (order 25, 26) | FlowStageBinding |

## Things worth a careful look

**1. `authentik_brand` is the risky resource.** The provider sends the whole object on update, so any field omitted from the config is written back as null. Every `flow_*` and `branding_*` field is spelled out on purpose and matches the live object. Dropping `flow_authentication` would leave the instance with no login flow.

**2. `evaluate_on_plan = false` / `re_evaluate_policies = true`** are pinned on the two imported stage bindings. Both differ from provider defaults, and both matter — the gating policies read `request.context["pending_user"]`, which is not populated at flow-plan time.

**3. Three built-ins referenced by UUID, not managed** (`locals.tf`): the two shared password prompt fields and the password policy. They are shared with authentik's own `default-password-change` flow, so managing them here would let an edit aimed at our stages rewrite a built-in flow. The provider pinned in `versions.tf` (2026.2.1) also ships no data source for either kind — `authentik_stage_prompt_field` exists as a data source only on the provider's `main` branch.

## Verification

`tofu 1.12.5` / provider `2026.2.1`, matching what CI installs:

- `tofu fmt -check -recursive` — clean
- `tofu init -backend=false && tofu validate` — `Success! The configuration is valid.`

Live state was read from the cluster with `ak shell` and every pinned value (UUIDs, `evaluate_on_plan`, `user_creation_mode`, `user_type`, brand fields) transcribed from it rather than inferred.

**Not yet verified: `tofu plan` against real state.** CI does not run one (no credentials), and `authentik-config` has `approvePlan: auto`, so this applies automatically ~10 min after merge with no human seeing the plan. Worth running a pre-merge plan given the brand import — see review comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHsWUQGkdiXaBh7tAudBfg