### PR TITLE
fix(longhorn): remove the no-op networkPolicies values block

### DIFF
--- a/clusters/vollminlab-cluster/longhorn-system/longhorn/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn/app/configmap.yaml
@@ -9,15 +9,6 @@ metadata:
     category: storage
 data:
   values.yaml: |
-    # Longhorn 1.12.1 began rendering NetworkPolicies for the manager, webhook,
-    # instance-manager and backing-image components. They allow ingress only from
-    # named Longhorn pods, which silently blocked Prometheus from scraping
-    # longhorn-manager:9500 — 100% of longhorn-backend targets went down and
-    # TargetDown fired minutes after the upgrade. This cluster has never had
-    # NetworkPolicies in longhorn-system; set it explicitly so a future chart
-    # default cannot re-enable them without us choosing to.
-    networkPolicies:
-      enabled: false
     defaultSettings:
       defaultReplicaCount: 3
       defaultDataPath: /var/lib/longhorn


### PR DESCRIPTION
Follow-up correcting my own error.

#1074 added `networkPolicies.enabled: false` to stop the chart rendering the policies that blocked Prometheus scraping. **It does not work** — `helm template` emits all six policies with the chart's stock defaults too, so that flag does not gate them.

#1076 fixed the real problem with an additive `allow-monitoring-scrape` policy (verified: scrape returns HTTP 200, TargetDown cleared). Its description claimed this values block had been reverted. It had not.

Left in place it is dead config carrying a comment that asserts something untrue — exactly the kind of trap #1071 just cleaned up. The working fix stays in `networkpolicy.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uXgEor4Qp9wcQUHJ9GkkB