### PR TITLE
feat(monitoring): alert when Longhorn's reclaim path stops reclaiming

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -348,6 +348,55 @@ spec:
             summary: "Longhorn node {{ $labels.node }} storage below 15% free"
             description: "Longhorn storage node {{ $labels.node }} has less than 15% free. New replicas may fail to schedule. Expand the disk or evict replicas."
 
+        # Reclaim-path outcome check. Longhorn is thin-provisioned and only learns a
+        # block is free when the filesystem discards it, so `actualSize` drifts above
+        # real usage until the daily filesystem-trim RecurringJob runs.
+        #
+        # CronJobNotSucceededRecently (prometheusrule-gitops.yaml) already covers the
+        # job dying. It does NOT cover the job *succeeding while doing nothing*, which
+        # is exactly what happened on 2026-08-17: Longhorn 1.12.1 shipped a
+        # NetworkPolicy that blocked the old trim CronJob's API calls, and it logged
+        # "trimmed 0 volumes" and exited 0 every night (#1086). This alert watches the
+        # outcome instead of the mechanism, so it catches any future failure of the
+        # reclaim path regardless of cause.
+        #
+        # kubelet reports one series per node for RWX volumes (pvc-completed-downloads
+        # is mounted on several), so the right-hand side MUST be aggregated with
+        # `max by` — an unaggregated join fails with "many-to-many matching not allowed"
+        # rather than returning a wrong number.
+        #
+        # Threshold: measured floor after a working trim is ~26GB, which is space held
+        # by the deliberately retained snapshots of snapshot-retention (retain: 3), not
+        # waste. It was 67GB with trim broken. 60GB sits above the floor and below the
+        # broken state; revisit if snapshot retention changes.
+        - alert: LonghornStaleSpaceHigh
+          expr: |
+            sum(
+              longhorn_volume_actual_size_bytes
+              - on (pvc_namespace, pvc) group_left()
+                max by (pvc_namespace, pvc) (
+                  label_replace(
+                    label_replace(
+                      kubelet_volume_stats_used_bytes,
+                      "pvc_namespace", "$1", "namespace", "(.+)"
+                    ),
+                    "pvc", "$1", "persistentvolumeclaim", "(.+)"
+                  )
+                )
+            ) > 60e9
+          for: 6h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Longhorn is holding {{ $value | humanize1024 }}B more than its filesystems use"
+            description: >-
+              Longhorn allocated size exceeds live filesystem usage cluster-wide by
+              {{ $value | humanize1024 }}B, above the ~26GB expected from retained
+              snapshots. The daily filesystem-trim RecurringJob is probably running but
+              reclaiming nothing — check that it logs per-volume "Running recurring
+              filesystem trim" lines, not just a successful exit:
+              `kubectl logs -n longhorn-system -l job-name=<latest filesystem-trim job>`.
+
     - name: minio
       rules:
         - alert: MinioDiskUsageHigh


### PR DESCRIPTION
## Why

#1086 fixed a trim job that had been **succeeding while doing nothing**. Nothing in the current alerting would have caught it:

- `CronJobNotSucceededRecently` watches whether the job *runs*. The job ran fine every night.
- It trimmed 0 volumes because a NetworkPolicy blocked its API calls, and still exited 0.

This is the third instance of the same shape on this cluster — velero's empty `victoria-metrics-b2` schedule, the OOMKilled pvb-healer, and now this. Alerting on the *outcome* rather than the mechanism catches the next one regardless of cause.

## What

`LonghornStaleSpaceHigh` — cluster-wide Longhorn allocated size minus live filesystem usage.

## Thresholds are measured, not guessed

| state | cluster-wide drift |
|---|---|
| trim broken (this morning) | **67 GB** |
| after one working trim run | **26 GB** |
| alert threshold | **60 GB** for 6h |

The ~26 GB floor is not waste — it's space held by the snapshots `snapshot-retention` deliberately retains (`retain: 3`). 60 GB sits clear of that floor and well below the broken state. Worth revisiting if snapshot retention ever changes; that's noted in a comment on the rule.

## One non-obvious detail

The join **must** aggregate the kubelet side with `max by (pvc_namespace, pvc)`. `pvc-completed-downloads` is RWX and mounted on several nodes, so kubelet emits one series per node. Without the aggregation the query fails outright:

```
found duplicate series for the match group {pvc="pvc-completed-downloads", pvc_namespace="mediastack"}
on the right hand-side of the operation ... many-to-many matching not allowed
```

It errors rather than silently returning a wrong number, which is the good failure mode — but it means the aggregation isn't optional.

No KSM join is needed, incidentally: `longhorn_volume_actual_size_bytes` already carries `pvc` and `pvc_namespace` labels.

## Verification

- `promtool check rules` on the extracted spec — SUCCESS, 29 rules
- Evaluated the **exact** expression from the file against live Prometheus: returns empty (correctly not firing) at the current 25.5 GB; the unguarded form returns the expected value
- yamllint clean under the CI config; `kubectl kustomize` builds; server-side dry-run accepted

## Not included

A trim-specific liveness alert — the existing `CronJobNotSucceededRecently` already picks up the new `filesystem-trim` CronJob automatically, so a second one would be redundant.