### PR TITLE
fix(velero): pin velero-plugin-for-aws to v1.14.0 — later releases break B2

### DIFF
--- a/.claude/rules/velero.md
+++ b/.claude/rules/velero.md
@@ -181,3 +181,51 @@ kubectl logs -n velero $(kubectl get pods -n velero --sort-by=.metadata.creation
 ## Gate for Cilium migration (Phase 8)
 
 Do not start the Cilium CNI migration until a `daily-full` backup shows `Completed` status and a test restore has been validated. First expected clean backup: **2026-04-23 at 2am UTC** (after circular backup fix in PR #410).
+
+## Backblaze B2 rejects `x-amz-tagging` — velero-plugin-for-aws is pinned at v1.14.0
+
+**Do not bump `velero-plugin-for-aws`.** `renovate.json5` holds it at v1.14.0 with
+`allowedVersions: "<=1.14.0"`, and the image line in the velero `configmap.yaml` says so too.
+
+The plugin sets `PutObjectInput.Tagging` unconditionally, even when the BSL's `tagging` config is
+empty — which is the default and our case:
+
+```go
+input := &s3.PutObjectInput{ Bucket: ..., Key: ..., Body: body, Tagging: aws.String(o.tagging) }
+```
+
+`aws-sdk-go-v2` used to drop the resulting empty header. From `service/s3` v1.97.3 it serializes
+`x-amz-tagging:` instead, and Backblaze rejects the header's *presence* — their S3 docs state it
+"will be explicitly rejected if it is included on the Copy Object (or Put Object) API calls".
+Every B2 backup then fails on the final `velero-backup.json` upload:
+
+```
+InvalidArgument: Unsupported header 'x-amz-tagging' received for this API call
+```
+
+**There is no config workaround.** An empty tag is exactly what breaks, and a non-empty one is
+rejected too, because B2 does not support object tagging at all. **v1.14.1 is not safe either** —
+`object_store.go` is byte-identical across v1.14.0/.1/.2, and the SDK jump (`service/s3`
+v1.48.0 → v1.97.3) landed in v1.14.1. The only safe version is v1.14.0.
+
+**When lifting the pin:** confirm upstream sets `Tagging` only when non-empty, and expect to also
+need `checksumAlgorithm: ""` on the `b2` BSL — the same SDK family breaks B2 on
+`x-amz-sdk-checksum-algorithm`, and that knob is currently unset because the old SDK never
+triggered it.
+
+### Two traps this incident is the canonical example of
+
+**A merged image bump is not a running image bump.** v1.14.2 merged 2026-08-11; the velero pod did
+not restart until 2026-08-17T03:19, and the first B2 backup after that restart failed. Six days
+separated the commit from the breakage, so the git-blame window and the outage window do not
+overlap. Never rule out a bump because "that merged last week and was fine" — check the pod's
+actual start time and its initContainer image:
+
+```bash
+kubectl get pods -n velero -l app.kubernetes.io/name=velero \
+  -o custom-columns='NAME:.metadata.name,START:.status.startTime,PLUGIN:.spec.initContainers[0].image'
+```
+
+**A healthy `daily-full` proves nothing about B2.** MinIO accepts `x-amz-tagging`; B2 does not. The
+schedule most likely to be watched is the one that cannot see this class of bug. When changing
+anything in the object-store path, verify against **both** BSLs.

--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -26,9 +26,27 @@ data:
         memory: 1500Mi
 
     # AWS plugin provides S3-compatible support for both MinIO and Backblaze B2
+    #
+    # PINNED AT v1.14.0 — DO NOT BUMP. See the renovate.json5 packageRule that
+    # enforces this, and the "Backblaze B2 rejects x-amz-tagging" section in
+    # .claude/rules/velero.md.
+    #
+    # Short version: the plugin sets PutObjectInput.Tagging unconditionally, even
+    # when the BSL's `tagging` config is empty (which is our case, and the
+    # default). aws-sdk-go-v2 used to drop an empty header; from service/s3
+    # v1.97.3 it serializes `x-amz-tagging:` instead. Backblaze rejects that
+    # header outright -- their S3 docs say it "will be explicitly rejected if it
+    # is included on the Copy Object (or Put Object) API calls" -- so every B2
+    # backup fails on the final velero-backup.json upload.
+    #
+    # v1.14.1 and v1.14.2 are both affected: object_store.go is byte-identical
+    # across .0/.1/.2, and the SDK jump (service/s3 v1.48.0 -> v1.97.3) landed in
+    # v1.14.1. There is no config workaround -- an empty tag is what breaks, and
+    # a non-empty one is rejected too, because B2 does not support object
+    # tagging at all. MinIO is unaffected, so daily-full masks this entirely.
     initContainers:
       - name: velero-plugin-for-aws
-        image: velero/velero-plugin-for-aws:v1.14.2
+        image: velero/velero-plugin-for-aws:v1.14.0
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - mountPath: /target

--- a/renovate.json5
+++ b/renovate.json5
@@ -76,6 +76,37 @@
       "matchUpdateTypes": ["major"],
       "labels": ["renovate", "dependencies", "major-update"],
       "automerge": false
+    },
+    {
+      // Held at v1.14.0 because every later release breaks Backblaze B2.
+      //
+      // The plugin sets PutObjectInput.Tagging unconditionally, even when the
+      // BSL `tagging` config is empty. aws-sdk-go-v2 used to omit the resulting
+      // empty header; from service/s3 v1.97.3 it sends `x-amz-tagging:`, and B2
+      // rejects that header's presence outright. Every B2 backup then fails on
+      // the velero-backup.json upload with:
+      //
+      //   InvalidArgument: Unsupported header 'x-amz-tagging' received for this
+      //   API call
+      //
+      // v1.14.1 and v1.14.2 are both affected -- object_store.go is identical
+      // across .0/.1/.2 and the SDK jump landed in v1.14.1 -- so this is a
+      // hold, not a "skip one bad release". There is no config workaround: an
+      // empty tag is what breaks, and a non-empty one is rejected too, because
+      // B2 does not support object tagging at all.
+      //
+      // MinIO accepts the header, so velero-daily-full keeps passing and hides
+      // this. It went unnoticed for 6 days between the v1.14.2 merge and the
+      // pod restart that actually started running it.
+      //
+      // To lift: confirm upstream only sets Tagging when non-empty, then expect
+      // to also need `checksumAlgorithm: ""` on the b2 BSL -- the same SDK
+      // family breaks B2 on x-amz-sdk-checksum-algorithm, and that config knob
+      // is currently unset.
+      "description": "Hold velero-plugin-for-aws at v1.14.0 — later versions break Backblaze B2 (x-amz-tagging)",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["velero/velero-plugin-for-aws"],
+      "allowedVersions": "<=1.14.0"
     }
   ]
 }


### PR DESCRIPTION
**Both Backblaze B2 schedules are currently failing.** First failure was this morning at 04:00.

```
InvalidArgument: Unsupported header 'x-amz-tagging' received for this API call
```

## Root cause

The plugin sets `Tagging` unconditionally, even when the BSL's `tagging` config is empty — the default, and our config:

```go
input := &s3.PutObjectInput{ Bucket: ..., Key: ..., Body: body,
    Tagging: aws.String(o.tagging) }   // o.tagging == ""
```

`aws-sdk-go-v2` used to drop the resulting empty header. Newer versions serialize `x-amz-tagging:`, and [Backblaze rejects the header's presence outright](https://www.backblaze.com/docs/cloud-storage-s3-compatible-api) — it "will be explicitly rejected if it is included on the Copy Object (or Put Object) API calls".

## Why v1.14.0 specifically, and why a hold rather than a skip

`object_store.go` is **byte-identical** across all three releases (same md5) — the plugin code never changed. The SDK did, and the jump landed in **v1.14.1**:

| Release | `aws-sdk-go-v2` | `service/s3` | B2 |
|---|---|---|---|
| v1.14.0 | 1.24.1 | 1.48.0 | ✅ |
| v1.14.1 | 1.41.5 | **1.97.3** | ❌ |
| v1.14.2 | 1.41.12 | 1.101.0 | ❌ |

So v1.14.0 is the only safe version, and the `renovate.json5` rule is a hold (`allowedVersions: "<=1.14.0"`), not a one-release skip. Without it the next bump silently reintroduces the outage.

**No config workaround exists.** An empty tag is what breaks; a non-empty one is rejected too, because B2 doesn't support object tagging at all. **No forward fix exists** either — v1.14.2 is the newest release, and only unpinned dev tags sit beyond it, which Kyverno blocks.

## Two traps recorded in `.claude/rules/velero.md`

- **A merged image bump is not a running image bump.** v1.14.2 merged 08-11 (61ad3254), but the velero pod didn't restart until **08-17T03:19** — the blame window and the outage window are six days apart.
- **A healthy `daily-full` proves nothing about B2.** MinIO accepts the header. The schedule most likely to be watched is the one that structurally cannot see this bug.

## When lifting the pin

Expect to also need `checksumAlgorithm: ""` on the `b2` BSL — [the same SDK family breaks B2 on `x-amz-sdk-checksum-algorithm`](https://github.com/vmware-tanzu/velero/issues/7534), and that knob is unset today only because the old SDK never triggered it.

---

Touches `velero/app/configmap.yaml` at the initContainer image line — distant from the schedules block #1078 edits — and appends to `.claude/rules/velero.md` after #1078's insertion point, so the two should not conflict.