### PR TITLE
fix(audiobookshelf): stop CFS-throttling the player on a 500m quota

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/audiobookshelf/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/mediastack/audiobookshelf/app/configmap.yaml
@@ -47,7 +47,25 @@ data:
         cpu: 100m
         memory: 256Mi
       limits:
-        cpu: 500m
+        # CPU limit raised 500m -> 2000m on 2026-08-17. Measured over 30d, the
+        # container's peak 5m-average CPU was only 0.13 cores — but 30.6% of CFS
+        # scheduling periods were throttled. Those two numbers are not in tension:
+        # audiobookshelf is a single Node process whose work arrives in short bursts
+        # (stream start, library scan, progress sync), and a 500m quota is 50ms of
+        # every 100ms period. The bursts hit the ceiling and get clipped even while
+        # the 5m average looks idle. The symptom is latency on stream start, not a
+        # visible error.
+        #
+        # Only the *limit* moves. The 100m request is left alone, so scheduling and
+        # node packing are unchanged — k8sworker02 is at 75% of CPU *requests* and
+        # already 298% overcommitted on limits, which is the normal state for a
+        # burstable node. Raising a limit consumes no allocatable capacity.
+        #
+        # 2000m also covers the one case that genuinely needs a core: if a title ever
+        # has to be transcoded, ffmpeg wants ~0.5-1 full core, and under the old limit
+        # a single transcode saturated the whole container.
+        cpu: 2000m
+        # Unchanged. 30d peak working set was 280Mi against this 750Mi ceiling.
         memory: 750Mi
     podLabels:
       app: audiobookshelf


### PR DESCRIPTION
Raises the Audiobookshelf CPU **limit** from 500m to 2000m. The 100m request is unchanged.

## The measurement

30d peaks from VictoriaMetrics, `mediastack/audiobookshelf`:

| Metric | Peak | Limit |
|---|---|---|
| CPU (5m avg) | 0.13 cores | 500m |
| Memory working set | 280Mi | 750Mi |
| **CFS throttled periods** | **30.6%** | — |

The first and third rows look contradictory but are not. Audiobookshelf is a single Node process whose work arrives in short bursts — stream start, library scan, progress sync — and a 500m quota is 50ms out of every 100ms period. The bursts clip against the ceiling while the 5-minute average still reads idle. Nothing errors; it shows up as latency on stream start, which is exactly the kind of thing nobody files a ticket about.

## Why this is free

Only the limit moves. Scheduling keys on requests, and k8sworker02 currently sits at 75% of CPU requests / 298% of limits — normal for a burstable node. A limit consumes no allocatable capacity, so node packing is unchanged.

2000m also covers the one path that genuinely wants a core: if a title ever has to be transcoded, ffmpeg takes ~0.5–1 core, which the old limit could not supply without starving the rest of the process.

Memory is left alone — the 30d peak was 280Mi against a 750Mi ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)