### PR TITLE
feat(authentik): add speterson user with Audiobookshelf access

### DIFF
--- a/terraform/authentik/groups.tf
+++ b/terraform/authentik/groups.tf
@@ -5,7 +5,7 @@ resource "authentik_group" "audiobookshelf_admins" {
 
 resource "authentik_group" "audiobookshelf_users" {
   name  = "Audiobookshelf Users"
-  users = toset([authentik_user.jvollmin.id, authentik_user.gkroner.id, authentik_user.chavelock.id, authentik_user.jkvedaras.id, authentik_user.rjutkiewicz.id])
+  users = toset([authentik_user.jvollmin.id, authentik_user.gkroner.id, authentik_user.chavelock.id, authentik_user.jkvedaras.id, authentik_user.rjutkiewicz.id, authentik_user.speterson.id])
 }
 
 resource "authentik_group" "filebrowser_users" {

--- a/terraform/authentik/users.tf
+++ b/terraform/authentik/users.tf
@@ -65,3 +65,14 @@ resource "authentik_user" "rjutkiewicz" {
     ignore_changes = [password, groups]
   }
 }
+
+resource "authentik_user" "speterson" {
+  username  = "speterson"
+  name      = "Shaun Peterson"
+  email     = "Shaun.Steven.Peterson@gmail.com"
+  is_active = true
+
+  lifecycle {
+    ignore_changes = [password, groups]
+  }
+}


### PR DESCRIPTION
## What

Adds `speterson` (Shaun Peterson, Shaun.Steven.Peterson@gmail.com) and adds him to the **Audiobookshelf Users** group.

Same shape as `rjutkiewicz` in #1064 — group membership drives the ABS role via the `Audiobookshelf Policy` scope mapping (`Audiobookshelf Users` → `user`).

## Scope

Audiobookshelf only. Not added to `Jellyfin Users` or `FileBrowser Users`, matching how Ricky was set up. Say so if that's wrong and it's a one-line follow-up.

## No import block this time

Verified against the live instance before writing: no user matches `peterson` by username or email, so tofu creates this one. (#1064 needed an import because that account had already been created by hand.)

## Nothing to pre-create in Audiobookshelf

`authOpenIDAutoRegister = True`, so his ABS account is created on first SSO login as `type=user` with access to all libraries — same as jvollmin, gkroner, jkvedaras and now rjutkiewicz.

## Verification

`tofu 1.12.5` / provider `2026.2.1`:

- `tofu fmt -check -recursive` — clean
- `tofu init -backend=false && tofu validate` — `Success! The configuration is valid.`
- gitleaks 8.30.1 with the CI config — no leaks

Expected plan: 1 user created, 1 group membership updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHsWUQGkdiXaBh7tAudBfg