### PR TITLE
fix(velero): replace the no-op victoria-metrics-b2 schedule with grafana-b2

### DIFF
--- a/.claude/rules/velero.md
+++ b/.claude/rules/velero.md
@@ -7,7 +7,7 @@
   |---|---|---|---|
   | `velero-daily-full` | `0 3 * * *` | MinIO | 96h |
   | `velero-daily-b2` | `0 4 * * *` | Backblaze B2 | 2160h |
-  | `velero-victoria-metrics-b2` | `0 5 * * *` | Backblaze B2 | 2160h |
+  | `velero-grafana-b2` | `0 5 * * *` | Backblaze B2 | 2160h |
   | `velero-monthly-b2` | `0 6 1 * *` | Backblaze B2 | 8760h |
 
   Schedules run **serially** — a backup created while another is running goes to
@@ -17,7 +17,54 @@
   `monitoring`, `tofu`, `trivy-system`, `velero`
 - **Resource policy:** `velero-skip-smb-policy` — skips `smb` StorageClass volumes (NAS
   shares) **and all `emptyDir` volumes**. Applied to `daily-full`, `daily-b2` and
-  `monthly-b2`; `victoria-metrics-b2` has none. Name is historical, scope is wider.
+  `monthly-b2`; `grafana-b2` has none. Name is historical, scope is wider.
+
+## A Velero backup that matches nothing still reports Completed
+
+`velero-victoria-metrics-b2` selected `app: victoria-metrics`, which no pod or PVC in
+`monitoring` has ever carried — the chart forces `app: server`. It matched zero volumes
+for its entire life and reported `Completed`, `0 errors`, `4 items` every single night.
+Nothing alerts on this: phase is the only signal Velero exposes, and an empty backup is a
+successful one. `velero_backup_items_total` reads 0 for every schedule here, so it cannot
+be used as a content guard either.
+
+**So: for any schedule with a `labelSelector`, the selector is only verified by checking
+that a PodVolumeBackup was actually created.**
+
+```bash
+kubectl get podvolumebackups.velero.io -n velero \
+  -l velero.io/backup-name=<backup-name> --no-headers | wc -l   # 0 means it backed up nothing
+```
+
+**A selector must match a label carried by both the pod and the PVC.** The pod alone gets
+you a PVB (the data), the PVC alone gets you the object needed to restore into. Matching
+only the pod silently produces an unrestorable backup. `app.kubernetes.io/name` is usually
+on both; the hand-applied `app` label is usually pod-only. Verify, don't assume:
+
+```bash
+kubectl get pvc -n <ns> <pvc> -o jsonpath='{.metadata.labels}' | python3 -m json.tool
+```
+
+## The monitoring namespace is deliberately mostly unbacked
+
+`monitoring` is in `excludedNamespaces` on `daily-full`, `daily-b2` and `monthly-b2`.
+That is correct — the metrics are the bulk of it and Velero is the wrong tool:
+
+- **victoria-metrics-lt** (cold, 395d, 750Gi) is backed up by its own `vmbackup` CronJob
+  to `s3://vollminlab-k8s-backups/victoria-metrics-lt`. vmbackup asks VictoriaMetrics for
+  a real snapshot first; FSB would walk a directory that background merges are actively
+  rewriting and produce a torn copy.
+- **victoria-metrics (hot, 30d)** is intentionally **not** backed up. Prometheus
+  remote-writes the same stream to both tiers (measured 7d: 10.915B samples each, 0
+  dropped, 0 failed), so the hot tier is an exact subset of the cold tier.
+- **prometheus** (24h retention) is a scrape buffer — both tiers hold the same data longer.
+- **grafana** IS backed up (`grafana-b2`), because grafana.db holds UI-created dashboards,
+  users and API keys that exist nowhere else. The 35 sidecar dashboards are
+  ConfigMap-provisioned and reproducible from git; grafana.db is not.
+
+Before excluding a namespace, ask which of its PVCs hold state that is not reproducible
+from git and not already stored elsewhere. Here that was exactly one, and it was the one
+thing the broken schedule wasn't covering.
 - **Node-agents:** DaemonSet with DMZ toleration; 9 pods (6 workers + 3 CPs)
 - **`loadConcurrency` is pinned at the default 1 per node — do not raise it.** All worker
   VMDKs share one datastore; a full FSB pass already drives PSI full I/O-stall to 26-48%

--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -272,7 +272,31 @@ data:
                 operator: NotIn
                 values:
                   - volsync
-      victoria-metrics-b2:
+      # Replaces the former `victoria-metrics-b2` schedule, which selected
+      # `app: victoria-metrics` — a label no pod or PVC in this namespace has
+      # ever carried (the chart forces `app: server`). It matched zero volumes
+      # and reported Completed / 0 errors / 4 items every night, so the failure
+      # was invisible: a Velero backup that captures nothing still succeeds.
+      #
+      # It is not re-pointed at victoria-metrics, because that data does not
+      # need Velero:
+      #   * Prometheus remote-writes the SAME stream to both tiers. Measured
+      #     over 7d: 10.915B samples to each, 0 dropped, 0 failed. The hot
+      #     tier's 30d is an exact subset of the cold tier's 395d.
+      #   * The cold tier is backed up to this same bucket by vmbackup, which
+      #     takes a real VictoriaMetrics snapshot. FSB cannot — it walks a
+      #     directory that background merges are rewriting, so it would produce
+      #     a torn copy even when it "succeeds".
+      #   * Pointing it at the hot tier would add ~41 GiB of nightly FSB reads
+      #     to the shared worker datastore, in the window that already drives
+      #     PSI full I/O-stall to 26-48%, to protect redundant data.
+      #
+      # Grafana is what actually needed a backup here. `monitoring` is in
+      # excludedNamespaces on all three other schedules, so its 1 GiB sqlite DB
+      # — UI-created dashboards, users, API keys, starred/prefs — was covered
+      # by nothing. The 35 sidecar dashboards are ConfigMap-provisioned and
+      # reproducible; grafana.db is not.
+      grafana-b2:
         disabled: false
         schedule: "0 5 * * *"
         useOwnerReferencesInBackup: false
@@ -285,6 +309,13 @@ data:
             parallelFilesUpload: 2
           includedNamespaces:
             - monitoring
+          # Must be a label carried by BOTH the pod and the PVC. The pod also
+          # has `app: grafana`, but the chart does not put that on the PVC — so
+          # selecting on it would back up the volume's contents while silently
+          # dropping the PVC object needed to restore them. That asymmetry is
+          # the same shape as the bug this schedule replaces; verify with
+          # `kubectl get pvc -n monitoring <name> -o jsonpath='{.metadata.labels}'`
+          # before changing it.
           labelSelector:
             matchLabels:
-              app: victoria-metrics
+              app.kubernetes.io/name: grafana


### PR DESCRIPTION
## What

`velero-victoria-metrics-b2` selected `app: victoria-metrics` — a label **no pod or PVC in `monitoring` has ever carried** (the chart forces `app: server`). It has matched zero volumes for its entire life while reporting `Completed / 0 errors / 4 items` every night.

```
velero-victoria-metrics-b2-20260813050051   Completed   4   <none>
velero-victoria-metrics-b2-20260814050052   Completed   4   <none>
velero-victoria-metrics-b2-20260815050031   Completed   4   <none>
velero-victoria-metrics-b2-20260816050032   Completed   4   <none>
```

An empty Velero backup is a *successful* backup, and `velero_backup_items_total` reads 0 for every schedule here — so there was no signal to alert on.

## Why not just fix the selector

The obvious fix — repoint it at the hot tier — is the wrong one:

- **The data is redundant.** Prometheus remote-writes the same stream to both tiers. Measured over 7d: **10.915B samples to each, 0 dropped, 0 failed**. Hot (30d) is an exact subset of cold (395d).
- **The cold tier is already covered**, by vmbackup to this same bucket, using a real VictoriaMetrics snapshot. FSB can't do that — it walks a directory background merges are actively rewriting, so it yields a torn copy even when it "succeeds".
- **It would cost ~41 GiB of nightly FSB reads** on the shared worker datastore, in the window that already drives PSI full I/O-stall to 26–48%.

## What actually needed a backup

`monitoring` is in `excludedNamespaces` on all three other schedules, so **grafana.db was covered by nothing** — UI-created dashboards, users, API keys. 1 GiB, and genuinely unreproducible (the 35 sidecar dashboards are ConfigMap-provisioned and already in git).

The selector is `app.kubernetes.io/name: grafana`, verified present on **both** pod and PVC:

```
pod/kube-prometheus-stack-grafana-64b8f7fc55-z64cr
pvc/kube-prometheus-stack-grafana
deploy/kube-prometheus-stack-grafana
svc/kube-prometheus-stack-grafana
```

The pod also has `app: grafana`, but the chart omits it on the PVC — selecting on that would back up the volume's contents while dropping the PVC object needed to restore them. Same shape as the bug being fixed.

## Also

`.claude/rules/velero.md` gains three things it was missing: why a matching-nothing backup reports success, how to verify a selector (count the PVBs — `kubectl get podvolumebackups -l velero.io/backup-name=<name>`), and why `monitoring` is deliberately mostly unbacked.

Old backups keep their own TTL and age out; deleting a Schedule does not delete Backups.