### PR TITLE
fix(monitoring): stop KSM-derived alerts flapping on pod replacement

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -145,10 +145,26 @@ spec:
               off-site retention tier stale. Check 'velero backup get' and repo maintenance.
 
         - alert: KubeJobFailed
+          # Aggregated with `max by (namespace, job_name)` so the alert's identity does
+          # not include the kube-state-metrics pod that happened to report it.
+          #
+          # kube_job_failed has no `pod` label of its own, so the scrape target's `pod`
+          # and `instance` labels land on the series. Every time the KSM pod is replaced
+          # the series identity changes: the old one goes stale (alert RESOLVES) and a
+          # new one appears (alert FIRES) — while the underlying failed Job never changed.
+          # On 2026-08-17 the descheduler was cycling KSM every 30 minutes, so a single
+          # persistently-failed Job produced 7 distinct ALERTS series in 6 hours and
+          # flapped continuously.
+          #
+          # This does NOT affect KSM metrics that carry their own `pod` label
+          # (kube_pod_status_ready and friends) — there the subject pod wins and the
+          # series is stable. Only pod-less KSM metrics need this treatment; the other
+          # one on this cluster is kube_cronjob_status_last_successful_time, fixed the
+          # same way in prometheusrule-gitops.yaml.
           expr: |
-            (kube_job_failed{namespace!="velero"} > 0)
+            max by (namespace, job_name) (kube_job_failed{namespace!="velero"}) > 0
               or
-            (kube_job_failed{namespace="velero", job_name!~".*-kopia-maintain.*"} > 0)
+            max by (namespace, job_name) (kube_job_failed{namespace="velero", job_name!~".*-kopia-maintain.*"}) > 0
           for: 15m
           labels:
             severity: warning

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-gitops.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-gitops.yaml
@@ -60,9 +60,16 @@ spec:
         # that legitimately run less than daily must be excluded by name, otherwise the
         # gap between their normal runs trips the threshold — e.g. kube-system's monthly
         # kubeadm-cert-monitor (`0 9 1 * *`) would false-fire for ~30 days between runs.
+        # Aggregated with `max by (namespace, cronjob)` for the same reason as
+        # KubeJobFailed in prometheusrule-custom.yaml: kube_cronjob_status_* carries no
+        # `pod` label of its own, so the scrape target's `pod`/`instance` labels land on
+        # the series and every kube-state-metrics pod replacement changes the alert's
+        # identity — resolving and re-firing while nothing about the CronJob changed.
+        # `max` also picks the most recent success if two KSM pods ever overlap, which is
+        # the correct reading of "last succeeded".
         - alert: CronJobNotSucceededRecently
           expr: |
-            (time() - kube_cronjob_status_last_successful_time{cronjob!="kubeadm-cert-monitor"}) > 93600
+            (time() - max by (namespace, cronjob) (kube_cronjob_status_last_successful_time{cronjob!="kubeadm-cert-monitor"})) > 93600
           for: 15m
           labels:
             severity: warning


### PR DESCRIPTION
`KubeJobFailed` fired and resolved repeatedly this morning against a **single persistently-failed Job**. The Job never changed state — the alert's identity did.

## Cause

`kube_job_failed` has no `pod` label of its own, so the scrape target's `pod` and `instance` labels land on the series. Every kube-state-metrics pod replacement changes the series identity: old goes stale → **resolve**; new appears → **fire**.

The descheduler was cycling KSM every ~30 min, so one failed Job produced **7 distinct `ALERTS` series in 6 hours**, differing only in the reporting pod:

```
KubeJobFailed  job=velero-backup-content-guard-29782620  pod=...-bz6r6   firing samples=2
KubeJobFailed  job=velero-backup-content-guard-29782620  pod=...-thlcd   firing samples=7
KubeJobFailed  job=velero-backup-content-guard-29782620  pod=...-r2kbb   firing samples=7
KubeJobFailed  job=velero-backup-content-guard-29782620  pod=...-pmfn4   firing samples=22
KubeJobFailed  job=velero-backup-content-guard-29782620  pod=...-npt5z   firing samples=22
```

## Fix

`max by (namespace, job_name)` — drops the reporting pod from the alert's identity so it stays firing across KSM restarts. Both labels the annotations use are preserved.

## Scope: which metrics actually need this

Only KSM metrics **without** their own `pod` label. Measured over 6h by counting distinct `pod` values:

| Metric | distinct `pod` values | of which are KSM pods | Affected? |
|---|---:|---:|---|
| `kube_job_failed` | 7 | **7** | ✅ fixed |
| `kube_cronjob_status_last_successful_time` | 7 | **7** | ✅ fixed |
| `kube_pod_status_ready` | 1341 | 7 | ❌ subject pod wins — left alone |

So the rules keying on `kube_pod_container_status_restarts_total` / `kube_pod_status_ready` are **not** affected and are deliberately untouched.

Verified live — the new expression returns the same single series, carrying only `namespace` and `job_name`:

```
OLD: {job_name: velero-backup-content-guard-29782620, pod: ...-bz6r6}
NEW: {job_name: velero-backup-content-guard-29782620, namespace: velero}
```

`CronJobNotSucceededRecently` verified to return 0 firing series (nothing currently stale).

---

This fixes the **symptom**. The descheduler thrash that cycles KSM every 30 minutes is a separate PR.