### PR TITLE
fix(authentik): correct display name spelling to "Ricky Jutkiewicz"

### DIFF
--- a/terraform/authentik/users.tf
+++ b/terraform/authentik/users.tf
@@ -57,7 +57,7 @@ resource "authentik_user" "chavelock" {
 
 resource "authentik_user" "rjutkiewicz" {
   username  = "rjutkiewicz"
-  name      = "Rickie Jutkiewicz"
+  name      = "Ricky Jutkiewicz"
   email     = "ricotheheavy@gmail.com"
   is_active = true
 


### PR DESCRIPTION
## What

One-line change: `authentik_user.rjutkiewicz.name` from `"Rickie Jutkiewicz"` to `"Ricky Jutkiewicz"`.

## Scope

Display name only. `username` (`rjutkiewicz`), `email`, and `Audiobookshelf Users` membership are all untouched — so this changes nothing about access, and the outstanding recovery link stays valid (it is bound to the user pk, not the name).

Audiobookshelf picks the name up from the OIDC `profile` claim, so it refreshes on his next login.

## Verification

`tofu 1.12.5` / provider `2026.2.1`:

- `tofu fmt -check -recursive` — clean
- `tofu init -backend=false && tofu validate` — `Success! The configuration is valid.`
- gitleaks 8.30.1 with the CI config — no leaks

Expected plan: `1 to change`, the single `name` attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHsWUQGkdiXaBh7tAudBfg