### PR TITLE
fix(radarr,sonarr): let quality profiles actually upgrade, and bound what they grab

### DIFF
--- a/terraform/radarr/imports.tf
+++ b/terraform/radarr/imports.tf
@@ -41,3 +41,47 @@ import {
   to = radarr_delay_profile.default
   id = "1"
 }
+
+# Quality definitions — built-in rows that can only be updated, never created,
+# so each one needs an import block before tofu will manage it.
+# IDs fetched 2026-08-18 via kubectl exec radarr /api/v3/qualitydefinition
+
+import {
+  to = radarr_quality_definition.bluray_1080p
+  id = "22"
+}
+
+import {
+  to = radarr_quality_definition.remux_1080p
+  id = "23"
+}
+
+import {
+  to = radarr_quality_definition.hdtv_2160p
+  id = "24"
+}
+
+import {
+  to = radarr_quality_definition.webdl_2160p
+  id = "25"
+}
+
+import {
+  to = radarr_quality_definition.webrip_2160p
+  id = "26"
+}
+
+import {
+  to = radarr_quality_definition.bluray_2160p
+  id = "27"
+}
+
+import {
+  to = radarr_quality_definition.remux_2160p
+  id = "28"
+}
+
+import {
+  to = radarr_quality_definition.br_disk
+  id = "29"
+}

--- a/terraform/radarr/quality-definitions.tf
+++ b/terraform/radarr/quality-definitions.tf
@@ -1,0 +1,73 @@
+# Per-quality size ceilings (MB per minute of runtime).
+# IDs and titles fetched 2026-08-18 via kubectl exec radarr /api/v3/qualitydefinition
+#
+# Only the tiers that were previously uncapped (max = null, i.e. unlimited) are
+# managed here. HDTV/WEBDL/WEBRip-1080p already carry a 100 MB/min cap and are
+# deliberately left alone.
+#
+# These ceilings are what bound library growth now that upgrade_allowed is true.
+# A movie below its profile cutoff takes the best allowed release it sees, and
+# "Any" — which 519 of 589 movies use — allows every tier up to Remux-2160p.
+#
+# Reference points, for a 110-minute film:
+#   200 MB/min = 22 GB     300 MB/min = 33 GB     350 MB/min = 38 GB
+#   250 MB/min = 27 GB     400 MB/min = 44 GB
+#
+# Every value is kept strictly under 400: Radarr's slider treats 400 as
+# "Unlimited", so a literal 400 would defeat the point of setting a cap.
+
+resource "radarr_quality_definition" "bluray_1080p" {
+  id       = 22
+  title    = "Bluray-1080p"
+  min_size = 0
+  max_size = 200 # ~22 GB; observed 1080p Blu-rays run 9-21 GB
+}
+
+resource "radarr_quality_definition" "remux_1080p" {
+  id       = 23
+  title    = "Remux-1080p"
+  min_size = 0
+  max_size = 250 # ~27 GB; observed 1080p remuxes run 32-39 GB, so most are excluded
+}
+
+resource "radarr_quality_definition" "hdtv_2160p" {
+  id       = 24
+  title    = "HDTV-2160p"
+  min_size = 0
+  max_size = 250 # ~27 GB
+}
+
+resource "radarr_quality_definition" "webdl_2160p" {
+  id       = 25
+  title    = "WEBDL-2160p"
+  min_size = 0
+  max_size = 250 # ~27 GB; observed 4K WEB-DLs run 20-26 GB, so these still qualify
+}
+
+resource "radarr_quality_definition" "webrip_2160p" {
+  id       = 26
+  title    = "WEBRip-2160p"
+  min_size = 0
+  max_size = 250 # ~27 GB
+}
+
+resource "radarr_quality_definition" "bluray_2160p" {
+  id       = 27
+  title    = "Bluray-2160p"
+  min_size = 0
+  max_size = 300 # ~33 GB; admits the x265 encodes, not the 54-63 GB ones
+}
+
+resource "radarr_quality_definition" "remux_2160p" {
+  id       = 28
+  title    = "Remux-2160p"
+  min_size = 0
+  max_size = 350 # ~38 GB; observed 4K remuxes run 50-90 GB, so in practice this excludes them
+}
+
+resource "radarr_quality_definition" "br_disk" {
+  id       = 29
+  title    = "BR-DISK"
+  min_size = 0
+  max_size = 300 # ~33 GB; full-disc rips, uncapped until now
+}

--- a/terraform/radarr/quality-profiles.tf
+++ b/terraform/radarr/quality-profiles.tf
@@ -1,12 +1,21 @@
 # Quality profiles imported from Radarr API
 # Retrieved 2026-05-14 via kubectl exec radarr /api/v3/qualityprofile
 # language id=1 = English
+#
+# upgrade_allowed is true on every profile. With it false (the previous state)
+# Radarr treats the *highest allowed quality* as the cutoff, so any existing file
+# "meets cutoff" and no release is ever grabbed as a replacement — a 720p file
+# stays 720p forever no matter how many searches you run.
+#
+# cutoff is the quality at which upgrading stops. Items *below* cutoff take the
+# best allowed release they see, which can be 2160p on the profiles that allow it
+# — per-quality size ceilings in quality-definitions.tf are what bound that.
 
-# Profile: Any (id=1) — all qualities allowed, no upgrade
+# Profile: Any (id=1) — 519 of 589 movies. All qualities allowed, up to Remux-2160p.
 resource "radarr_quality_profile" "any" {
   name            = "Any"
-  upgrade_allowed = false
-  cutoff          = 20 # Bluray-1080p
+  upgrade_allowed = true
+  cutoff          = 7 # Bluray-1080p — stop upgrading once a 1080p Blu-ray is in place
   lifecycle { ignore_changes = [quality_groups] }
 
   language = {
@@ -125,11 +134,11 @@ resource "radarr_quality_profile" "any" {
   ]
 }
 
-# Profile: SD (id=2) — SD and WEB 480p / Bluray 480p/576p allowed, no upgrade
+# Profile: SD (id=2) — unused (0 movies). SD and WEB 480p / Bluray 480p/576p.
 resource "radarr_quality_profile" "sd" {
   name            = "SD"
-  upgrade_allowed = false
-  cutoff          = 20 # upgrade_allowed = false, so cutoff is irrelevant
+  upgrade_allowed = true
+  cutoff          = 21 # Bluray-576p — top of this profile's own list
   lifecycle { ignore_changes = [quality_groups] }
 
   language = {
@@ -188,11 +197,11 @@ resource "radarr_quality_profile" "sd" {
   ]
 }
 
-# Profile: HD-720p (id=3) — 720p qualities only, no upgrade
+# Profile: HD-720p (id=3) — unused (0 movies). 720p qualities only.
 resource "radarr_quality_profile" "hd_720p" {
   name            = "HD-720p"
-  upgrade_allowed = false
-  cutoff          = 6 # Bluray-720p
+  upgrade_allowed = true
+  cutoff          = 6 # Bluray-720p — top of this profile's own list
   lifecycle { ignore_changes = [quality_groups] }
 
   language = {
@@ -219,11 +228,11 @@ resource "radarr_quality_profile" "hd_720p" {
   ]
 }
 
-# Profile: HD-1080p (id=4) — 1080p qualities only, no upgrade
+# Profile: HD-1080p (id=4) — unused (0 movies). 1080p qualities only.
 resource "radarr_quality_profile" "hd_1080p" {
   name            = "HD-1080p"
-  upgrade_allowed = false
-  cutoff          = 7 # Bluray-1080p
+  upgrade_allowed = true
+  cutoff          = 7 # Bluray-1080p — stops short of Remux-1080p (32-39 GB)
   lifecycle { ignore_changes = [quality_groups] }
 
   language = {
@@ -254,11 +263,11 @@ resource "radarr_quality_profile" "hd_1080p" {
   ]
 }
 
-# Profile: Ultra-HD (id=5) — 4K qualities only, no upgrade
+# Profile: Ultra-HD (id=5) — unused (0 movies). 4K qualities only.
 resource "radarr_quality_profile" "ultra_hd" {
   name            = "Ultra-HD"
-  upgrade_allowed = false
-  cutoff          = 31 # Remux-2160p
+  upgrade_allowed = true
+  cutoff          = 19 # Bluray-2160p — stops short of Remux-2160p (50-90 GB)
   lifecycle { ignore_changes = [quality_groups] }
 
   language = {
@@ -289,11 +298,11 @@ resource "radarr_quality_profile" "ultra_hd" {
   ]
 }
 
-# Profile: HD - 720p/1080p (id=6) — 720p and 1080p qualities, no upgrade
+# Profile: HD - 720p/1080p (id=6) — 70 movies. 720p and 1080p qualities.
 resource "radarr_quality_profile" "hd_720p_1080p" {
   name            = "HD - 720p/1080p"
-  upgrade_allowed = false
-  cutoff          = 6 # Bluray-720p
+  upgrade_allowed = true
+  cutoff          = 7 # Bluray-1080p — was 6 (Bluray-720p), which capped this profile at 720p
   lifecycle { ignore_changes = [quality_groups] }
 
   language = {

--- a/terraform/sonarr/imports.tf
+++ b/terraform/sonarr/imports.tf
@@ -41,3 +41,37 @@ import {
   to = sonarr_delay_profile.default
   id = "1"
 }
+
+# Quality definitions — built-in rows that can only be updated, never created,
+# so each one needs an import block before tofu will manage it.
+# IDs fetched 2026-08-18 via kubectl exec sonarr /api/v3/qualitydefinition
+
+import {
+  to = sonarr_quality_definition.raw_hd
+  id = "10"
+}
+
+import {
+  to = sonarr_quality_definition.bluray_1080p_remux
+  id = "17"
+}
+
+import {
+  to = sonarr_quality_definition.webrip_2160p
+  id = "19"
+}
+
+import {
+  to = sonarr_quality_definition.webdl_2160p
+  id = "20"
+}
+
+import {
+  to = sonarr_quality_definition.bluray_2160p
+  id = "21"
+}
+
+import {
+  to = sonarr_quality_definition.bluray_2160p_remux
+  id = "22"
+}

--- a/terraform/sonarr/quality-definitions.tf
+++ b/terraform/sonarr/quality-definitions.tf
@@ -1,0 +1,66 @@
+# Per-quality size ceilings (MB per minute of runtime).
+# IDs and titles fetched 2026-08-18 via kubectl exec sonarr /api/v3/qualitydefinition
+#
+# Only the tiers that were previously uncapped (max = null, i.e. unlimited) are
+# managed here. The 1080p tiers already carry sane caps (HDTV 125, WEBRip/WEBDL 130,
+# Bluray 155) and HDTV-2160p is at Sonarr's own 199.9 default — all left untouched.
+#
+# TV is where uncapped growth hurts most: 3,934 episode files at 1.37 GB average
+# today, and every Sonarr profile allows every quality up to Bluray-2160p Remux
+# (see the KNOWN DEFECT note in quality-profiles.tf). These ceilings are the only
+# thing bounding that now that upgrade_allowed is true.
+#
+# Reference points, for a 45-minute episode:
+#   200 MB/min = 9 GB      300 MB/min = 13.5 GB
+#   250 MB/min = 11 GB     350 MB/min = 15.75 GB
+#
+# min_size and preferred_size are carried over from live state unchanged; only
+# max_size is being introduced.
+
+resource "sonarr_quality_definition" "raw_hd" {
+  id             = 10
+  title          = "Raw-HD"
+  min_size       = 4
+  max_size       = 200
+  preferred_size = 95
+}
+
+resource "sonarr_quality_definition" "bluray_1080p_remux" {
+  id             = 17
+  title          = "Bluray-1080p Remux"
+  min_size       = 35
+  max_size       = 200
+  preferred_size = 95
+}
+
+resource "sonarr_quality_definition" "webrip_2160p" {
+  id             = 19
+  title          = "WEBRip-2160p"
+  min_size       = 35
+  max_size       = 250
+  preferred_size = 95
+}
+
+resource "sonarr_quality_definition" "webdl_2160p" {
+  id             = 20
+  title          = "WEBDL-2160p"
+  min_size       = 35
+  max_size       = 250
+  preferred_size = 95
+}
+
+resource "sonarr_quality_definition" "bluray_2160p" {
+  id             = 21
+  title          = "Bluray-2160p"
+  min_size       = 35
+  max_size       = 300
+  preferred_size = 95
+}
+
+resource "sonarr_quality_definition" "bluray_2160p_remux" {
+  id             = 22
+  title          = "Bluray-2160p Remux"
+  min_size       = 35
+  max_size       = 350
+  preferred_size = 95
+}

--- a/terraform/sonarr/quality-profiles.tf
+++ b/terraform/sonarr/quality-profiles.tf
@@ -4,12 +4,25 @@
 # Note: all 18 quality groups are included in every profile because Sonarr's API always returns
 # the full quality list per profile (with per-quality allowed flags). Unlike Radarr, omitting
 # non-allowed qualities causes drift on import.
+#
+# KNOWN DEFECT, not addressed here: live state has *every* quality flagged allowed on *every*
+# profile (verified 2026-08-18 against /api/v3/qualityprofile), so the names SD / HD-720p /
+# HD-1080p / Ultra-HD / HD - 720p/1080p currently describe nothing — all six behave identically
+# and differ only by cutoff. Radarr's equivalent profiles are still correctly restricted.
+# Restoring the per-profile quality lists means dropping the ignore_changes below and rewriting
+# quality_groups, which reorders quality ranking for the whole TV library — its own PR.
+#
+# upgrade_allowed is true on every profile. With it false (the previous state) Sonarr treats the
+# highest allowed quality as the cutoff, so any existing file "meets cutoff" and nothing is ever
+# upgraded. The previous cutoffs compounded this: each was pinned to the *lowest* quality in its
+# list (SDTV / HDTV-720p / HDTV-1080p / HDTV-2160p) under a comment saying "cutoff irrelevant",
+# which is only true while upgrades are off.
 
-# Profile: Any (id=1) — all qualities allowed except Unknown, Raw-HD, 2160p, upgrade disabled
+# Profile: Any (id=1) — 82 of 88 series. Every quality is allowed live, up to Bluray-2160p Remux.
 resource "sonarr_quality_profile" "any" {
   name            = "Any"
-  upgrade_allowed = false
-  cutoff          = 1 # upgrade_allowed = false, cutoff irrelevant
+  upgrade_allowed = true
+  cutoff          = 7 # Bluray-1080p — stop upgrading once a 1080p Blu-ray is in place
   lifecycle { ignore_changes = [quality_groups] }
 
   quality_groups = [
@@ -104,11 +117,11 @@ resource "sonarr_quality_profile" "any" {
   ]
 }
 
-# Profile: SD (id=2) — SD qualities allowed (SDTV, WEB 480p, DVD, Bluray 480p/576p), no upgrade
+# Profile: SD (id=2) — unused (0 series).
 resource "sonarr_quality_profile" "sd" {
   name            = "SD"
-  upgrade_allowed = false
-  cutoff          = 1 # upgrade_allowed = false, cutoff irrelevant
+  upgrade_allowed = true
+  cutoff          = 22 # Bluray-576p
   lifecycle { ignore_changes = [quality_groups] }
 
   quality_groups = [
@@ -203,11 +216,11 @@ resource "sonarr_quality_profile" "sd" {
   ]
 }
 
-# Profile: HD-720p (id=3) — 720p qualities allowed (HDTV-720p, WEB 720p, Bluray-720p), no upgrade
+# Profile: HD-720p (id=3) — unused (0 series).
 resource "sonarr_quality_profile" "hd_720p" {
   name            = "HD-720p"
-  upgrade_allowed = false
-  cutoff          = 4 # upgrade_allowed = false, cutoff irrelevant
+  upgrade_allowed = true
+  cutoff          = 6 # Bluray-720p
   lifecycle { ignore_changes = [quality_groups] }
 
   quality_groups = [
@@ -302,11 +315,11 @@ resource "sonarr_quality_profile" "hd_720p" {
   ]
 }
 
-# Profile: HD-1080p (id=4) — 1080p qualities allowed (HDTV-1080p, WEB 1080p, Bluray-1080p), no upgrade
+# Profile: HD-1080p (id=4) — unused (0 series).
 resource "sonarr_quality_profile" "hd_1080p" {
   name            = "HD-1080p"
-  upgrade_allowed = false
-  cutoff          = 9 # upgrade_allowed = false, cutoff irrelevant
+  upgrade_allowed = true
+  cutoff          = 7 # Bluray-1080p — stops short of Bluray-1080p Remux
   lifecycle { ignore_changes = [quality_groups] }
 
   quality_groups = [
@@ -401,11 +414,11 @@ resource "sonarr_quality_profile" "hd_1080p" {
   ]
 }
 
-# Profile: Ultra-HD (id=5) — 4K qualities allowed (HDTV-2160p, WEB 2160p, Bluray-2160p), no upgrade
+# Profile: Ultra-HD (id=5) — unused (0 series).
 resource "sonarr_quality_profile" "ultra_hd" {
   name            = "Ultra-HD"
-  upgrade_allowed = false
-  cutoff          = 16 # upgrade_allowed = false, cutoff irrelevant
+  upgrade_allowed = true
+  cutoff          = 19 # Bluray-2160p — stops short of Bluray-2160p Remux
   lifecycle { ignore_changes = [quality_groups] }
 
   quality_groups = [
@@ -500,11 +513,11 @@ resource "sonarr_quality_profile" "ultra_hd" {
   ]
 }
 
-# Profile: HD - 720p/1080p (id=6) — 720p and 1080p qualities allowed, no upgrade
+# Profile: HD - 720p/1080p (id=6) — 6 series.
 resource "sonarr_quality_profile" "hd_720p_1080p" {
   name            = "HD - 720p/1080p"
-  upgrade_allowed = false
-  cutoff          = 4 # upgrade_allowed = false, cutoff irrelevant
+  upgrade_allowed = true
+  cutoff          = 7 # Bluray-1080p — was 4 (HDTV-720p), which capped this profile at 720p
   lifecycle { ignore_changes = [quality_groups] }
 
   quality_groups = [


### PR DESCRIPTION
## Why

Every quality profile in both apps had `upgrade_allowed = false`. With that off the arrs treat the **highest allowed quality** as the cutoff, so any existing file "meets cutoff" and no release is ever grabbed as a replacement. A 720p file stays 720p forever no matter how many searches you run.

Found while replacing "The Drama (2026)" — a 720p WEB-DL that Jellyfin can't play on the Apple TV because it is genuinely anamorphic (SAR 333:320). Radarr found 153 releases and rejected all 71 of the 1080p ones with:

```
['Existing file meets cutoff: Remux-1080p []']
```

The cutoffs compounded it:

| | before | problem |
|---|---|---|
| radarr `Any` | `20` | id 20 is **Bluray-480p**; the comment claimed Bluray-1080p (that's id 7) |
| radarr `HD - 720p/1080p` | `6` | Bluray-720p — the profile could never reach 1080p even with upgrades on |
| radarr `Ultra-HD` | `31` | Remux-2160p — never satisfied below a 50-90 GB file |
| all sonarr | lowest id in list | pinned to SDTV / HDTV-720p / HDTV-1080p / HDTV-2160p under a comment saying "cutoff irrelevant", which is only true while upgrades are off |

## Why the size ceilings come with it

Enabling upgrades without ceilings would be worse than leaving it broken. `Any` covers **519 of 589 movies** and **82 of 88 series**, allows every tier up to Remux-2160p, and every quality above 1080p had `maxSize = null`. An item below cutoff takes the best allowed release it sees, so 4K remuxes were reachable for the entire library.

Measured before/after, per minute of runtime:

| | radarr | sonarr |
|---|---|---|
| Bluray-1080p | null → **200** | already 155 |
| Remux-1080p / Bluray-1080p Remux | null → **250** | null → **200** |
| HDTV-2160p | null → **250** | already 199.9 |
| WEBDL-2160p / WEBRip-2160p | null → **250** | null → **250** |
| Bluray-2160p | null → **300** | null → **300** |
| Remux-2160p / Bluray-2160p Remux | null → **350** | null → **350** |
| BR-DISK | null → **300** | — |
| Raw-HD | — | null → **200** |

Every value is under 400 on purpose: Radarr's slider reads 400 as *Unlimited*, so a literal 400 would defeat the cap.

For a 110-minute film these admit all the observed 4K WEB-DLs (20-26 GB) and the x265 Blu-rays, and in practice exclude 4K remuxes, which ran 50-90 GB.

## Blast radius

- **Movies:** 3.12 TB on disk, **315 of 589 below a 1080p cutoff** (79 SDTV, 64 DVD, 53 WEBDL-720p, 37 Bluray-720p, 28 HDTV-720p…).
- **TV:** 5.37 TB, 3,934 episode files, 1.37 GB average.
- **Free space is shared:** `/movies` and `/tv` both report **13 T avail** on the same pool.

RSS sync only sees newly-posted releases, so this arrives gradually rather than as one wave — but running *Search Monitored* after this merges would not be gradual. Worth watching pool free space over the next week.

## Known defect documented, not fixed

Live Sonarr state has **every quality flagged allowed on every profile** (verified against `/api/v3/qualityprofile`), so `SD` / `HD-720p` / `HD-1080p` / `Ultra-HD` / `HD - 720p/1080p` currently describe nothing — all six behave identically and differ only by cutoff. Radarr's equivalents are still correctly restricted. Restoring the per-profile lists means dropping `ignore_changes` and rewriting `quality_groups`, which reorders quality ranking for the whole TV library, so it belongs in its own PR. Noted in the file header.

## Verification

The repo's CI does not check terraform, and tofu-controller runs `approvePlan: auto` — a merge applies straight to the live instances. So both roots were checked locally against the providers that will actually resolve:

```
tofu fmt -check -recursive   -> clean
radarr  validate: Success! The configuration is valid.   (devopsarr/radarr 2.4.0)
sonarr  validate: Success! The configuration is valid.   (devopsarr/sonarr 3.4.2)
```

Quality-definition IDs and titles were read from each app's live `/api/v3/qualitydefinition`. They are built-in rows that can only be updated, never created, so each gets an `import` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014H1QY7REDHYX2AcRuDuSnF