### PR TITLE
feat(velero): alert when a backup schedule captures nothing or stops running

### DIFF
--- a/clusters/vollminlab-cluster/velero/kustomization.yaml
+++ b/clusters/vollminlab-cluster/velero/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - velero/app
+  - velero-backup-content-guard/app
   - velero-pvb-healer/app

--- a/clusters/vollminlab-cluster/velero/velero-backup-content-guard/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/velero/velero-backup-content-guard/app/cronjob.yaml
@@ -1,0 +1,95 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: velero-backup-content-guard
+  namespace: velero
+  labels:
+    app: velero-backup-content-guard
+    env: production
+    category: storage
+spec:
+  # 09:00 UTC — after every backup window (03:00 daily-full, 04:00 daily-b2,
+  # 05:00 grafana-b2, 06:00 monthly-b2) and after the 07:30 vmbackup CronJob,
+  # with slack for a queue drain. Schedules run serially and itemOperationTimeout
+  # is 4h, so a 03:00 run can still be going at 07:00; 09:00 clears that.
+  #
+  # Daily is the right cadence: this checks yesterday's outcome, not live state,
+  # and a backup that captured nothing stays wrong until someone fixes it.
+  schedule: "0 9 * * *"
+  timeZone: Etc/UTC
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 3600
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 86400
+      # backoffLimit 0, unlike velero-pvb-healer's 2. The healer never self-fails,
+      # so a failed pod there means external disruption and retrying is right.
+      # This script fails *on purpose* to raise KubeJobFailed — retrying would
+      # just re-observe the same broken schedule and delay the alert.
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: velero-backup-content-guard
+            env: production
+            category: storage
+        spec:
+          serviceAccountName: velero-backup-content-guard
+          restartPolicy: Never
+          containers:
+            - name: velero-backup-content-guard
+              image: docker.io/alpine/kubectl:1.33.4
+              command: ["/bin/sh", "/scripts/guard.sh"]
+              env:
+                - name: VELERO_NAMESPACE
+                  value: "velero"
+                # One missed daily run plus slack for a long serial queue drain.
+                # Matches the CronJobNotSucceededRecently threshold so the two
+                # guards agree on what "stopped running" means.
+                - name: MAX_AGE_HOURS
+                  value: "26"
+                # 768h = 32 days: one monthly run plus slack. A monthly schedule
+                # cannot satisfy the 26h default.
+                - name: MAX_AGE_OVERRIDES
+                  value: "velero-monthly-b2:768"
+                # Empty: every schedule here sets defaultVolumesToFsBackup: true,
+                # so every one is expected to produce PodVolumeBackups. Add a
+                # schedule name here only if it deliberately captures Kubernetes
+                # objects and no volume data.
+                - name: SKIP_VOLUME_CHECK
+                  value: ""
+                - name: DRY_RUN
+                  value: "false"
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 48Mi
+                limits:
+                  cpu: 200m
+                  # Same 128Mi as velero-pvb-healer after #1056. Every list this
+                  # makes is label-scoped — schedules (4), one backup, and one
+                  # backup's PVBs — so it never decodes the ~7,000-object
+                  # unscoped PVB set that OOM-killed the healer at 64Mi.
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+          volumes:
+            - name: script
+              configMap:
+                name: velero-backup-content-guard-script
+            # readOnlyRootFilesystem is on, and the script writes its schedule
+            # list to $TMPDIR. Reading that list from a file rather than a pipe
+            # is deliberate — see the comment in guard.sh main().
+            - name: tmp
+              emptyDir: {}

--- a/clusters/vollminlab-cluster/velero/velero-backup-content-guard/app/guard.sh
+++ b/clusters/vollminlab-cluster/velero/velero-backup-content-guard/app/guard.sh
@@ -1,0 +1,309 @@
+#!/bin/sh
+# velero-backup-content-guard: fail loudly when a Velero schedule stops backing
+# up anything, or stops running at all.
+#
+# Why this exists
+# ---------------
+# On 2026-08-17 `velero-victoria-metrics-b2` was found to have backed up zero
+# volumes for its entire life. Its labelSelector was `app: victoria-metrics`, a
+# label no pod or PVC in the monitoring namespace has ever carried -- the
+# victoria-metrics-single chart forces `app: server`. Every night it reported:
+#
+#   velero-victoria-metrics-b2-20260816050032   Completed   4 items   0 errors
+#
+# Nothing alerted, and nothing could have: **an empty Velero backup is a
+# successful Velero backup**. Phase is the only health signal Velero exposes,
+# and it was green. `velero_backup_items_total` is exported but reads 0 for
+# every schedule on this cluster, so it cannot serve as a content guard either.
+#
+# CronJobs on this cluster are covered by CronJobNotSucceededRecently (26h) and
+# KubeJobFailed. Velero schedules had no equivalent for either failure mode --
+# not "produced nothing", and not "stopped running". This closes both.
+#
+# How it reports
+# --------------
+# The script exits non-zero when any check fails, so the Job fails, so the
+# existing KubeJobFailed alert fires. That is deliberate: it reuses an alerting
+# path already proven on this cluster rather than adding a metrics exporter and
+# bespoke PromQL that would itself need a guard. A Kubernetes Event is also
+# emitted per finding, so `kubectl get events -n velero` explains a red job
+# without needing the pod log.
+set -u
+
+# --- tunables (overridable via env in the CronJob) ---
+VELERO_NAMESPACE="${VELERO_NAMESPACE:-velero}"
+
+# Hours a schedule may go without producing a backup before it is considered
+# stale. 26h matches CronJobNotSucceededRecently: one missed daily run plus
+# slack for a long queue drain (schedules run serially here, and
+# itemOperationTimeout is 4h).
+MAX_AGE_HOURS="${MAX_AGE_HOURS:-26}"
+
+# Per-schedule staleness overrides, space-separated `name:hours`. Monthly
+# schedules obviously cannot satisfy a 26h bound. 768h = 32 days, which is one
+# monthly run plus slack.
+#
+# This lives here rather than as an annotation on the Schedule because the
+# velero chart generates Schedule objects from its values and its support for
+# arbitrary per-schedule metadata varies by chart version -- an env map is one
+# place to look and cannot silently stop being applied.
+MAX_AGE_OVERRIDES="${MAX_AGE_OVERRIDES:-velero-monthly-b2:768}"
+
+# Schedules exempt from the "must have backed up at least one volume" check --
+# space-separated names. A schedule that legitimately captures only Kubernetes
+# objects and no PVC data belongs here. Empty by default: every schedule on this
+# cluster sets defaultVolumesToFsBackup: true, so every one of them is expected
+# to produce PodVolumeBackups.
+SKIP_VOLUME_CHECK="${SKIP_VOLUME_CHECK:-}"
+
+DRY_RUN="${DRY_RUN:-false}"
+
+# Single kubectl entry point so tests can stub it.
+kc() { kubectl "$@"; }
+
+log() { echo "[$(date -u +%FT%TZ)] $*"; }
+
+# strip_zero: echo a numeric field without its leading zero. "08" is an invalid
+# octal literal in ash/dash arithmetic, so every parsed field goes through this.
+strip_zero() {
+  v="${1#0}"
+  [ -n "$v" ] || v=0
+  echo "$v"
+}
+
+# rfc3339_to_epoch: convert 2026-08-11T03:02:59Z to unix seconds via the
+# days-from-civil algorithm. Kubernetes timestamps are always UTC, but busybox
+# `date` and GNU `date` disagree on how to parse this format (-D vs -d), so the
+# arithmetic is done here to keep the script portable and unit-testable.
+# $1=timestamp. Returns 1 on anything that is not an RFC3339 UTC stamp.
+rfc3339_to_epoch() {
+  ts="$1"
+  case "$ts" in *T*Z) ;; *) return 1 ;; esac
+  y=$(strip_zero "${ts%%-*}");    rest="${ts#*-}"
+  mo=$(strip_zero "${rest%%-*}"); rest="${rest#*-}"
+  d=$(strip_zero "${rest%%T*}");  rest="${rest#*T}"
+  h=$(strip_zero "${rest%%:*}");  rest="${rest#*:}"
+  mi=$(strip_zero "${rest%%:*}"); rest="${rest#*:}"
+  s=$(strip_zero "${rest%%[.Z]*}")
+
+  [ "$mo" -le 2 ] && y=$((y - 1))
+  era=$((y / 400))
+  yoe=$((y - era * 400))
+  if [ "$mo" -gt 2 ]; then mp=$((mo - 3)); else mp=$((mo + 9)); fi
+  doy=$(((153 * mp + 2) / 5 + d - 1))
+  doe=$((yoe * 365 + yoe / 4 - yoe / 100 + doy))
+  days=$((era * 146097 + doe - 719468))
+  echo $((days * 86400 + h * 3600 + mi * 60 + s))
+}
+
+# in_list: exit 0 if $1 appears as a whitespace-separated word in $2.
+# Word-boundary matched, so "velero-daily" does not match "velero-daily-b2".
+in_list() {
+  needle="$1"; hay="$2"
+  for w in $hay; do
+    [ "$w" = "$needle" ] && return 0
+  done
+  return 1
+}
+
+# max_age_for: hours this schedule may go without a backup. $1=schedule name.
+# Falls back to MAX_AGE_HOURS when the name has no override entry.
+max_age_for() {
+  name="$1"
+  for pair in $MAX_AGE_OVERRIDES; do
+    case "$pair" in
+      "$name":*) echo "${pair#*:}"; return 0 ;;
+    esac
+  done
+  echo "$MAX_AGE_HOURS"
+}
+
+# schedule_rows: one line per Schedule -- "name lastBackup paused".
+# `<none>` is what kubectl prints for an absent field; callers must handle it.
+schedule_rows() {
+  kc get schedules.velero.io -n "$VELERO_NAMESPACE" --no-headers \
+    -o custom-columns='NAME:.metadata.name,LAST:.status.lastBackup,PAUSED:.spec.paused' 2>/dev/null
+}
+
+# newest_backup: name of the most recent Backup produced by a schedule, or
+# empty. Scoped by the velero.io/schedule-name label and sorted by creation
+# time; `-o jsonpath={.items[-1:]...}` takes the last, i.e. newest.
+newest_backup() {
+  kc get backups.velero.io -n "$VELERO_NAMESPACE" \
+    -l "velero.io/schedule-name=$1" --sort-by=.metadata.creationTimestamp \
+    -o jsonpath='{.items[-1:].metadata.name}' 2>/dev/null
+}
+
+# backup_phase: phase of a Backup, or empty if it has none yet.
+backup_phase() {
+  kc get backups.velero.io -n "$VELERO_NAMESPACE" "$1" \
+    -o jsonpath='{.status.phase}' 2>/dev/null
+}
+
+# pvb_count: how many PodVolumeBackups a Backup produced.
+#
+# Scoped by the velero.io/backup-name label, never listed unscoped. PVBs are
+# retained for their backup's whole TTL (2160h on the B2 schedules), so an
+# unscoped list is thousands of objects -- that is what OOM-killed the sibling
+# velero-pvb-healer on every run until #1056. Scoping bounds this at one
+# backup's PVB count permanently.
+pvb_count() {
+  kc get podvolumebackups.velero.io -n "$VELERO_NAMESPACE" \
+    -l "velero.io/backup-name=$1" --no-headers 2>/dev/null | grep -c . || true
+}
+
+# emit_event: best-effort Warning Event so a red job is explainable from
+# `kubectl get events` alone. Never fails the run -- the exit code is the
+# primary signal and must not depend on the events API being writable.
+emit_event() {
+  reason="$1"; msg="$2"
+  [ "$DRY_RUN" = "true" ] && return 0
+  kc create -n "$VELERO_NAMESPACE" -f - >/dev/null 2>&1 <<EOF || log "  (event emit failed, continuing)"
+apiVersion: v1
+kind: Event
+metadata:
+  generateName: velero-backup-content-guard-
+  namespace: $VELERO_NAMESPACE
+type: Warning
+reason: $reason
+message: "$msg"
+involvedObject:
+  apiVersion: v1
+  kind: Namespace
+  name: $VELERO_NAMESPACE
+source:
+  component: velero-backup-content-guard
+EOF
+}
+
+main() {
+  now=$(date -u +%s)
+  failures=0
+  checked=0
+
+  # Rows go to a file, and the loop below reads from that file with `< "$tmp"`.
+  # It must NOT be `schedule_rows | while read ...`: a piped while runs in a
+  # subshell, so every `failures=$((failures + 1))` inside it would be discarded
+  # on exit and the guard would report success no matter what it found. That is
+  # the same class of silent-success bug this script exists to catch.
+  tmp="${TMPDIR:-/tmp}/velero-guard-rows.$$"
+  schedule_rows > "$tmp"
+
+  if [ ! -s "$tmp" ]; then
+    # Distinct from "every schedule passed". If the guard cannot see any
+    # schedules it has verified nothing, and saying "OK" would be a lie of
+    # exactly the kind it exists to catch.
+    rm -f "$tmp"
+    log "ERROR: no Velero schedules found in namespace $VELERO_NAMESPACE"
+    emit_event "VeleroGuardFoundNoSchedules" \
+      "velero-backup-content-guard found no Schedule objects in $VELERO_NAMESPACE -- it verified nothing."
+    return 1
+  fi
+
+  while read -r name last paused; do
+    [ -n "$name" ] || continue
+
+    if [ "$paused" = "true" ]; then
+      log "$name: paused, skipping"
+      continue
+    fi
+
+    checked=$((checked + 1))
+
+    # --- check 1: is it still running at all? ---
+    max_h=$(max_age_for "$name")
+    max_s=$((max_h * 3600))
+    if last_epoch=$(rfc3339_to_epoch "$last"); then
+      age=$((now - last_epoch))
+      if [ "$age" -gt "$max_s" ]; then
+        age_h=$((age / 3600))
+        log "FAIL $name: last backup was ${age_h}h ago (limit ${max_h}h)"
+        emit_event "VeleroScheduleStale" \
+          "Velero schedule $name has not produced a backup in ${age_h}h (limit ${max_h}h)."
+        failures=$((failures + 1))
+        continue
+      fi
+    else
+      # No lastBackup at all. A schedule that has never run is either brand new
+      # or broken; either way it is not yet meaningful to check its contents.
+      log "WARN $name: no lastBackup recorded yet, skipping (newly created?)"
+      continue
+    fi
+
+    # --- check 2: did the most recent run actually capture any volumes? ---
+    if in_list "$name" "$SKIP_VOLUME_CHECK"; then
+      log "OK   $name: fresh (${max_h}h bound); volume check exempted"
+      continue
+    fi
+
+    b=$(newest_backup "$name")
+    if [ -z "$b" ]; then
+      log "FAIL $name: status.lastBackup is set but no Backup object carries its label"
+      emit_event "VeleroScheduleBackupMissing" \
+        "Velero schedule $name reports lastBackup=$last but no Backup object has label velero.io/schedule-name=$name."
+      failures=$((failures + 1))
+      continue
+    fi
+
+    phase=$(backup_phase "$b")
+    case "$phase" in
+      Completed|PartiallyFailed)
+        # Ran to the end. Worth counting what it captured.
+        ;;
+      Failed|FailedValidation)
+        # Outright failure. This IS the guard's job, despite the PrometheusRule
+        # named VeleroBackupFailed existing: that rule is hard-scoped to
+        # schedule="velero-daily-full". As of 2026-08-17 monthly-b2 and the
+        # victoria-metrics schedule had no failure alert at all, and daily-b2
+        # only had a 72h persistently-failing rule -- so a B2 backup could fail
+        # outright and stay silent for three days.
+        #
+        # This guard enumerates schedules dynamically, so it covers every
+        # schedule including ones added later without anyone remembering to
+        # extend a PromQL selector. Overlapping with VeleroBackupFailed on
+        # daily-full is the intended trade: duplicate noise on one schedule
+        # beats silence on the rest.
+        log "FAIL $name: newest backup $b is phase=$phase"
+        emit_event "VeleroBackupFailed" \
+          "Velero backup $b (schedule $name) is in phase $phase. Check 'velero backup describe $b'."
+        failures=$((failures + 1))
+        continue
+        ;;
+      *)
+        # InProgress, Queued, Deleting, or a phase newer than this script. A
+        # running backup has nothing to count yet.
+        log "SKIP $name: newest backup $b is phase=${phase:-<none>}, not a finished run"
+        continue
+        ;;
+    esac
+
+    n=$(pvb_count "$b")
+    if [ "$n" -eq 0 ]; then
+      log "FAIL $name: backup $b is $phase but produced 0 PodVolumeBackups -- it captured no volume data"
+      emit_event "VeleroBackupCapturedNoVolumes" \
+        "Velero backup $b (schedule $name) reported $phase but produced 0 PodVolumeBackups. Its labelSelector probably matches nothing -- check that the selector uses a label present on BOTH the pod and the PVC."
+      failures=$((failures + 1))
+      continue
+    fi
+
+    log "OK   $name: $b $phase, $n PodVolumeBackups"
+  done < "$tmp"
+  rm -f "$tmp"
+
+  # "Checked nothing" is a failure, not a pass. The -s test above catches a
+  # truly empty listing, but not a listing that is whitespace, or one where
+  # every schedule was skipped as paused/never-run. In all of those cases the
+  # guard has verified nothing, and exiting 0 would assert health it never
+  # observed -- which is precisely the failure mode it was written to catch.
+  if [ "$checked" -eq 0 ]; then
+    log "ERROR: 0 schedules were actually checked -- the guard verified nothing"
+    emit_event "VeleroGuardCheckedNothing" \
+      "velero-backup-content-guard completed without checking any schedule. Every schedule was absent, paused, or had never run."
+    return 1
+  fi
+
+  log "checked $checked schedule(s), $failures failure(s)"
+  [ "$failures" -eq 0 ]
+}
+
+[ -n "${GUARD_TEST:-}" ] || main

--- a/clusters/vollminlab-cluster/velero/velero-backup-content-guard/app/guard_test.sh
+++ b/clusters/vollminlab-cluster/velero/velero-backup-content-guard/app/guard_test.sh
@@ -1,0 +1,212 @@
+#!/bin/sh
+# Unit tests for guard.sh. Run: sh guard_test.sh
+# Must pass under both dash and busybox ash (the image is alpine/kubectl).
+#
+# Sources guard.sh with GUARD_TEST=1 so main() does not run, then stubs the
+# helper functions per test. No cluster required.
+set -u
+HERE=$(dirname "$0")
+GUARD_TEST=1 . "$HERE/guard.sh"
+
+FAILS=0
+assert_eq() { # $1=actual $2=expected $3=msg
+  if [ "$1" = "$2" ]; then printf 'ok   - %s\n' "$3"
+  else printf 'FAIL - %s (got [%s] want [%s])\n' "$3" "$1" "$2"; FAILS=$((FAILS+1)); fi
+}
+assert_rc() { # $1=actual_rc $2=expected_rc $3=msg
+  if [ "$1" = "$2" ]; then printf 'ok   - %s\n' "$3"
+  else printf 'FAIL - %s (rc got [%s] want [%s])\n' "$3" "$1" "$2"; FAILS=$((FAILS+1)); fi
+}
+
+# Events are not under test; silence them everywhere.
+emit_event() { :; }
+
+# --- strip_zero / rfc3339_to_epoch (shared with heal.sh) ---
+assert_eq "$(strip_zero 08)" "8" "strip_zero drops the octal-poisoning zero"
+assert_eq "$(rfc3339_to_epoch 1970-01-01T00:00:00Z)" "0" "epoch zero"
+assert_eq "$(rfc3339_to_epoch 2026-08-17T05:00:32Z)" "1786942832" "the empty backup that started this"
+rfc3339_to_epoch "<none>"; assert_rc "$?" "1" "rejects <none>"
+
+# --- in_list ---
+in_list "velero-daily-b2" "velero-daily-b2 velero-x"; assert_rc "$?" "0" "in_list finds an exact word"
+in_list "velero-daily" "velero-daily-b2";             assert_rc "$?" "1" "in_list does not match a prefix"
+in_list "velero-daily-b2" "";                         assert_rc "$?" "1" "in_list on an empty list"
+
+# --- max_age_for ---
+MAX_AGE_HOURS=26
+MAX_AGE_OVERRIDES="velero-monthly-b2:768"
+assert_eq "$(max_age_for velero-daily-b2)"   "26"  "max_age_for falls back to the default"
+assert_eq "$(max_age_for velero-monthly-b2)" "768" "max_age_for honours the override"
+MAX_AGE_OVERRIDES="a:1 velero-monthly-b2:768 z:9"
+assert_eq "$(max_age_for velero-monthly-b2)" "768" "max_age_for finds a mid-list override"
+MAX_AGE_OVERRIDES="velero-monthly-b2:768"
+
+# ---------------------------------------------------------------------------
+# main() end-to-end, with the cluster stubbed.
+# ---------------------------------------------------------------------------
+# Fixed "now" so the staleness arithmetic is deterministic.
+#   2026-08-17T12:00:00Z = 1786968000  (cross-checked with `date -u -d ... +%s`)
+NOW=1786968000
+date() { # only ever called as `date -u +%s` or `date -u +%FT%TZ`
+  case "${2:-}" in
+    +%s) echo "$NOW" ;;
+    *)   echo "2026-08-17T12:00:00Z" ;;
+  esac
+}
+
+# Per-test fixtures, consumed by the stubs below.
+SCHEDULES=""   # "name last paused" rows
+BACKUPS=""     # "schedule backup phase pvbcount" rows
+
+schedule_rows() { printf '%s\n' "$SCHEDULES"; }
+newest_backup() {
+  for row in $BACKUPS; do
+    s=$(echo "$row" | cut -d, -f1)
+    [ "$s" = "$1" ] && { echo "$row" | cut -d, -f2; return 0; }
+  done
+  echo ""
+}
+backup_phase() {
+  for row in $BACKUPS; do
+    b=$(echo "$row" | cut -d, -f2)
+    [ "$b" = "$1" ] && { echo "$row" | cut -d, -f3; return 0; }
+  done
+  echo ""
+}
+pvb_count() {
+  for row in $BACKUPS; do
+    b=$(echo "$row" | cut -d, -f2)
+    [ "$b" = "$1" ] && { echo "$row" | cut -d, -f4; return 0; }
+  done
+  echo 0
+}
+
+run_main() { out=$(main 2>&1); rc=$?; }
+
+# --- THE REGRESSION TEST: the bug this whole thing exists for ---
+# velero-victoria-metrics-b2 completed, on time, 0 errors -- and 0 volumes.
+SCHEDULES="velero-victoria-metrics-b2 2026-08-17T05:00:32Z <none>"
+BACKUPS="velero-victoria-metrics-b2,velero-victoria-metrics-b2-20260817050032,Completed,0"
+run_main
+assert_rc "$rc" "1" "a Completed backup with 0 PodVolumeBackups FAILS the guard"
+case "$out" in *"captured no volume data"*) r=0 ;; *) r=1 ;; esac
+assert_rc "$r" "0" "  ...and says why"
+
+# --- the healthy case ---
+SCHEDULES="velero-daily-full 2026-08-17T03:00:43Z <none>"
+BACKUPS="velero-daily-full,velero-daily-full-20260817030043,Completed,24"
+run_main
+assert_rc "$rc" "0" "a Completed backup with PVBs passes"
+
+# --- PartiallyFailed still counts as a run worth inspecting ---
+SCHEDULES="velero-daily-b2 2026-08-17T04:00:48Z <none>"
+BACKUPS="velero-daily-b2,velero-daily-b2-20260817040048,PartiallyFailed,19"
+run_main
+assert_rc "$rc" "0" "PartiallyFailed with PVBs passes the content check"
+BACKUPS="velero-daily-b2,velero-daily-b2-20260817040048,PartiallyFailed,0"
+run_main
+assert_rc "$rc" "1" "PartiallyFailed with 0 PVBs still fails"
+
+# --- staleness ---
+# 2026-08-15T05:00:00Z is 55h before NOW, past the 26h default.
+SCHEDULES="velero-daily-full 2026-08-15T05:00:00Z <none>"
+BACKUPS="velero-daily-full,velero-daily-full-20260815050000,Completed,24"
+run_main
+assert_rc "$rc" "1" "a schedule that stopped running fails on staleness"
+case "$out" in *"55h ago"*) r=0 ;; *) r=1 ;; esac
+assert_rc "$r" "0" "  ...and reports the real age"
+
+# monthly is allowed to be old
+SCHEDULES="velero-monthly-b2 2026-08-01T06:00:16Z <none>"
+BACKUPS="velero-monthly-b2,velero-monthly-b2-20260801060016,Completed,88"
+run_main
+assert_rc "$rc" "0" "the monthly override exempts a 16-day-old backup"
+
+# ...but not arbitrarily old: 768h = 32d, so 2026-06-01 is stale even for monthly
+SCHEDULES="velero-monthly-b2 2026-06-01T06:00:16Z <none>"
+BACKUPS="velero-monthly-b2,velero-monthly-b2-20260601060016,Completed,88"
+run_main
+assert_rc "$rc" "1" "the monthly override is a bound, not an exemption"
+
+# --- paused / never-run schedules are not failures ---
+# A paused schedule alongside a healthy one is simply skipped. Note the paused
+# one is deliberately ancient: pausing must suppress the staleness check too.
+SCHEDULES="velero-daily-full 2026-08-17T03:00:43Z <none>
+velero-paused-thing 2026-06-01T05:00:00Z true"
+BACKUPS="velero-daily-full,velero-daily-full-1,Completed,24"
+run_main
+assert_rc "$rc" "0" "a paused schedule is skipped, not failed"
+case "$out" in *"checked 1 schedule(s)"*) r=0 ;; *) r=1 ;; esac
+assert_rc "$r" "0" "  ...and does not count toward the checked total"
+
+# But if EVERY schedule is paused, nothing is being backed up at all — the
+# guard must not report success for a cluster with no live backups.
+SCHEDULES="velero-daily-full 2026-08-17T03:00:43Z true"
+BACKUPS="velero-daily-full,velero-daily-full-1,Completed,24"
+run_main
+assert_rc "$rc" "1" "all schedules paused fails — the guard verified nothing"
+
+SCHEDULES="velero-brand-new <none> <none>"
+BACKUPS=""
+run_main
+assert_rc "$rc" "0" "a schedule that has never run is skipped, not failed"
+
+# --- in-flight backups are not judged ---
+SCHEDULES="velero-daily-full 2026-08-17T03:00:43Z <none>"
+BACKUPS="velero-daily-full,velero-daily-full-20260817030043,InProgress,0"
+run_main
+assert_rc "$rc" "0" "an InProgress backup is skipped, not failed for having 0 PVBs"
+BACKUPS="velero-daily-full,velero-daily-full-20260817030043,Queued,0"
+run_main
+assert_rc "$rc" "0" "a Queued backup is skipped too"
+
+# --- outright failures are caught here, not left to the daily-full-only rule ---
+# This is the live 2026-08-17 case: daily-b2 Failed on a B2 x-amz-tagging error
+# and no PrometheusRule would have fired on it for 72h.
+SCHEDULES="velero-daily-b2 2026-08-17T04:00:48Z <none>"
+BACKUPS="velero-daily-b2,velero-daily-b2-20260817040048,Failed,19"
+run_main
+assert_rc "$rc" "1" "a Failed backup fails the guard even with PVBs present"
+case "$out" in *"phase=Failed"*) r=0 ;; *) r=1 ;; esac
+assert_rc "$r" "0" "  ...and names the phase"
+BACKUPS="velero-daily-b2,velero-daily-b2-20260817040048,FailedValidation,0"
+run_main
+assert_rc "$rc" "1" "FailedValidation fails too"
+
+# --- volume-check exemption ---
+SCHEDULES="velero-objects-only 2026-08-17T05:00:00Z <none>"
+BACKUPS="velero-objects-only,velero-objects-only-20260817050000,Completed,0"
+SKIP_VOLUME_CHECK="velero-objects-only"
+run_main
+assert_rc "$rc" "0" "SKIP_VOLUME_CHECK exempts a deliberately volume-less schedule"
+SKIP_VOLUME_CHECK=""
+run_main
+assert_rc "$rc" "1" "  ...and removing it re-arms the check"
+
+# --- lastBackup set but the Backup object is gone ---
+SCHEDULES="velero-daily-full 2026-08-17T03:00:43Z <none>"
+BACKUPS=""
+run_main
+assert_rc "$rc" "1" "lastBackup with no matching Backup object fails"
+
+# --- seeing no schedules at all is a failure, not a pass ---
+SCHEDULES=""
+BACKUPS=""
+run_main
+assert_rc "$rc" "1" "an empty schedule list fails rather than reporting success"
+
+# --- multiple schedules: one bad poisons the run, and all are still checked ---
+SCHEDULES="velero-daily-full 2026-08-17T03:00:43Z <none>
+velero-victoria-metrics-b2 2026-08-17T05:00:32Z <none>
+velero-daily-b2 2026-08-17T04:00:48Z <none>"
+BACKUPS="velero-daily-full,velero-daily-full-1,Completed,24
+velero-victoria-metrics-b2,velero-vm-1,Completed,0
+velero-daily-b2,velero-daily-b2-1,Completed,19"
+run_main
+assert_rc "$rc" "1" "one empty schedule fails a run of three"
+case "$out" in *"checked 3 schedule(s), 1 failure(s)"*) r=0 ;; *) r=1 ;; esac
+assert_rc "$r" "0" "  ...and the counters survive the loop (no subshell)"
+
+printf '\n'
+if [ "$FAILS" -eq 0 ]; then printf 'all tests passed\n'; else printf '%s test(s) failed\n' "$FAILS"; fi
+[ "$FAILS" -eq 0 ]

--- a/clusters/vollminlab-cluster/velero/velero-backup-content-guard/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/velero/velero-backup-content-guard/app/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: velero-backup-content-guard
+# Required: configMapGenerator emits a ConfigMap with no namespace, and unlike
+# kube-system the velero Flux Kustomization sets no targetNamespace, so the
+# generated ConfigMap is rejected with "namespace not specified" and takes the
+# whole velero Kustomization down with it. rbac.yaml and cronjob.yaml already
+# carry namespace: velero explicitly; this makes the generated object match.
+namespace: velero
+resources:
+  - rbac.yaml
+  - cronjob.yaml
+configMapGenerator:
+  - name: velero-backup-content-guard-script
+    files:
+      - guard.sh
+generatorOptions:
+  disableNameSuffixHash: true
+  labels:
+    app: velero-backup-content-guard
+    env: production
+    category: storage

--- a/clusters/vollminlab-cluster/velero/velero-backup-content-guard/app/rbac.yaml
+++ b/clusters/vollminlab-cluster/velero/velero-backup-content-guard/app/rbac.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: velero-backup-content-guard
+  namespace: velero
+  labels:
+    app: velero-backup-content-guard
+    env: production
+    category: storage
+---
+# Role, not ClusterRole: every object this reads — Schedules, Backups and
+# PodVolumeBackups — lives in the velero namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: velero-backup-content-guard
+  namespace: velero
+  labels:
+    app: velero-backup-content-guard
+    env: production
+    category: storage
+rules:
+  - apiGroups: ["velero.io"]
+    resources: ["schedules", "backups", "podvolumebackups"]
+    # Strictly read-only. This guard observes and reports; it never touches a
+    # backup. Its whole output is an exit code and an Event.
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: velero-backup-content-guard
+  namespace: velero
+  labels:
+    app: velero-backup-content-guard
+    env: production
+    category: storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: velero-backup-content-guard
+subjects:
+  - kind: ServiceAccount
+    name: velero-backup-content-guard
+    namespace: velero


### PR DESCRIPTION
Closes the gap found in #1078: **an empty Velero backup is a successful Velero backup.**

`velero-victoria-metrics-b2` matched zero volumes for its entire life and reported `Completed / 0 errors / 4 items` every night. Phase is the only health signal Velero exposes and it was green throughout. `velero_backup_items_total` is exported but reads **0 for every schedule** on this cluster, so it can't serve as a content guard either.

## What it does

A daily CronJob (09:00 UTC, clear of every backup window) enumerates every Schedule and **fails the Job** — raising the existing `KubeJobFailed` alert — when any of these hold:

| Check | Fails when |
|---|---|
| Content | newest backup completed but produced **0 PodVolumeBackups** |
| Failure | newest backup is `Failed` / `FailedValidation` |
| Staleness | no backup in `MAX_AGE_HOURS` (26h; `monthly-b2` → 768h) |
| Consistency | `status.lastBackup` set but no Backup object carries the label |
| Self-check | zero schedules were actually checked |

Reusing `KubeJobFailed` rather than exporting new metrics is deliberate — it's an alerting path already proven here, whereas bespoke PromQL over a CustomResourceState exporter would itself be a thing that can silently stop matching. That's the exact failure being fixed.

## Why it also handles `Failed`

The `VeleroBackupFailed` PrometheusRule is **hard-scoped to `schedule="velero-daily-full"`**. Current coverage:

| Schedule | Failure alert |
|---|---|
| `velero-daily-full` | ✅ Failed + NotSucceeding + PersistentlyFailing |
| `velero-daily-b2` | ⚠️ only 72h persistently-failing |
| `velero-monthly-b2` | ❌ none |
| `velero-victoria-metrics-b2` | ❌ none |

This guard enumerates schedules dynamically, so it covers all of them — including schedules added later without anyone remembering to extend a PromQL selector.

## Verified against the live cluster

Not just rendered — actually run, read-only, before opening this PR:

```
FAIL velero-daily-b2: newest backup velero-daily-b2-20260817040048 is phase=Failed
OK   velero-daily-full: velero-daily-full-20260817030043 Completed, 24 PodVolumeBackups
OK   velero-monthly-b2: velero-monthly-b2-20260801060016 Completed, 88 PodVolumeBackups
FAIL velero-victoria-metrics-b2: velero-victoria-metrics-b2-20260816050032 is Completed
     but produced 0 PodVolumeBackups -- it captured no volume data
checked 4 schedule(s), 2 failure(s)
```

It catches both real problems and passes the two healthy schedules. **The `daily-b2` failure is a separate live incident** — see the note below.

## Tests

`sh guard_test.sh` — 34 assertions, pure-shell stubs, no cluster needed. Passes under **both `dash` and `busybox ash`** (the image is `alpine/kubectl`).

Two bugs they caught during development, both worth naming because they're the same species as the bug this guard exists for:

1. A run that checked **zero** schedules exited 0 — asserting health it never observed.
2. Reading the schedule list from a **pipe** would run the loop in a subshell and discard the failure counter — a guard that always reports success.

Per the repo's convention for `velero-pvb-healer`, tests are not wired into CI.

---

> **Unrelated live incident surfaced by this work:** `velero-daily-b2` failed at 04:00 today with `InvalidArgument: Unsupported header 'x-amz-tagging'` from Backblaze B2. The velero pod restarted at 03:19 and picked up `velero-plugin-for-aws:v1.14.2` (merged 08-11 in 61ad3254, not running until that restart). MinIO supports object tagging, B2 does not — so `daily-full` is fine and **both B2 schedules are broken going forward**. Previous version was `v1.14.0`. Tracked separately, not fixed here.