### PR TITLE
docs: draw the traps and cycles in eight runbooks and specs as mermaid diagrams

### DIFF
--- a/docs/runbooks/ci-runner-breakglass.md
+++ b/docs/runbooks/ci-runner-breakglass.md
@@ -6,15 +6,33 @@ How to merge a PR when the self-hosted ARC runners are down.
 
 Every CI job in this repo normally runs on the self-hosted `vollminlab` runner set
 (ARC, `actions-runner-system` namespace). Branch protection makes those jobs
-required checks with `enforce_admins` on, so:
+required checks with `enforce_admins` on. The failure mode is a closed loop:
+dead runners block the checks, the blocked checks block the PR, and that PR is
+the one that would bring the runners back.
 
-- runners die →
-- required checks can never start →
-- the PR that would **fix** the runners can never merge →
-- runners stay dead.
+```mermaid
+flowchart LR
+    subgraph deadlock["The deadlock"]
+        direction TB
+        R["ARC runners down<br/><i>actions-runner-system</i>"] --> C["Required checks never start<br/><i>enforce_admins is on, so admin merge cannot help</i>"]
+        C --> P["The PR that would fix the runners cannot merge"]
+        P --> R
+    end
 
-Admin merge does not help (`enforce_admins` is enabled), and disabling branch
-protection to escape is worse than the outage.
+    C -->|"the only exit, and it comes from outside CI"| BG["gh variable set CI_RUNNER<br/><i>a GitHub API call — nothing about it runs on a runner</i>"]
+    BG --> H["Every job moves to GitHub-hosted runners<br/><i>runs-on falls back to vars.CI_RUNNER</i>"]
+    H --> M["Checks run, the fix PR merges"]
+    M --> F["Runners healthy again"]
+    F --> U["gh variable delete CI_RUNNER<br/><i>then re-run CI on main</i>"]
+
+    H -.->|"what you give up while it is set"| W["Integration Test steps skipped —<br/>no kubeconfig, so no server-side dry-run<br/><i>job still reports success, by design</i>"]
+
+    classDef cut fill:#1f6feb,stroke:#1f6feb,color:#fff
+    class BG cut
+```
+
+Nothing inside the loop breaks it. Admin merge does not help (`enforce_admins`
+is enabled), and disabling branch protection to escape is worse than the outage.
 
 ## The escape hatch
 

--- a/docs/runbooks/etcd-local-nvme-migration.md
+++ b/docs/runbooks/etcd-local-nvme-migration.md
@@ -102,6 +102,27 @@ quorum throughout, so there is no downtime.
 Do the **leader last** (or step it down first) to avoid an extra election mid-move. Identify the
 leader with `IS LEADER = true` in the endpoint status table.
 
+```mermaid
+flowchart TD
+    PRE0["Pre-flight: three CP VMs on three distinct hosts,<br/>etcd DB size, target datastore free space,<br/>a Completed Velero backup as the rollback floor"] --> ORD["Order the members — leader last.<br/><i>k8scp03, then k8scp02, then k8scp01</i>"]
+    ORD --> HEALTH
+
+    HEALTH{"Pre-check: do all three members<br/>report is healthy?"}
+    HEALTH -->|"no"| HOLD["Stop. Quorum is 2 of 3 —<br/>moving now has no margin."]
+    HEALTH -->|"yes"| MOVE["Storage vMotion this VM's disks to<br/>its own host's local NVMe — all VMDKs.<br/><i>VM stays powered on, sub-second stun</i>"]
+
+    MOVE --> GATE{"GATE — both must hold:<br/>three of three is healthy, and<br/>RAFT APPLIED INDEX converged and advancing"}
+    GATE -->|"not yet"| GATE
+    GATE -->|"unhealthy, or latency regressed"| RB["Roll back this VM's disks to the old datastore.<br/>Do not touch the next member."]
+    GATE -->|"converged"| NEXT{"Members remaining?"}
+
+    NEXT -->|"yes — next member"| HEALTH
+    NEXT -->|"no"| POST["Per VM: DRS must-run-on-this-host rule,<br/>HA restart disabled.<br/>Then reclaim the vacated CP datastore."]
+
+    classDef gate fill:#bf8700,stroke:#bf8700,color:#fff
+    class GATE gate
+```
+
 For each CP VM, in order `k8scp03 → k8scp02 → k8scp01` (non-leader members first; adjust to your
 live leader):
 

--- a/docs/runbooks/expose-dmz-service.md
+++ b/docs/runbooks/expose-dmz-service.md
@@ -2,7 +2,20 @@
 
 Use this when you have a new k8s service in the `dmz` namespace that needs to be reachable from the internet via `*.vollminlab.com`.
 
-The full stack is: **Cloudflare → HAProxy DMZ → UDM firewall → k8s NodePort**
+The full stack is: **Cloudflare → HAProxy DMZ → UDM firewall → k8s NodePort**. Each
+step below configures one hop of that path:
+
+```mermaid
+flowchart LR
+    C["Internet client<br/>NAME.vollminlab.com"] --> CF["Cloudflare<br/><i>Step 3 — proxied CNAME<br/>to dynamic.vollminlab.com</i>"]
+    CF --> HA["HAProxy DMZ pair<br/>haproxydmz01 + haproxydmz02<br/><i>Step 1 — acl, use_backend, backend on both<br/>Step 4 — wildcard TLS terminates here</i>"]
+    HA -->|"Step 2b — DMZ_LAN accept"| FW["UDM firewall"]
+    FW --> NP["NodePort on 192.168.152.15 and .16<br/><i>the dmz namespace service</i>"]
+    NP -.->|"Step 2c — LAN_DMZ, established/related<br/>the easy one to forget: without it<br/>the request just hangs"| FW
+    FW -.-> HA
+
+    PG["Step 2a — port firewall group<br/><i>the NodePort number</i>"] -.->|"referenced by both rules"| FW
+```
 
 ---
 

--- a/docs/runbooks/harbor-dockerhub-proxy-cache.md
+++ b/docs/runbooks/harbor-dockerhub-proxy-cache.md
@@ -49,13 +49,26 @@ Two halves, in two repos:
 
 ## How a pull flows
 
-1. A pod references `docker.io/foo/bar:tag` (or `redis:7-alpine`, etc.).
-2. containerd matches `docker.io` in `certs.d` → requests the manifest from
-   `https://harbor.vollminlab.com/v2/dockerhub-proxy/...`.
-3. Harbor checks its cache; on a miss it pulls from Docker Hub (authenticated),
-   caches the layers, and serves them.
-4. Library images map to `dockerhub-proxy/library/<name>`; org images to
-   `dockerhub-proxy/<org>/<name>`.
+```mermaid
+flowchart LR
+    POD["Pod references<br/>docker.io/library/NAME:tag"] --> CTD["containerd on the node<br/><i>config_path = /etc/containerd/certs.d</i>"]
+    CTD -->|"host entry matches docker.io"| HB["Harbor proxy-cache project<br/>dockerhub-proxy"]
+    HB --> Q{"Layers already cached?"}
+    Q -->|"hit"| LOCAL["Served in-cluster —<br/>no Docker Hub request at all"]
+    Q -->|"miss"| DH["Docker Hub<br/><i>authenticated with the read-only PAT,<br/>so the limit is well above anonymous</i>"]
+    DH --> STORE["Harbor caches the layers,<br/>then serves them"]
+    LOCAL --> POD
+    STORE --> POD
+
+    CTD -.->|"fallback — the server = registry-1.docker.io line,<br/>taken only when Harbor is unreachable"| ANON["Docker Hub, anonymous<br/><i>one cluster egress IP against ~100 pulls / 6h —<br/>the 429 storms are back</i>"]
+    ANON -.-> POD
+
+    classDef fallback stroke-dasharray: 4 3
+    class ANON fallback
+```
+
+Path mapping through the proxy: library images map to
+`dockerhub-proxy/library/<name>`; org images to `dockerhub-proxy/<org>/<name>`.
 
 ## Verifying it works
 

--- a/docs/runbooks/kyverno-recovery.md
+++ b/docs/runbooks/kyverno-recovery.md
@@ -1,5 +1,34 @@
 # Kyverno Emergency Recovery
 
+Both recoveries below hinge on an ordering constraint where the intuitive order
+is the broken one: deleting the ClusterPolicy is not what unblocks the webhook
+(the restart is), and reconciling is not what clears a stuck HelmRelease (the
+rollback is).
+
+```mermaid
+flowchart TD
+    S{"Which failure?"}
+    S -->|"every pod op denied by<br/>mutate.kyverno.svc-fail"| K1["Read the broken policy name<br/>out of the denial message"]
+    S -->|"HelmRelease READY=False,<br/>error unchanged after the fix"| H1["helm history RELEASE"]
+
+    K1 --> K2["kubectl delete clusterpolicy BROKEN"]
+    K2 --> K3["kubectl rollout restart<br/>deployment/kyverno-admission-controller"]
+    K2 -.-> NOTE["Deleting the object is not enough —<br/>the compiled rule stays in the webhook's memory"]
+    K3 --> K4["Server-side dry-run a throwaway Deployment"]
+    K4 --> D{"Which webhook denies now?"}
+    D -->|"validate — restrict-default-namespace<br/><i>expected, mutations are flowing</i>"| KOK["Unblocked. Fix the policy in git, PR, merge,<br/>then flux resume kustomization kyverno-policies"]
+    D -->|"mutate.kyverno.svc-fail, still"| K2
+
+    H1 --> H2["helm rollback RELEASE"]
+    H2 --> H3["flux reconcile source helm,<br/>then the HelmRelease"]
+    H3 --> HOK["READY=True, Helm upgrade succeeded"]
+    H1 -.->|"the intuitive order"| TRAP["flux reconcile first:<br/>the failed revision in etcd is replayed<br/>and the stale error looks permanent"]
+    TRAP -.->|"rollback is what clears it"| H2
+
+    classDef trap stroke-dasharray: 4 3
+    class NOTE,TRAP trap
+```
+
 ## Webhook blocking all mutations
 
 Symptom: `admission webhook "mutate.kyverno.svc-fail" denied the request` on every pod/deployment operation.

--- a/docs/runbooks/longhorn-ext4-corruption.md
+++ b/docs/runbooks/longhorn-ext4-corruption.md
@@ -37,6 +37,27 @@ Any of these, especially in combination:
 
 ## Diagnosis — is it the source volume or just a bad clone?
 
+```mermaid
+flowchart TD
+    A["One PVC's VolSync backup is stale for days,<br/>every other backup succeeds"] --> B["Longhorn says robustness=healthy<br/>and the pod has been Running for weeks"]
+    B --> C["Record the exact fsck string —<br/>inode, block, offset"]
+    C --> D["Delete the clone PVC and the stuck mover pod<br/>so VolSync rebuilds a clone from a fresh snapshot"]
+    D --> E{"Does the new clone fail at the<br/>byte-identical inode, block and offset?"}
+
+    E -->|"different error, or it mounts clean"| T["Transient — a one-off torn write.<br/>Stop here. No repair window."]
+    E -->|"identical — two independently taken snapshots<br/>cannot reproduce one defect by chance"| R["Stable on-disk corruption<br/>in the source volume"]
+
+    R --> R1["flux suspend helmrelease<br/><i>or Flux re-scales it out from under you</i>"]
+    R1 --> R2["kubectl scale deploy --replicas=0"]
+    R2 --> R3{"Longhorn volume state = detached?"}
+    R3 -->|"not yet — keep waiting"| R3
+    R3 -->|"detached"| R4["Attach in Maintenance Mode,<br/>then e2fsck -fy /dev/longhorn/PV<br/><i>never against a still-attached volume —<br/>that makes the damage worse</i>"]
+    R4 --> R5["Detach, scale back to 1, flux resume"]
+    R5 --> V{"Does replicationsource lastSyncTime advance?"}
+    V -->|"no — repaired but unproven"| R4
+    V -->|"yes"| DONE["Done. The clone mounting fsck-clean<br/>is the only real confirmation."]
+```
+
 This is the key branch. A single failed clone can be a one-off torn write and is not worth a repair
 window. Corruption in the **source** volume is.
 

--- a/docs/superpowers/specs/1password-eso-design.md
+++ b/docs/superpowers/specs/1password-eso-design.md
@@ -41,21 +41,28 @@ Both `1password` and `external-secrets` are new namespaces following existing cl
 
 ### 3.2 Data Flow
 
-```
-1Password.com (cloud)
-       ↑  HTTPS :443
-1password-connect  (1password ns)
-  ├── credentials.json + ESO token Secret  ← manually bootstrapped during DR
-  └── PVC: 1Gi Longhorn (local cache — serves existing secrets if cloud briefly unreachable)
-       ↑  HTTP :8080 (cluster-internal)
-ClusterSecretStore  (name: onepassword-cluster-store)
-  └── connectTokenSecretRef → namespace: 1password / secret: onepassword-connect-token
-       ↑  resolves ExternalSecret CRs
-ESO operator  (external-secrets ns)
-       ↑
-All app namespaces → ExternalSecret CRs → K8s Secrets → pods
-                                                          ↓
-                                               Reloader detects Secret changes → restarts annotated pods
+```mermaid
+flowchart TD
+    OP["1Password.com<br/><i>Homelab vault — the source of truth</i>"] -->|"HTTPS 443"| CN["1password-connect<br/><i>1password namespace, single replica</i>"]
+    CN --> CACHE["Longhorn PVC, 1Gi<br/><i>local cache</i>"]
+    CACHE -.->|"cloud briefly unreachable:<br/>already-known secrets still resolve"| CN
+    CN -->|"HTTP 8080, cluster-internal"| CSS["ClusterSecretStore<br/>onepassword-cluster-store"]
+    CSS --> ESO["ESO operator<br/><i>external-secrets namespace</i>"]
+    ESO -->|"resolves, every refreshInterval"| ES["ExternalSecret CRs<br/><i>one per app, in the app's own namespace</i>"]
+    ES --> SEC["Kubernetes Secrets<br/><i>creationPolicy: Owner</i>"]
+    SEC --> POD["Pods<br/><i>secretKeyRef / valuesFrom</i>"]
+    SEC --> REL["Reloader"]
+    REL -->|"restarts annotated workloads"| POD
+
+    subgraph manual["Manually bootstrapped — the only non-automated inputs, applied before Flux"]
+        B1["1password-credentials.json"]
+        B2["Connect access token Secret"]
+    end
+    B1 -.->|"Connect cannot start without it"| CN
+    B2 -.->|"connectTokenSecretRef"| CSS
+
+    classDef boot fill:#8250df,stroke:#8250df,color:#fff
+    class B1,B2 boot
 ```
 
 ### 3.3 Why ClusterSecretStore (not per-namespace SecretStore)

--- a/docs/superpowers/specs/storage-crashloop-resiliency-design.md
+++ b/docs/superpowers/specs/storage-crashloop-resiliency-design.md
@@ -33,6 +33,54 @@ the wait.
 On 2026-06-20 this left radarr and sonarr crashlooping for **2+ days** (36–38 restarts each) until a
 human ran the manual scale-0→1 recovery. That manual step is the gap this design closes.
 
+The whole shape — the trap, the one exit, and where the rejected alternative lands instead
+(next section) — as a state machine:
+
+```mermaid
+stateDiagram-v2
+    direction TB
+
+    state "Pod Running" as Running
+    state "Longhorn replica blip" as Blip
+    state "In-pod ext4 mount errored, read-only" as EIO
+    state "Container exits: radarr 134, sonarr 139" as Crash
+    state "CrashLoopBackOff" as CLBO
+
+    [*] --> Running
+    Running --> Blip : node memory or IO pressure
+    Blip --> EIO : data layer fine, Longhorn still reports healthy and attached
+    EIO --> Crash
+    Crash --> CLBO : kubelet restarts the container, never the pod
+    CLBO --> EIO : pod stays scheduled, volume stays attached, stale mount never cleared
+
+    note right of CLBO
+        The trap. No pod delete means no Longhorn detach,
+        so the loop cannot exit from inside.
+    end note
+
+    state "Deployment scaled to 0" as Zero
+    state "Waiting for detach" as Wait
+    state "Scaled back to original replicas" as Up
+
+    CLBO --> Zero : external actor — longhorn-mount-healer or a human
+    Zero --> Wait
+    Wait --> Wait : errored ext4 cannot unmount cleanly, mount reports busy
+    Wait --> Up : volumes.longhorn.io state = detached
+    Up --> Running
+
+    note right of Wait
+        The load-bearing step. Nothing stock performs it:
+        the 6 minute force-detach fires only on an unreachable node.
+    end note
+
+    state "Pod evicted" as Evicted
+    state "ContainerCreating, wedged" as Wedged
+
+    CLBO --> Evicted : rejected path — descheduler RemovePodsHavingTooManyRestarts
+    Evicted --> Wedged : replacement starts at once, no wait for detach
+    Wedged --> Wedged : races the still-attaching volume, re-triggered every cycle
+```
+
 This is **not** a node-specific problem and the fix must not be node-specific. Node memory pressure
 is *a* trigger, but the resiliency requirement is that the cluster heals itself from a stuck pod
 **regardless of which app, which node, or what triggered the stale mount**. The cure must be


### PR DESCRIPTION
Eight docs describe failure modes whose *shape* is the point — a cycle, a trapping state machine, an ordering constraint where the intuitive order is the broken one. Each was flattened into prose, bullets-with-arrows, or ASCII art that lost that shape. This adds a mermaid diagram to each, and removes the artwork the diagram supersedes rather than leaving both.

| Doc | What the diagram carries that the prose didn't |
|---|---|
| `runbooks/ci-runner-breakglass.md` | The deadlock as an actual cycle, with `CI_RUNNER` as the single edge that cuts it — from outside CI, so nothing broken can block it |
| `runbooks/kyverno-recovery.md` | Both ordering constraints, branching on which webhook denies. Delete-without-restart and reconcile-before-rollback are drawn as the dead ends they are |
| `runbooks/longhorn-ext4-corruption.md` | The diagnosis tree, with the byte-identical inode/block/offset test as the load-bearing diamond: identical → real corruption, anything else → stop |
| `runbooks/expose-dmz-service.md` | The external request path with every runbook step labelled onto the hop it configures — including the LAN_DMZ **return** rule, the easy one to forget |
| `specs/storage-crashloop-resiliency-design.md` | The trapping state machine and its one exit, plus the rejected descheduler path landing in a `ContainerCreating` wedge instead of recovery |
| `specs/1password-eso-design.md` | Replaces the §3.2 ASCII art, whose arrows pointed upward against reading order. Marks the two manually-bootstrapped DR inputs as the only non-automated edges |
| `runbooks/harbor-dockerhub-proxy-cache.md` | Cache hit vs. miss, and the direct-to-Docker-Hub fallback edge — the path that brings the 429 storms back when Harbor is down |
| `runbooks/etcd-local-nvme-migration.md` | The quorum-safe rolling loop with the health + RAFT APPLIED INDEX gate drawn as an explicit blocking condition on the loop, leader last |

Docs only — no manifests, no cluster impact.

## Verification

Every block was extracted from the committed markdown and rendered with `@mermaid-js/mermaid-cli`; all 8 of 8 render. Several were also rendered to PNG and inspected for legibility — one diagram was reworked after review because a self-loop label truncated, and another because a dashed warning node read like a flow step.

No version numbers were introduced anywhere, per the repo's convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHsWUQGkdiXaBh7tAudBfg