### PR TITLE
fix(metallb): make the frr liveness timeout we already asked for actually apply

### DIFF
--- a/clusters/vollminlab-cluster/metallb-system/metallb/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/metallb-system/metallb/app/helmrelease.yaml
@@ -21,3 +21,45 @@ spec:
     - kind: ConfigMap
       name: metallb-values
       valuesKey: values.yaml
+  # The chart drops livenessProbe.timeoutSeconds for the frr container.
+  #
+  # configmap.yaml has asked for `frrk8s.livenessProbe.timeoutSeconds: 5` for a
+  # while and it silently only half-applied: frr-k8s's controller.yaml renders
+  # timeoutSeconds for the `controller` container but, for the `frr` container,
+  # emits only periodSeconds and failureThreshold. So frr kept Kubernetes'
+  # 1s default while controller correctly got 5s -- verified on the live
+  # DaemonSet, where failureThreshold=6 landed on BOTH containers and
+  # timeoutSeconds=5 landed on only one.
+  #
+  # A 1s timeout on an HTTPS probe is tripped by ordinary I/O stalls rather than
+  # by an unhealthy BGP daemon. On 2026-08-15 at 03:27 the frr containers on
+  # k8sworker01 and k8sworker04 were SIGTERMed (exit 143) within one second of
+  # each other, inside the 03:00 velero daily-full window -- a node-wide stall,
+  # not two independent frr failures. Restarting frr flaps BGP, so the probe was
+  # making a busy node worse.
+  #
+  # failureThreshold 6 x periodSeconds 10 still detects a genuinely hung frr in
+  # ~60s, so this loosens the per-attempt deadline without weakening detection.
+  # Remove this patch once the chart templates timeoutSeconds for frr.
+  # Strategic-merge, keyed by container name: kustomize merges containers by
+  # `name`, so this survives the chart reordering them. A JSON-patch index would
+  # not -- `frr` is currently index 1, behind `controller`, and ahead of
+  # reloader/frr-metrics/frr-status.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: DaemonSet
+              name: metallb-frr-k8s
+            patch: |
+              apiVersion: apps/v1
+              kind: DaemonSet
+              metadata:
+                name: metallb-frr-k8s
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: frr
+                        livenessProbe:
+                          timeoutSeconds: 5


### PR DESCRIPTION
## The bug

`configmap.yaml` already sets `frrk8s.livenessProbe.timeoutSeconds: 5`. It has only ever **half-applied**:

| container | timeoutSeconds | failureThreshold |
|---|---|---|
| controller | **5** | 6 |
| frr | **1** | 6 |

`failureThreshold: 6` reached *both* containers, so the values are being consumed correctly. The chart simply never renders `timeoutSeconds` for the `frr` container — frr-k8s's `controller.yaml` emits only `periodSeconds` and `failureThreshold` there, while the `controller` container gets the full set.

Rendering the chart locally with our real values confirms it — the frr probe comes out with **no `timeoutSeconds` key at all**, so Kubernetes defaults it to 1s:

```
{'httpGet': {'path': '/livez', 'port': 9141, 'scheme': 'HTTPS'},
 'periodSeconds': 10, 'failureThreshold': 6}
```

## Why it matters

A 1-second deadline on an HTTPS probe measures **node responsiveness, not BGP health**.

On 2026-08-15 at 03:27 the frr containers on `k8sworker01` and `k8sworker04` were SIGTERMed (exit 143) **within one second of each other** — inside the 03:00 velero `daily-full` window. That's one node-wide I/O stall, not two independent frr failures. Restarting frr flaps BGP, so the probe was making a loaded node worse rather than recovering anything.

Restart counts track node pressure, not frr: `k8sworker02` 39, `k8sworker03` 15, `k8sworker01` 6, `k8sworker04` 5, control planes 1–3. (w02 being the outlier is consistent with its known memory pressure.)

## The fix

A `postRenderer` — no Helm value can reach the field. The repo already uses this pattern in five HelmReleases.

**Keyed by container name, not index.** Kustomize merges containers by `name`, so it survives the chart reordering them. An index-based JSON patch would have been wrong: `frr` is index **1**, behind `controller` and ahead of `reloader`/`frr-metrics`/`frr-status`.

## Verification

Applied the patch to the rendered chart and confirmed the result:

```
frr: {'failureThreshold': 6, 'httpGet': {...}, 'periodSeconds': 10, 'timeoutSeconds': 5}
```

`timeoutSeconds` lands; `failureThreshold`, `periodSeconds` and `httpGet` are all preserved. yamllint clean, `kubectl kustomize` builds, server-side dry-run accepted.

## Detection is unchanged

`failureThreshold: 6` × `periodSeconds: 10` still catches a genuinely hung frr in ~60s. This loosens the per-attempt deadline, not the detection window.

**Expect one frr rollout on apply.** Remove this patch once the chart templates `timeoutSeconds` for frr — worth an upstream issue.