### PR TITLE
fix(arc): gate runner registration on the dind sidecar being ready

### DIFF
--- a/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/actions-runner-system/arc-runners/app/configmap.yaml
@@ -43,7 +43,33 @@ data:
         containers:
           - name: runner
             image: ghcr.io/actions/actions-runner:2.336.0
-            command: ["/home/runner/run.sh"]
+            # Wait for the dind sidecar before registering with GitHub.
+            #
+            # dockerd needs ~19s to bind :2375 (measured 2026-08-17: container
+            # start 01:45:58, "API listen on [::]:2375" 01:46:17) but run.sh
+            # registers this runner immediately. Inside that window GitHub can
+            # hand it a job using `services:`, which the runner initialises
+            # BEFORE any step executes — so it dies at "Initialize containers"
+            # with "Cannot connect to the Docker daemon at tcp://localhost:2375"
+            # and no workflow-level step can defend against it.
+            #
+            # Pod containers start in parallel and probes cannot order them, so
+            # the gate has to live in this command. Fails open: if dind never
+            # comes up we still register, because a runner that never appears
+            # starves all CI, which is worse than the original race.
+            command:
+              - /bin/bash
+              - -c
+              - |
+                for i in $(seq 1 120); do
+                  if curl -sf --max-time 2 http://localhost:2375/_ping >/dev/null 2>&1; then
+                    echo "runner: docker ready after ${i}s"
+                    exec /home/runner/run.sh
+                  fi
+                  sleep 1
+                done
+                echo "runner: docker not ready after 120s — registering anyway" >&2
+                exec /home/runner/run.sh
             env:
               - name: DOCKER_HOST
                 value: tcp://localhost:2375


### PR DESCRIPTION
## The bug

vollmint's `Go Tests` failed twice last night at `Cannot connect to the Docker daemon at tcp://localhost:2375`, ~6s into "Initialize containers". I assumed a rare flake. It isn't.

**Measured on both live runners:**

```
dind container started   01:45:58
runner first log line    01:45:57      ← already registering
"API listen on [::]:2375" 01:46:17     ← docker usable
```

That is a **19-second window** in which the runner is registered and accepting work while Docker does not exist. With ephemeral runners — one job per pod, pods replaced constantly — *every freshly created runner carries it*. Any job using `services:` (or `container:`) that lands there dies.

`Web Tests` never failed because it never touches Docker. That asymmetry is what made it look random.

## Why it can't be fixed in the workflow

The runner initialises `services:` containers **before the first step runs**. There is no point at which a "wait for docker" step could execute. I checked this before reaching for the workflow.

## Why it can't be fixed with a probe

Pod containers start in parallel, and Kubernetes has no ordering between them — a readiness or startup probe on `dind` does not delay `runner`. An init container can't help either, since dind isn't running during the init phase.

So the gate has to be in the runner's own command.

```yaml
command:
  - /bin/bash
  - -c
  - |
    for i in $(seq 1 120); do
      if curl -sf --max-time 2 http://localhost:2375/_ping >/dev/null 2>&1; then
        echo "runner: docker ready after ${i}s"
        exec /home/runner/run.sh
      fi
      sleep 1
    done
    echo "runner: docker not ready after 120s — registering anyway" >&2
    exec /home/runner/run.sh
```

`curl`, `bash`, and `seq` are all present in `ghcr.io/actions/actions-runner:2.336.0` — verified in a live pod, not assumed.

## Fails open, deliberately

If dind never comes up, the runner registers anyway after 120s. A runner that never appears starves *all* CI across the org — including `github-admin`'s own `Terraform Plan` gate, which would leave no way to revert this by PR. A degraded runner that can still serve Docker-free jobs is strictly better than an absent one.

## Verification

Both paths run inside a live runner container:

```
=== docker UP
runner: docker ready after 1s
    [would exec run.sh]
  elapsed: 0s

=== unreachable port, loop shortened to 3
    [would exec run.sh]
  elapsed: 3s  (fell through and still registers)
runner: docker not ready after 3s — registering anyway
```

Plus: the extracted script passes `bash -n`, the embedded `values.yaml` round-trips through two layers of YAML with the script intact, and `pre-commit run check-flux-helm-values` passes.

## Blast radius

Flux picks up the ConfigMap through `valuesFrom`, upgrades the HelmRelease, and ARC rolls the runner template. Ephemeral runners are replaced continuously anyway, so this is not a disruptive rollout.

Timing changes only — no image, resource, RBAC, or policy changes.

## Why this matters more than it did yesterday

Four repos gained **required** status checks in vollminlab/github-admin#19. While those checks were advisory a dind race was noise; now it blocks merges. No workflow changes are needed anywhere — fixing it here fixes it for every repo and every job that uses a service container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHsWUQGkdiXaBh7tAudBfg