### PR TITLE
feat(authentik): add bhasslinger user with Audiobookshelf access

### DIFF
--- a/terraform/authentik/groups.tf
+++ b/terraform/authentik/groups.tf
@@ -5,7 +5,7 @@ resource "authentik_group" "audiobookshelf_admins" {
 
 resource "authentik_group" "audiobookshelf_users" {
   name  = "Audiobookshelf Users"
-  users = toset([authentik_user.jvollmin.id, authentik_user.gkroner.id, authentik_user.chavelock.id, authentik_user.jkvedaras.id, authentik_user.rjutkiewicz.id, authentik_user.speterson.id])
+  users = toset([authentik_user.jvollmin.id, authentik_user.gkroner.id, authentik_user.chavelock.id, authentik_user.jkvedaras.id, authentik_user.rjutkiewicz.id, authentik_user.speterson.id, authentik_user.bhasslinger.id])
 }
 
 resource "authentik_group" "filebrowser_users" {

--- a/terraform/authentik/users.tf
+++ b/terraform/authentik/users.tf
@@ -76,3 +76,14 @@ resource "authentik_user" "speterson" {
     ignore_changes = [password, groups]
   }
 }
+
+resource "authentik_user" "bhasslinger" {
+  username  = "bhasslinger"
+  name      = "Brandon Hasslinger"
+  email     = "brandon.hasslinger17@gmail.com"
+  is_active = true
+
+  lifecycle {
+    ignore_changes = [password, groups]
+  }
+}


### PR DESCRIPTION
Adds Brandon Hasslinger (`bhasslinger`) and puts him in the **Audiobookshelf Users** group — the same two-file change as `rjutkiewicz` (#1064) and `speterson` (#1067).

## Why no Audiobookshelf-side change

Verified against the live ABS API rather than assumed:

- `authOpenIDAutoRegister: true` — the ABS account is created on first SSO login
- `authOpenIDGroupClaim: "groups"` — the Authentik group decides the ABS role

So the Authentik group membership is the whole grant. That is also why #1064 and #1067 touched only `terraform/authentik/`.

## After merge

Issue a recovery link via the Authentik REST API with `token_duration: days=3`. The link is single-use and must be opened in a private window — `recovery-flow` is `require_unauthenticated`, so an existing session gets "Flow does not apply to current user".

🤖 Generated with [Claude Code](https://claude.com/claude-code)