### PR TITLE
fix(descheduler): stop the CPU-threshold eviction thrash

### DIFF
--- a/clusters/vollminlab-cluster/kube-system/descheduler/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/kube-system/descheduler/app/configmap.yaml
@@ -67,7 +67,26 @@ data:
                   memory: 55
                   pods: 45
                 targetThresholds:
-                  cpu: 80
+                  # Raised 80 -> 90 on 2026-08-17. Same failure as the memory note
+                  # below, recurring on the other axis: CPU *requests* on the general
+                  # workers sit at w01 71%, w02 75%, w03 81%, w04 86%, so w03 and w04
+                  # were permanently over an 80% target. The only general node under
+                  # every underutilized threshold is w01 at 71% — w05/w06 are DMZ
+                  # nodes with a NoSchedule taint that nodeFit cannot place onto — so
+                  # there was nowhere to converge TO. The descheduler evicted 8-10
+                  # pods every 30-minute cycle, the scheduler put them back on equally
+                  # full nodes, and the loop repeated indefinitely.
+                  #
+                  # That churn was not harmless: it cycled kube-state-metrics every
+                  # 30 minutes, which changes the series identity of every pod-less
+                  # KSM metric and made KubeJobFailed flap firing/resolved against a
+                  # Job whose state never changed (fixed separately in #1081).
+                  #
+                  # 90% is above w04's current 86% and is not masking real pressure:
+                  # measured actual CPU usage is 9% on w03 and 39% on w04 against
+                  # those 81%/86% requests. The requests are oversubscribed, which is
+                  # a right-sizing question (cf. #928), not something eviction can fix.
+                  cpu: 90
                   # w03 carries a heavy immovable stateful floor (authentik-server +
                   # 3 CNPG DBs + minio) that pins its request-memory at ~70%. With the
                   # PVC guard the descheduler can only move stateless pods, so a 70%
@@ -78,6 +97,15 @@ data:
                   # on w03 is only ~55%, so this is not masking real pressure.
                   memory: 80
                   pods: 50
+                # Hard ceiling on evictions per node per cycle. The two incidents above
+                # were both "threshold set below an unreachable floor", and in both the
+                # symptom was unbounded churn — 8-10 evictions every 30 minutes, with
+                # no benefit. A threshold can be wrong again; this bounds the damage
+                # when it is, and makes the wrongness visible as a slow drift instead
+                # of a storm. Supported as a LowNodeUtilization arg in descheduler
+                # v0.36.0 (chart 0.36.0).
+                evictionLimits:
+                  node: 2
           plugins:
             balance:
               enabled:


### PR DESCRIPTION
The descheduler has been evicting **8–10 pods every 30-minute cycle** without ever converging — because there is nowhere to converge to.

## Why it can't converge

CPU **requests** on the general workers:

| Node | cpu req | mem req | actual cpu | status vs target 80 |
|---|---:|---:|---:|---|
| k8sworker01 | 71.1% | 36.4% | 9% | underutilized (only receiver) |
| k8sworker02 | 75.1% | 38.7% | 12% | mid |
| k8sworker03 | **81.0%** | 56.1% | **9%** | over target |
| k8sworker04 | **85.7%** | 78.3% | **39%** | over target |
| k8sworker05/06 | 31% / 58% | — | — | DMZ, NoSchedule taint — `nodeFit` can't use them |

w03 and w04 are permanently over target; the only general node under every underutilized threshold is w01 at 71%. So each cycle evicts off w03/w04, the scheduler puts pods back on equally full nodes, and it repeats.

This is **the same failure already documented in the comment directly below this change** — the earlier 70→80 memory fix simply left CPU as the next binding constraint.

## The churn wasn't harmless

It cycled kube-state-metrics every 30 minutes. Because pod-less KSM metrics inherit the scrape target's `pod`/`instance` labels, each replacement changed the series identity of `kube_job_failed` — making `KubeJobFailed` flap firing/resolved against a Job whose state never changed. #1081 fixes that symptom; **this removes the cause.**

## Is 90 masking real pressure?

No. Actual CPU usage is **9% on w03** and **39% on w04**, against 81% and 86% requests. The requests are oversubscribed — a right-sizing question (cf. #928) that eviction cannot answer.

**Expect `LowNodeUtilization` to go quiet** until requests actually grow. With every node now under target that's the correct outcome, and it still fires on a node genuinely packed past 90% cpu / 80% mem / 50% pods.

## Also: `evictionLimits.node: 2`

Both incidents here were "threshold set below an unreachable floor", and both presented as unbounded churn. A threshold can be wrong again — this bounds the blast radius so the next mistake surfaces as a slow drift instead of a storm.

Verified `evictionLimits` is a valid `LowNodeUtilization` arg in descheduler **v0.36.0**, matching the pinned chart 0.36.0, and confirmed the rendered policy parses with both changes.