### PR TITLE
fix(monitoring): stop vmbackup from disabling velero's B2 backup location

### DIFF
--- a/.claude/rules/velero.md
+++ b/.claude/rules/velero.md
@@ -185,6 +185,35 @@ kubectl exec -n minio $(kubectl get pods -n minio -l app=minio -o jsonpath='{.it
 
 Never trigger a backup or write operation when storage is < 5% free. Check headroom first.
 
+## Velero owns its bucket's root — never write anything else into it
+
+The `b2` BackupStorageLocation sets no `prefix`, so Velero validates the bucket's **top-level
+directories** and accepts only its own (`backups/`, `kopia/`, `restores/`, `metadata/`). Anything
+else flips it to `Unavailable`:
+
+```
+BackupStorageLocation "b2" is unavailable:
+  Backup store contains invalid top-level directories: [victoria-metrics-lt]
+```
+
+**That is a hard block, not a warning** — every backup targeting it fails before it starts:
+
+```
+phase: FailedValidation
+["backup can't be created because BackupStorageLocation b2 is in Unavailable status."]
+```
+
+This happened on 2026-08-17: #1075 pointed vmbackup at
+`s3://vollminlab-k8s-backups/victoria-metrics-lt`, the same bucket velero uses, and killed all
+three B2 schedules. Fixed by giving the cold-tier metrics their own bucket
+(`vollminlab-k8s-metrics`) and their own bucket-scoped B2 key.
+
+**So: any new B2 workload gets its own bucket.** Do not add a prefix to velero's BSL to make room —
+its existing backups live at the bucket root, so a prefix orphans every one of them.
+
+And note which schedule can see it: `daily-full` writes to MinIO and stayed green throughout, exactly
+as it did during the `x-amz-tagging` incident. **Verify against both BSLs, never just the healthy one.**
+
 ## Circular backup check
 
 `defaultVolumesToFsBackup: true` backs up **every** pod's volumes by default.  

--- a/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/backup-cronjob.yaml
+++ b/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/backup-cronjob.yaml
@@ -54,7 +54,13 @@ spec:
                 # live data directory mid-merge and produce a torn backup.
                 - -snapshot.createURL=http://victoria-metrics-lt-server.monitoring.svc:8428/snapshot/create
                 - -snapshot.deleteURL=http://victoria-metrics-lt-server.monitoring.svc:8428/snapshot/delete
-                - -dst=s3://vollminlab-k8s-backups/victoria-metrics-lt
+                # MUST NOT share velero's bucket. Velero's b2 BackupStorageLocation
+                # has no `prefix`, so it owns that bucket's root and marks itself
+                # Unavailable if it finds any top-level directory it does not
+                # recognise. Writing victoria-metrics-lt/ there on 2026-08-17 blocked
+                # every B2 backup with "backup can't be created because
+                # BackupStorageLocation b2 is in Unavailable status".
+                - -dst=s3://vollminlab-k8s-metrics/victoria-metrics-lt
                 - -customS3Endpoint=https://s3.us-west-000.backblazeb2.com
                 - -loggerFormat=json
               envFrom:

--- a/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/victoria-metrics-lt-b2-credentials-externalsecret.yaml
+++ b/clusters/vollminlab-cluster/monitoring/victoria-metrics-lt/app/victoria-metrics-lt-b2-credentials-externalsecret.yaml
@@ -23,10 +23,13 @@ spec:
         AWS_ACCESS_KEY_ID: "{{ .keyID }}"
         AWS_SECRET_ACCESS_KEY: "{{ .applicationKey }}"
   dataFrom:
-    # Same B2 application key velero already uses for this bucket. A dedicated
-    # key scoped to the victoria-metrics-lt/ prefix would be tighter, but B2
-    # application keys scope to a bucket rather than a prefix, so a second key
-    # would buy separation of revocation and nothing else. Worth doing if this
-    # ever needs to be revoked independently of velero.
+    # Dedicated key, scoped to the vollminlab-k8s-metrics bucket only.
+    #
+    # This used to borrow velero's key, which was reasonable while both wrote to
+    # the same bucket -- B2 application keys scope to a bucket, not a prefix, so
+    # a second key against a shared bucket would have bought nothing. Sharing the
+    # bucket turned out to be the problem: velero's BackupStorageLocation owns
+    # that bucket's root and went Unavailable the moment vmbackup created a
+    # top-level directory it did not recognise. Separate buckets, so separate keys.
     - extract:
-        key: "Backblaze B2 - vollminlab-k8s-velero"
+        key: "Backblaze B2 - vollminlab-k8s-metrics"


### PR DESCRIPTION
## Impact: all offsite B2 backups have been dead since 07:43Z today

`daily-b2` (2160h retention), `grafana-b2` and `monthly-b2` are **hard-blocked**. `daily-full` → MinIO is unaffected, which is why nothing surfaced it — the same blind spot as the `x-amz-tagging` incident.

## Cause

#1075 pointed vmbackup at `s3://vollminlab-k8s-backups/victoria-metrics-lt` — **velero's own bucket**. Velero's `b2` BSL sets no `prefix`, so it owns that bucket's root and accepts only top-level directories it recognises (`backups/`, `kopia/`, …).

The cold-tier backup's first run at 07:30 created `victoria-metrics-lt/`, and the BSL failed validation 13 minutes later:

```
BackupStorageLocation "b2" is unavailable:
  Backup store contains invalid top-level directories: [victoria-metrics-lt]
```

Bucket listing confirms exactly three top-level entries — `backups/`, `kopia/`, and the intruder.

**This is a hard block, not cosmetic.** Verified with a throwaway probe backup:

```
phase: FailedValidation
["backup can't be created because BackupStorageLocation b2 is in Unavailable status."]
```

## Fix

Give the cold tier its own bucket, `vollminlab-k8s-metrics`, with its own B2 application key scoped to that bucket (`listBuckets, listFiles, readFiles, writeFiles, deleteFiles`) instead of borrowing velero's.

Sharing velero's key was a reasonable call in #1075 — B2 keys scope to a *bucket*, not a prefix, so a second key against a shared bucket would have bought nothing. Separate buckets change that.

New key is stored in 1Password as **`Backblaze B2 - vollminlab-k8s-metrics`** (Homelab tag, fields `keyID` / `applicationKey`, noted as ExternalSecret-referenced), created *before* this ExternalSecret references it.

### Rejected alternative

Putting a `prefix:` on velero's BSL. Its existing backups live at the bucket root, so a prefix orphans ~90 days of offsite backups unless every object is server-side copied.

## Cost

One re-upload. Only a single vm-lt backup existed (52.4 GB, uploaded 08-17 07:51) and it re-runs nightly at 07:30.

## Follow-up (not in this PR)

The stray `victoria-metrics-lt/` prefix must be deleted from `vollminlab-k8s-backups` before the BSL returns to `Available` — that's a live B2 operation, done after merge, not a manifest change.

Unblocking the BSL also finally allows the `x-amz-tagging` pin from #1080 to be verified. The velero pod **has** rolled to `velero-plugin-for-aws:v1.14.0` (started 04:50:53Z), but today's 04:00 `daily-b2` began ~50 minutes before that roll, so it still failed on the old plugin and no clean B2 run has happened since.