### PR TITLE
fix(longhorn): disable the chart NetworkPolicies that broke metrics scraping

### DIFF
--- a/clusters/vollminlab-cluster/longhorn-system/longhorn/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn/app/configmap.yaml
@@ -9,6 +9,15 @@ metadata:
     category: storage
 data:
   values.yaml: |
+    # Longhorn 1.12.1 began rendering NetworkPolicies for the manager, webhook,
+    # instance-manager and backing-image components. They allow ingress only from
+    # named Longhorn pods, which silently blocked Prometheus from scraping
+    # longhorn-manager:9500 — 100% of longhorn-backend targets went down and
+    # TargetDown fired minutes after the upgrade. This cluster has never had
+    # NetworkPolicies in longhorn-system; set it explicitly so a future chart
+    # default cannot re-enable them without us choosing to.
+    networkPolicies:
+      enabled: false
     defaultSettings:
       defaultReplicaCount: 3
       defaultDataPath: /var/lib/longhorn


### PR DESCRIPTION
**Regression from #1068 (longhorn 1.12.0 → 1.12.1).** Caught by the post-merge health check.

## What broke

1.12.1 started rendering six NetworkPolicies in `longhorn-system`, Helm-owned by the longhorn release and created at the exact moment of the upgrade (`03:20:32Z`). The `longhorn-manager` policy admits ingress only from named Longhorn pods — `longhorn-manager`, `longhorn-ui`, `longhorn-csi-plugin`, recurring-job — which excludes Prometheus.

`TargetDown` fired minutes later:

> 100% of the longhorn-backend/longhorn-backend targets in longhorn-system namespace are down.

## Verified, not assumed

- Service has **6 healthy endpoints**
- ServiceMonitor selector `app: longhorn-manager` **matches** the Service labels, port name `manager` matches
- The container **does** declare `containerPort: 9500`
- A curl to `longhorn-manager:9500/metrics` from the `monitoring` namespace returns **`000`** — connection blocked

So nothing was misconfigured; the traffic was simply dropped.

## The fix

Set `networkPolicies.enabled: false` explicitly. This cluster has never run NetworkPolicies in `longhorn-system`, so this restores the previous posture rather than inventing one — and being explicit means a future chart default can't switch them back on without us choosing to.

## Why not the stricter option

Keeping the chart policies and adding an `allow-monitoring-scrape` rule for 9500 is the better long-term posture. But it needs every *other* path through `longhorn-system` verified first — admission webhook from the CP hosts, CSI, recovery backend — and this cluster has a history of webhook ingress rules failing silently under Calico IPIP. Restoring known-good now; hardening deliberately is separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uXgEor4Qp9wcQUHJ9GkkB