### PR TITLE
feat(monitoring): back up the cold metrics tier to B2 with vmbackup

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/backup-cronjob.yaml
+++ b/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/backup-cronjob.yaml
@@ -9,7 +9,7 @@ metadata:
     category: observability
 spec:
   # 07:30 UTC — deliberately clear of every velero window (03:00 daily-full,
-  # 04:00 daily-b2, 05:00 victoria-metrics-b2, 06:00 monthly-b2). All worker
+  # 04:00 daily-b2, 05:00 grafana-b2, 06:00 monthly-b2). All worker
   # VMDKs share one datastore and a full FSB pass already drives I/O-stall high;
   # this reads the same spindles, so it does not overlap with them.
   schedule: "30 7 * * *"

--- a/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/backup-cronjob.yaml
+++ b/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/backup-cronjob.yaml
@@ -1,0 +1,80 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: victoria-metrics-lt-backup
+  namespace: monitoring
+  labels:
+    app: victoria-metrics-lt
+    env: production
+    category: observability
+spec:
+  # 07:30 UTC — deliberately clear of every velero window (03:00 daily-full,
+  # 04:00 daily-b2, 05:00 victoria-metrics-b2, 06:00 monthly-b2). All worker
+  # VMDKs share one datastore and a full FSB pass already drives I/O-stall high;
+  # this reads the same spindles, so it does not overlap with them.
+  schedule: "30 7 * * *"
+  timeZone: Etc/UTC
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 3600
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 86400
+      # 2h ceiling. The first run uploads everything (~49 GiB today); every run
+      # after that is incremental against what is already in the bucket, so the
+      # steady state is the day's new parts plus whatever merges rewrote.
+      activeDeadlineSeconds: 7200
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app: victoria-metrics-lt
+            env: production
+            category: observability
+        spec:
+          restartPolicy: Never
+          # No nodeSelector needed: the PVC binds a local PV whose nodeAffinity
+          # already pins scheduling to the node holding the VMDK. Duplicating it
+          # here would be a second place to update if that node ever changes.
+          securityContext:
+            # Matches the victoria-metrics container, which runs as root and owns
+            # /storage as root:root. vmbackup only reads, but it has to be able
+            # to read the snapshot tree VM creates.
+            runAsUser: 0
+            runAsGroup: 0
+          containers:
+            - name: vmbackup
+              # Kept in step with the victoria-metrics image tag by Renovate.
+              image: docker.io/victoriametrics/vmbackup:v1.149.0
+              args:
+                - -storageDataPath=/storage
+                # vmbackup asks VM to hardlink a consistent snapshot, backs that
+                # up, then deletes it. Without these two URLs it would read a
+                # live data directory mid-merge and produce a torn backup.
+                - -snapshot.createURL=http://victoria-metrics-lt-server.monitoring.svc:8428/snapshot/create
+                - -snapshot.deleteURL=http://victoria-metrics-lt-server.monitoring.svc:8428/snapshot/delete
+                - -dst=s3://vollminlab-k8s-backups/victoria-metrics-lt
+                - -customS3Endpoint=https://s3.us-west-000.backblazeb2.com
+                - -loggerFormat=json
+              envFrom:
+                - secretRef:
+                    name: victoria-metrics-lt-b2-credentials
+              volumeMounts:
+                - name: storage
+                  mountPath: /storage
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  cpu: "2"
+                  memory: 1Gi
+          volumes:
+            - name: storage
+              persistentVolumeClaim:
+                # The StatefulSet's volumeClaimTemplate PVC. RWO restricts the
+                # volume to one NODE, not one pod, and the PV's nodeAffinity puts
+                # this pod on that same node — so mounting it alongside the
+                # running VM pod is allowed.
+                claimName: server-volume-victoria-metrics-lt-server-0

--- a/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/configmap.yaml
@@ -32,14 +32,19 @@ data:
           - ReadWriteOnce
         size: 750Gi
 
-      # Keeping this distinct from the hot tier's identity is deliberate: velero's
-      # victoria-metrics-b2 schedule must never sweep this 750Gi cold volume into
-      # a daily FSB pass.
+      # Keeping this distinct from the hot tier's identity is deliberate: no
+      # velero schedule may ever sweep this 750Gi cold volume into a daily FSB
+      # pass. FSB would walk a directory that background merges are actively
+      # rewriting and produce a torn copy; the backup-cronjob.yaml in this
+      # directory is the supported path, because vmbackup snapshots first.
       #
       # NOTE: the app key below does NOT survive — the chart sets its own
       # app=server on the pod, so both tiers end up labelled app=server and this
       # value only ever reaches env/category. The separation still holds, but it
       # holds by accident, via app.kubernetes.io/instance=victoria-metrics-lt.
+      # That same chart behaviour is what silently broke velero's old
+      # victoria-metrics-b2 schedule, which selected a label nothing carried and
+      # backed up zero volumes for its whole life (replaced by grafana-b2, #1078).
       # Do not rely on the app key here for backup scoping.
       #
       # Backup for this tier is TrueNAS ZFS snapshots of the pool_0 dataset (4wk,

--- a/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/configmap.yaml
@@ -32,11 +32,19 @@ data:
           - ReadWriteOnce
         size: 750Gi
 
-      # LOAD-BEARING label: this MUST be victoria-metrics-lt, NOT victoria-metrics.
-      # The velero victoria-metrics-b2 schedule selects app=victoria-metrics; a
-      # matching label would sweep this 750Gi cold volume into a daily B2 backup —
-      # the opposite of intent. Backup here is TrueNAS ZFS snapshots of the pool_0
-      # dataset, not Velero.
+      # Keeping this distinct from the hot tier's identity is deliberate: velero's
+      # victoria-metrics-b2 schedule must never sweep this 750Gi cold volume into
+      # a daily FSB pass.
+      #
+      # NOTE: the app key below does NOT survive — the chart sets its own
+      # app=server on the pod, so both tiers end up labelled app=server and this
+      # value only ever reaches env/category. The separation still holds, but it
+      # holds by accident, via app.kubernetes.io/instance=victoria-metrics-lt.
+      # Do not rely on the app key here for backup scoping.
+      #
+      # Backup for this tier is TrueNAS ZFS snapshots of the pool_0 dataset (4wk,
+      # same pool as the data) PLUS an incremental vmbackup to Backblaze B2 — see
+      # backup-cronjob.yaml. Not velero: FSB would re-walk the whole volume daily.
       podLabels:
         app: victoria-metrics-lt
         env: production

--- a/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - pv.yaml
   - configmap.yaml
   - helmrelease.yaml
+  - victoria-metrics-lt-b2-credentials-externalsecret.yaml
+  - backup-cronjob.yaml

--- a/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/victoria-metrics-lt-b2-credentials-externalsecret.yaml
+++ b/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/victoria-metrics-lt-b2-credentials-externalsecret.yaml
@@ -1,0 +1,32 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: victoria-metrics-lt-b2-credentials
+  namespace: monitoring
+  labels:
+    app: victoria-metrics-lt
+    env: production
+    category: observability
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: onepassword-cluster-store
+    kind: ClusterSecretStore
+  target:
+    name: victoria-metrics-lt-b2-credentials
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # vmbackup reads plain AWS-style env vars, not velero's ini "cloud" file,
+        # so the same 1Password item is rendered into a different shape here.
+        AWS_ACCESS_KEY_ID: "{{ .keyID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .applicationKey }}"
+  dataFrom:
+    # Same B2 application key velero already uses for this bucket. A dedicated
+    # key scoped to the victoria-metrics-lt/ prefix would be tighter, but B2
+    # application keys scope to a bucket rather than a prefix, so a second key
+    # would buy separation of revocation and nothing else. Worth doing if this
+    # ever needs to be revoked independently of velero.
+    - extract:
+        key: "Backblaze B2 - vollminlab-k8s-velero"


### PR DESCRIPTION
## Why

The 750Gi long-term VictoriaMetrics tier has **no copy off the NAS**. Queried TrueNAS directly:

```
replication        0 task(s)
cloudsync          0 task(s)
rsynctask          0 task(s)
pool/snapshottask  1 task(s)   -> pool_0/vm-lt-metrics, keep 4 WEEK
```

`pool_0` is RAIDZ2 across 5 disks, so two can fail. Snapshots cover corruption and accidental deletion. Neither covers losing the appliance — and the snapshots live on the same pool as the data.

## Why vmbackup and not velero

This tier was **deliberately** kept out of velero — the values file says so — because FSB would re-walk the entire volume on every run, and the backup window already drives I/O stall across the shared datastore.

`vmbackup` is the right shape for this data:

- **Incremental by default** — *"Incremental backups are performed if `-dst` points to an already existing backup. In this case only new data is uploaded"*. First run ships ~49 GiB; after that it's the day's new parts plus whatever merges rewrote.
- **Consistent** — `-snapshot.createURL` asks VictoriaMetrics to hardlink a snapshot first, so a merge running underneath can't tear the backup. `-snapshot.deleteURL` cleans it up after.

Scheduled **07:30 UTC**, clear of all four velero windows (03:00, 04:00, 05:00, 06:00).

## What's here

| File | |
|---|---|
| `backup-cronjob.yaml` | Daily `vmbackup` → `s3://vollminlab-k8s-backups/victoria-metrics-lt` |
| `victoria-metrics-lt-b2-credentials-externalsecret.yaml` | The B2 key velero already uses, rendered as `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` |

No NetworkPolicy changes needed — `monitoring` already has `allow-all-egress` (0.0.0.0/0) for B2 and `allow-intra-namespace` for the snapshot API.

No `nodeSelector`: the PVC binds a local PV whose `nodeAffinity` already pins scheduling to the node holding the VMDK. RWO restricts the volume to one **node**, not one pod, so mounting it alongside the running VM pod is allowed.

## A correction to the values file

The comment above `podLabels` claimed `app: victoria-metrics-lt` is load-bearing for keeping this volume out of velero's selector. It isn't — the chart sets its own `app: server` on the pod:

```
victoria-metrics-lt-server-0      app=server, app.kubernetes.io/instance=victoria-metrics-lt
victoria-metrics-single-server-0  app=server, app.kubernetes.io/instance=victoria-metrics
```

Both tiers carry the same `app` label. The separation is real but holds via `app.kubernetes.io/instance`, not the key the comment points at. Corrected in place so nobody relies on it.

## Verification

- All five flags and both credential env vars checked against the [vmbackup docs](https://docs.victoriametrics.com/victoriametrics/vmbackup/), not from memory
- `victoriametrics/vmbackup:v1.149.0` confirmed to exist on Docker Hub and matches the running VM image
- Snapshot API confirmed reachable and unauthenticated: `{"status":"ok","snapshots":[]}`, `snapshotAuthKey is_set=false`
- `kustomize build` passes; image pinned, requests+limits set, `app`/`env`/`category` labels present, no hostPath, not privileged

## Related, deliberately not in this PR

**`velero-victoria-metrics-b2` has never backed up anything.** It selects `app: victoria-metrics`, which matches zero pods. Six consecutive daily backups report `Completed`, 0 errors, 4 items — the HelmRelease CRD, the HelmRelease, the values ConfigMap and the Namespace, all of which are already in Git. Zero PodVolumeBackups.

That schedule was aimed at the **hot** tier, so fixing it means enabling a 60Gi daily FSB pass that has not been running. Given the known I/O-stall behaviour in the backup window, that is your call rather than mine — happy to send it as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHsWUQGkdiXaBh7tAudBfg