### PR TITLE
fix(radarr,sonarr): un-invert the quality ranking so upgrades can actually happen

### DIFF
--- a/terraform/radarr/quality-profiles.tf
+++ b/terraform/radarr/quality-profiles.tf
@@ -2,6 +2,34 @@
 # Retrieved 2026-05-14 via kubectl exec radarr /api/v3/qualityprofile
 # language id=1 = English
 #
+# ORDERING IS DELIBERATELY BEST-FIRST. DO NOT "FIX" IT TO READ WORST-FIRST.
+#
+# Radarr and Sonarr rank quality by position in this list, index 0 = WORST. But the
+# devopsarr provider writes the list REVERSED, so what you put here comes out backwards
+# in the app. Listing best-first is what produces a correct worst-first ranking live.
+#
+# Measured 2026-08-18 on two profiles independently: the tf order was worst-first, and
+# the live API read back the exact reverse in both cases. The API itself round-trips
+# order faithfully (verified by POSTing a scratch profile with a known order and reading
+# it back), so the reversal is the provider's, not the API's.
+#
+# The cost of getting this backwards is not cosmetic. Before this change every profile
+# was inverted live: WEBDL-720p outranked Bluray-1080p, so Radarr reported
+# `qualityCutoffNotMet: false` for 720p files and rejected all 97 candidate releases with
+# "Existing file meets cutoff" — only 1 of ~315 sub-1080p movies was eligible to upgrade.
+# In the "Any" profile it also meant WORKPRINT ranked 29 and CAM 28 against Remux-2160p
+# at 3: a cam rip beat a 4K remux.
+#
+# `lifecycle { ignore_changes = [quality_groups] }` used to sit on every profile here and
+# is why the inversion survived from the 2026-05-14 import until now. Do not re-add it —
+# it hides exactly this class of bug.
+#
+# To verify after any change to this file, read the live order back and confirm index 0
+# is the worst quality:
+#   kubectl exec -n mediastack <pod> -c <app> -- sh -c \
+#     "curl -s -H 'X-Api-Key: $KEY' 'http://localhost:<port>/api/v3/qualityprofile/1'" \
+#     | python3 -c "import json,sys;print([i.get('quality',{}).get('name') for i in json.load(sys.stdin)['items']][:4])"
+#
 # upgrade_allowed is true on every profile. With it false (the previous state)
 # Radarr treats the *highest allowed quality* as the cutoff, so any existing file
 # "meets cutoff" and no release is ever grabbed as a replacement — a 720p file
@@ -16,7 +44,6 @@ resource "radarr_quality_profile" "any" {
   name            = "Any"
   upgrade_allowed = true
   cutoff          = 7 # Bluray-1080p — stop upgrading once a 1080p Blu-ray is in place
-  lifecycle { ignore_changes = [quality_groups] }
 
   language = {
     id = 1
@@ -24,96 +51,12 @@ resource "radarr_quality_profile" "any" {
 
   quality_groups = [
     {
-      name      = "WORKPRINT"
-      qualities = [{ id = 24, name = "WORKPRINT", source = "workprint", resolution = 0 }]
+      name      = "Remux-2160p"
+      qualities = [{ id = 31, name = "Remux-2160p", source = "bluray", resolution = 2160 }]
     },
     {
-      name      = "CAM"
-      qualities = [{ id = 25, name = "CAM", source = "cam", resolution = 0 }]
-    },
-    {
-      name      = "TELESYNC"
-      qualities = [{ id = 26, name = "TELESYNC", source = "telesync", resolution = 0 }]
-    },
-    {
-      name      = "TELECINE"
-      qualities = [{ id = 27, name = "TELECINE", source = "telecine", resolution = 0 }]
-    },
-    {
-      name      = "REGIONAL"
-      qualities = [{ id = 29, name = "REGIONAL", source = "dvd", resolution = 480 }]
-    },
-    {
-      name      = "DVDSCR"
-      qualities = [{ id = 28, name = "DVDSCR", source = "dvd", resolution = 480 }]
-    },
-    {
-      name      = "SDTV"
-      qualities = [{ id = 1, name = "SDTV", source = "tv", resolution = 480 }]
-    },
-    {
-      name      = "DVD"
-      qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 0 }]
-    },
-    {
-      name      = "DVD-R"
-      qualities = [{ id = 23, name = "DVD-R", source = "dvd", resolution = 480 }]
-    },
-    {
-      id   = 1000
-      name = "WEB 480p"
-      qualities = [
-        { id = 8, name = "WEBDL-480p", source = "webdl", resolution = 480 },
-        { id = 12, name = "WEBRip-480p", source = "webrip", resolution = 480 },
-      ]
-    },
-    {
-      name      = "Bluray-480p"
-      qualities = [{ id = 20, name = "Bluray-480p", source = "bluray", resolution = 480 }]
-    },
-    {
-      name      = "Bluray-576p"
-      qualities = [{ id = 21, name = "Bluray-576p", source = "bluray", resolution = 576 }]
-    },
-    {
-      name      = "HDTV-720p"
-      qualities = [{ id = 4, name = "HDTV-720p", source = "tv", resolution = 720 }]
-    },
-    {
-      id   = 1001
-      name = "WEB 720p"
-      qualities = [
-        { id = 5, name = "WEBDL-720p", source = "webdl", resolution = 720 },
-        { id = 14, name = "WEBRip-720p", source = "webrip", resolution = 720 },
-      ]
-    },
-    {
-      name      = "Bluray-720p"
-      qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
-    },
-    {
-      name      = "HDTV-1080p"
-      qualities = [{ id = 9, name = "HDTV-1080p", source = "tv", resolution = 1080 }]
-    },
-    {
-      id   = 1002
-      name = "WEB 1080p"
-      qualities = [
-        { id = 3, name = "WEBDL-1080p", source = "webdl", resolution = 1080 },
-        { id = 15, name = "WEBRip-1080p", source = "webrip", resolution = 1080 },
-      ]
-    },
-    {
-      name      = "Bluray-1080p"
-      qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
-    },
-    {
-      name      = "Remux-1080p"
-      qualities = [{ id = 30, name = "Remux-1080p", source = "bluray", resolution = 1080 }]
-    },
-    {
-      name      = "HDTV-2160p"
-      qualities = [{ id = 16, name = "HDTV-2160p", source = "tv", resolution = 2160 }]
+      name      = "Bluray-2160p"
+      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
     },
     {
       id   = 1003
@@ -124,12 +67,96 @@ resource "radarr_quality_profile" "any" {
       ]
     },
     {
-      name      = "Bluray-2160p"
-      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
+      name      = "HDTV-2160p"
+      qualities = [{ id = 16, name = "HDTV-2160p", source = "tv", resolution = 2160 }]
     },
     {
-      name      = "Remux-2160p"
-      qualities = [{ id = 31, name = "Remux-2160p", source = "bluray", resolution = 2160 }]
+      name      = "Remux-1080p"
+      qualities = [{ id = 30, name = "Remux-1080p", source = "bluray", resolution = 1080 }]
+    },
+    {
+      name      = "Bluray-1080p"
+      qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
+    },
+    {
+      id   = 1002
+      name = "WEB 1080p"
+      qualities = [
+        { id = 3, name = "WEBDL-1080p", source = "webdl", resolution = 1080 },
+        { id = 15, name = "WEBRip-1080p", source = "webrip", resolution = 1080 },
+      ]
+    },
+    {
+      name      = "HDTV-1080p"
+      qualities = [{ id = 9, name = "HDTV-1080p", source = "tv", resolution = 1080 }]
+    },
+    {
+      name      = "Bluray-720p"
+      qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
+    },
+    {
+      id   = 1001
+      name = "WEB 720p"
+      qualities = [
+        { id = 5, name = "WEBDL-720p", source = "webdl", resolution = 720 },
+        { id = 14, name = "WEBRip-720p", source = "webrip", resolution = 720 },
+      ]
+    },
+    {
+      name      = "HDTV-720p"
+      qualities = [{ id = 4, name = "HDTV-720p", source = "tv", resolution = 720 }]
+    },
+    {
+      name      = "Bluray-576p"
+      qualities = [{ id = 21, name = "Bluray-576p", source = "bluray", resolution = 576 }]
+    },
+    {
+      name      = "Bluray-480p"
+      qualities = [{ id = 20, name = "Bluray-480p", source = "bluray", resolution = 480 }]
+    },
+    {
+      id   = 1000
+      name = "WEB 480p"
+      qualities = [
+        { id = 8, name = "WEBDL-480p", source = "webdl", resolution = 480 },
+        { id = 12, name = "WEBRip-480p", source = "webrip", resolution = 480 },
+      ]
+    },
+    {
+      name      = "DVD-R"
+      qualities = [{ id = 23, name = "DVD-R", source = "dvd", resolution = 480 }]
+    },
+    {
+      name      = "DVD"
+      qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 0 }]
+    },
+    {
+      name      = "SDTV"
+      qualities = [{ id = 1, name = "SDTV", source = "tv", resolution = 480 }]
+    },
+    {
+      name      = "DVDSCR"
+      qualities = [{ id = 28, name = "DVDSCR", source = "dvd", resolution = 480 }]
+    },
+    {
+      name      = "REGIONAL"
+      qualities = [{ id = 29, name = "REGIONAL", source = "dvd", resolution = 480 }]
+    },
+    {
+      name      = "TELECINE"
+      qualities = [{ id = 27, name = "TELECINE", source = "telecine", resolution = 0 }]
+    },
+    {
+      name      = "TELESYNC"
+      qualities = [{ id = 26, name = "TELESYNC", source = "telesync", resolution = 0 }]
+    },
+    {
+      name      = "CAM"
+      qualities = [{ id = 25, name = "CAM", source = "cam", resolution = 0 }]
+    },
+    {
+      name      = "WORKPRINT"
+      qualities = [{ id = 24, name = "WORKPRINT", source = "workprint", resolution = 0 }]
     },
   ]
 }
@@ -139,7 +166,6 @@ resource "radarr_quality_profile" "sd" {
   name            = "SD"
   upgrade_allowed = true
   cutoff          = 21 # Bluray-576p — top of this profile's own list
-  lifecycle { ignore_changes = [quality_groups] }
 
   language = {
     id = 1
@@ -147,36 +173,12 @@ resource "radarr_quality_profile" "sd" {
 
   quality_groups = [
     {
-      name      = "WORKPRINT"
-      qualities = [{ id = 24, name = "WORKPRINT", source = "workprint", resolution = 0 }]
+      name      = "Bluray-576p"
+      qualities = [{ id = 21, name = "Bluray-576p", source = "bluray", resolution = 576 }]
     },
     {
-      name      = "CAM"
-      qualities = [{ id = 25, name = "CAM", source = "cam", resolution = 0 }]
-    },
-    {
-      name      = "TELESYNC"
-      qualities = [{ id = 26, name = "TELESYNC", source = "telesync", resolution = 0 }]
-    },
-    {
-      name      = "TELECINE"
-      qualities = [{ id = 27, name = "TELECINE", source = "telecine", resolution = 0 }]
-    },
-    {
-      name      = "REGIONAL"
-      qualities = [{ id = 29, name = "REGIONAL", source = "dvd", resolution = 480 }]
-    },
-    {
-      name      = "DVDSCR"
-      qualities = [{ id = 28, name = "DVDSCR", source = "dvd", resolution = 480 }]
-    },
-    {
-      name      = "SDTV"
-      qualities = [{ id = 1, name = "SDTV", source = "tv", resolution = 480 }]
-    },
-    {
-      name      = "DVD"
-      qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 0 }]
+      name      = "Bluray-480p"
+      qualities = [{ id = 20, name = "Bluray-480p", source = "bluray", resolution = 480 }]
     },
     {
       id   = 1000
@@ -187,12 +189,36 @@ resource "radarr_quality_profile" "sd" {
       ]
     },
     {
-      name      = "Bluray-480p"
-      qualities = [{ id = 20, name = "Bluray-480p", source = "bluray", resolution = 480 }]
+      name      = "DVD"
+      qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 0 }]
     },
     {
-      name      = "Bluray-576p"
-      qualities = [{ id = 21, name = "Bluray-576p", source = "bluray", resolution = 576 }]
+      name      = "SDTV"
+      qualities = [{ id = 1, name = "SDTV", source = "tv", resolution = 480 }]
+    },
+    {
+      name      = "DVDSCR"
+      qualities = [{ id = 28, name = "DVDSCR", source = "dvd", resolution = 480 }]
+    },
+    {
+      name      = "REGIONAL"
+      qualities = [{ id = 29, name = "REGIONAL", source = "dvd", resolution = 480 }]
+    },
+    {
+      name      = "TELECINE"
+      qualities = [{ id = 27, name = "TELECINE", source = "telecine", resolution = 0 }]
+    },
+    {
+      name      = "TELESYNC"
+      qualities = [{ id = 26, name = "TELESYNC", source = "telesync", resolution = 0 }]
+    },
+    {
+      name      = "CAM"
+      qualities = [{ id = 25, name = "CAM", source = "cam", resolution = 0 }]
+    },
+    {
+      name      = "WORKPRINT"
+      qualities = [{ id = 24, name = "WORKPRINT", source = "workprint", resolution = 0 }]
     },
   ]
 }
@@ -202,7 +228,6 @@ resource "radarr_quality_profile" "hd_720p" {
   name            = "HD-720p"
   upgrade_allowed = true
   cutoff          = 6 # Bluray-720p — top of this profile's own list
-  lifecycle { ignore_changes = [quality_groups] }
 
   language = {
     id = 1
@@ -210,8 +235,8 @@ resource "radarr_quality_profile" "hd_720p" {
 
   quality_groups = [
     {
-      name      = "HDTV-720p"
-      qualities = [{ id = 4, name = "HDTV-720p", source = "tv", resolution = 720 }]
+      name      = "Bluray-720p"
+      qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
     },
     {
       id   = 1001
@@ -222,8 +247,8 @@ resource "radarr_quality_profile" "hd_720p" {
       ]
     },
     {
-      name      = "Bluray-720p"
-      qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
+      name      = "HDTV-720p"
+      qualities = [{ id = 4, name = "HDTV-720p", source = "tv", resolution = 720 }]
     },
   ]
 }
@@ -233,7 +258,6 @@ resource "radarr_quality_profile" "hd_1080p" {
   name            = "HD-1080p"
   upgrade_allowed = true
   cutoff          = 7 # Bluray-1080p — stops short of Remux-1080p (32-39 GB)
-  lifecycle { ignore_changes = [quality_groups] }
 
   language = {
     id = 1
@@ -241,8 +265,12 @@ resource "radarr_quality_profile" "hd_1080p" {
 
   quality_groups = [
     {
-      name      = "HDTV-1080p"
-      qualities = [{ id = 9, name = "HDTV-1080p", source = "tv", resolution = 1080 }]
+      name      = "Remux-1080p"
+      qualities = [{ id = 30, name = "Remux-1080p", source = "bluray", resolution = 1080 }]
+    },
+    {
+      name      = "Bluray-1080p"
+      qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
     },
     {
       id   = 1002
@@ -253,12 +281,8 @@ resource "radarr_quality_profile" "hd_1080p" {
       ]
     },
     {
-      name      = "Bluray-1080p"
-      qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
-    },
-    {
-      name      = "Remux-1080p"
-      qualities = [{ id = 30, name = "Remux-1080p", source = "bluray", resolution = 1080 }]
+      name      = "HDTV-1080p"
+      qualities = [{ id = 9, name = "HDTV-1080p", source = "tv", resolution = 1080 }]
     },
   ]
 }
@@ -268,7 +292,6 @@ resource "radarr_quality_profile" "ultra_hd" {
   name            = "Ultra-HD"
   upgrade_allowed = true
   cutoff          = 19 # Bluray-2160p — stops short of Remux-2160p (50-90 GB)
-  lifecycle { ignore_changes = [quality_groups] }
 
   language = {
     id = 1
@@ -276,8 +299,12 @@ resource "radarr_quality_profile" "ultra_hd" {
 
   quality_groups = [
     {
-      name      = "HDTV-2160p"
-      qualities = [{ id = 16, name = "HDTV-2160p", source = "tv", resolution = 2160 }]
+      name      = "Remux-2160p"
+      qualities = [{ id = 31, name = "Remux-2160p", source = "bluray", resolution = 2160 }]
+    },
+    {
+      name      = "Bluray-2160p"
+      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
     },
     {
       id   = 1003
@@ -288,12 +315,8 @@ resource "radarr_quality_profile" "ultra_hd" {
       ]
     },
     {
-      name      = "Bluray-2160p"
-      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
-    },
-    {
-      name      = "Remux-2160p"
-      qualities = [{ id = 31, name = "Remux-2160p", source = "bluray", resolution = 2160 }]
+      name      = "HDTV-2160p"
+      qualities = [{ id = 16, name = "HDTV-2160p", source = "tv", resolution = 2160 }]
     },
   ]
 }
@@ -303,7 +326,6 @@ resource "radarr_quality_profile" "hd_720p_1080p" {
   name            = "HD - 720p/1080p"
   upgrade_allowed = true
   cutoff          = 7 # Bluray-1080p — was 6 (Bluray-720p), which capped this profile at 720p
-  lifecycle { ignore_changes = [quality_groups] }
 
   language = {
     id = 1
@@ -311,24 +333,12 @@ resource "radarr_quality_profile" "hd_720p_1080p" {
 
   quality_groups = [
     {
-      name      = "HDTV-720p"
-      qualities = [{ id = 4, name = "HDTV-720p", source = "tv", resolution = 720 }]
+      name      = "Remux-1080p"
+      qualities = [{ id = 30, name = "Remux-1080p", source = "bluray", resolution = 1080 }]
     },
     {
-      id   = 1001
-      name = "WEB 720p"
-      qualities = [
-        { id = 5, name = "WEBDL-720p", source = "webdl", resolution = 720 },
-        { id = 14, name = "WEBRip-720p", source = "webrip", resolution = 720 },
-      ]
-    },
-    {
-      name      = "Bluray-720p"
-      qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
-    },
-    {
-      name      = "HDTV-1080p"
-      qualities = [{ id = 9, name = "HDTV-1080p", source = "tv", resolution = 1080 }]
+      name      = "Bluray-1080p"
+      qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
     },
     {
       id   = 1002
@@ -339,12 +349,24 @@ resource "radarr_quality_profile" "hd_720p_1080p" {
       ]
     },
     {
-      name      = "Bluray-1080p"
-      qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
+      name      = "HDTV-1080p"
+      qualities = [{ id = 9, name = "HDTV-1080p", source = "tv", resolution = 1080 }]
     },
     {
-      name      = "Remux-1080p"
-      qualities = [{ id = 30, name = "Remux-1080p", source = "bluray", resolution = 1080 }]
+      name      = "Bluray-720p"
+      qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
+    },
+    {
+      id   = 1001
+      name = "WEB 720p"
+      qualities = [
+        { id = 5, name = "WEBDL-720p", source = "webdl", resolution = 720 },
+        { id = 14, name = "WEBRip-720p", source = "webrip", resolution = 720 },
+      ]
+    },
+    {
+      name      = "HDTV-720p"
+      qualities = [{ id = 4, name = "HDTV-720p", source = "tv", resolution = 720 }]
     },
   ]
 }

--- a/terraform/sonarr/quality-profiles.tf
+++ b/terraform/sonarr/quality-profiles.tf
@@ -5,12 +5,40 @@
 # the full quality list per profile (with per-quality allowed flags). Unlike Radarr, omitting
 # non-allowed qualities causes drift on import.
 #
-# KNOWN DEFECT, not addressed here: live state has *every* quality flagged allowed on *every*
-# profile (verified 2026-08-18 against /api/v3/qualityprofile), so the names SD / HD-720p /
-# HD-1080p / Ultra-HD / HD - 720p/1080p currently describe nothing — all six behave identically
-# and differ only by cutoff. Radarr's equivalent profiles are still correctly restricted.
-# Restoring the per-profile quality lists means dropping the ignore_changes below and rewriting
-# quality_groups, which reorders quality ranking for the whole TV library — its own PR.
+# ORDERING IS DELIBERATELY BEST-FIRST. DO NOT "FIX" IT TO READ WORST-FIRST.
+#
+# Radarr and Sonarr rank quality by position in this list, index 0 = WORST. But the
+# devopsarr provider writes the list REVERSED, so what you put here comes out backwards
+# in the app. Listing best-first is what produces a correct worst-first ranking live.
+#
+# Measured 2026-08-18 on two profiles independently: the tf order was worst-first, and
+# the live API read back the exact reverse in both cases. The API itself round-trips
+# order faithfully (verified by POSTing a scratch profile with a known order and reading
+# it back), so the reversal is the provider's, not the API's.
+#
+# The cost of getting this backwards is not cosmetic. Before this change every profile
+# was inverted live: WEBDL-720p outranked Bluray-1080p, so Radarr reported
+# `qualityCutoffNotMet: false` for 720p files and rejected all 97 candidate releases with
+# "Existing file meets cutoff" — only 1 of ~315 sub-1080p movies was eligible to upgrade.
+# In the "Any" profile it also meant WORKPRINT ranked 29 and CAM 28 against Remux-2160p
+# at 3: a cam rip beat a 4K remux.
+#
+# `lifecycle { ignore_changes = [quality_groups] }` used to sit on every profile here and
+# is why the inversion survived from the 2026-05-14 import until now. Do not re-add it —
+# it hides exactly this class of bug.
+#
+# To verify after any change to this file, read the live order back and confirm index 0
+# is the worst quality:
+#   kubectl exec -n mediastack <pod> -c <app> -- sh -c \
+#     "curl -s -H 'X-Api-Key: $KEY' 'http://localhost:<port>/api/v3/qualityprofile/1'" \
+#     | python3 -c "import json,sys;print([i.get('quality',{}).get('name') for i in json.load(sys.stdin)['items']][:4])"
+#
+# KNOWN DEFECT, still not addressed here: live state has *every* quality flagged allowed on
+# *every* profile, so the names SD / HD-720p / HD-1080p / Ultra-HD / HD - 720p/1080p describe
+# nothing — all six differ only by cutoff. Radarr's equivalents are correctly restricted.
+# This PR fixes the *ranking* of those qualities, not *which* are allowed; narrowing them
+# would drop 4K from the 6 series on HD - 720p/1080p, which is a product decision, not a bug
+# fix, so it stays separate.
 #
 # upgrade_allowed is true on every profile. With it false (the previous state) Sonarr treats the
 # highest allowed quality as the cutoff, so any existing file "meets cutoff" and nothing is ever
@@ -23,80 +51,15 @@ resource "sonarr_quality_profile" "any" {
   name            = "Any"
   upgrade_allowed = true
   cutoff          = 7 # Bluray-1080p — stop upgrading once a 1080p Blu-ray is in place
-  lifecycle { ignore_changes = [quality_groups] }
 
   quality_groups = [
     {
-      name      = "Unknown"
-      qualities = [{ id = 0, name = "Unknown", source = "unknown", resolution = 0 }]
+      name      = "Bluray-2160p Remux"
+      qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
     },
     {
-      name      = "SDTV"
-      qualities = [{ id = 1, name = "SDTV", source = "television", resolution = 480 }]
-    },
-    {
-      id   = 1000
-      name = "WEB 480p"
-      qualities = [
-        { id = 12, name = "WEBRip-480p", source = "webRip", resolution = 480 },
-        { id = 8, name = "WEBDL-480p", source = "web", resolution = 480 },
-      ]
-    },
-    {
-      name      = "DVD"
-      qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 480 }]
-    },
-    {
-      name      = "Bluray-480p"
-      qualities = [{ id = 13, name = "Bluray-480p", source = "bluray", resolution = 480 }]
-    },
-    {
-      name      = "Bluray-576p"
-      qualities = [{ id = 22, name = "Bluray-576p", source = "bluray", resolution = 576 }]
-    },
-    {
-      name      = "HDTV-720p"
-      qualities = [{ id = 4, name = "HDTV-720p", source = "television", resolution = 720 }]
-    },
-    {
-      name      = "HDTV-1080p"
-      qualities = [{ id = 9, name = "HDTV-1080p", source = "television", resolution = 1080 }]
-    },
-    {
-      name      = "Raw-HD"
-      qualities = [{ id = 10, name = "Raw-HD", source = "televisionRaw", resolution = 1080 }]
-    },
-    {
-      id   = 1001
-      name = "WEB 720p"
-      qualities = [
-        { id = 14, name = "WEBRip-720p", source = "webRip", resolution = 720 },
-        { id = 5, name = "WEBDL-720p", source = "web", resolution = 720 },
-      ]
-    },
-    {
-      name      = "Bluray-720p"
-      qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
-    },
-    {
-      id   = 1002
-      name = "WEB 1080p"
-      qualities = [
-        { id = 15, name = "WEBRip-1080p", source = "webRip", resolution = 1080 },
-        { id = 3, name = "WEBDL-1080p", source = "web", resolution = 1080 },
-      ]
-    },
-    {
-      name      = "Bluray-1080p"
-      qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
-    },
-    {
-      name      = "Bluray-1080p Remux"
-      qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
-    },
-    {
-      name      = "HDTV-2160p"
-      qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
+      name      = "Bluray-2160p"
+      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
     },
     {
       id   = 1003
@@ -107,12 +70,76 @@ resource "sonarr_quality_profile" "any" {
       ]
     },
     {
-      name      = "Bluray-2160p"
-      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
+      name      = "HDTV-2160p"
+      qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
     },
     {
-      name      = "Bluray-2160p Remux"
-      qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
+      name      = "Bluray-1080p Remux"
+      qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
+    },
+    {
+      name      = "Bluray-1080p"
+      qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
+    },
+    {
+      id   = 1002
+      name = "WEB 1080p"
+      qualities = [
+        { id = 15, name = "WEBRip-1080p", source = "webRip", resolution = 1080 },
+        { id = 3, name = "WEBDL-1080p", source = "web", resolution = 1080 },
+      ]
+    },
+    {
+      name      = "Bluray-720p"
+      qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
+    },
+    {
+      id   = 1001
+      name = "WEB 720p"
+      qualities = [
+        { id = 14, name = "WEBRip-720p", source = "webRip", resolution = 720 },
+        { id = 5, name = "WEBDL-720p", source = "web", resolution = 720 },
+      ]
+    },
+    {
+      name      = "Raw-HD"
+      qualities = [{ id = 10, name = "Raw-HD", source = "televisionRaw", resolution = 1080 }]
+    },
+    {
+      name      = "HDTV-1080p"
+      qualities = [{ id = 9, name = "HDTV-1080p", source = "television", resolution = 1080 }]
+    },
+    {
+      name      = "HDTV-720p"
+      qualities = [{ id = 4, name = "HDTV-720p", source = "television", resolution = 720 }]
+    },
+    {
+      name      = "Bluray-576p"
+      qualities = [{ id = 22, name = "Bluray-576p", source = "bluray", resolution = 576 }]
+    },
+    {
+      name      = "Bluray-480p"
+      qualities = [{ id = 13, name = "Bluray-480p", source = "bluray", resolution = 480 }]
+    },
+    {
+      name      = "DVD"
+      qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 480 }]
+    },
+    {
+      id   = 1000
+      name = "WEB 480p"
+      qualities = [
+        { id = 12, name = "WEBRip-480p", source = "webRip", resolution = 480 },
+        { id = 8, name = "WEBDL-480p", source = "web", resolution = 480 },
+      ]
+    },
+    {
+      name      = "SDTV"
+      qualities = [{ id = 1, name = "SDTV", source = "television", resolution = 480 }]
+    },
+    {
+      name      = "Unknown"
+      qualities = [{ id = 0, name = "Unknown", source = "unknown", resolution = 0 }]
     },
   ]
 }
@@ -122,80 +149,15 @@ resource "sonarr_quality_profile" "sd" {
   name            = "SD"
   upgrade_allowed = true
   cutoff          = 22 # Bluray-576p
-  lifecycle { ignore_changes = [quality_groups] }
 
   quality_groups = [
     {
-      name      = "Unknown"
-      qualities = [{ id = 0, name = "Unknown", source = "unknown", resolution = 0 }]
+      name      = "Bluray-2160p Remux"
+      qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
     },
     {
-      name      = "SDTV"
-      qualities = [{ id = 1, name = "SDTV", source = "television", resolution = 480 }]
-    },
-    {
-      id   = 1000
-      name = "WEB 480p"
-      qualities = [
-        { id = 12, name = "WEBRip-480p", source = "webRip", resolution = 480 },
-        { id = 8, name = "WEBDL-480p", source = "web", resolution = 480 },
-      ]
-    },
-    {
-      name      = "DVD"
-      qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 480 }]
-    },
-    {
-      name      = "Bluray-480p"
-      qualities = [{ id = 13, name = "Bluray-480p", source = "bluray", resolution = 480 }]
-    },
-    {
-      name      = "Bluray-576p"
-      qualities = [{ id = 22, name = "Bluray-576p", source = "bluray", resolution = 576 }]
-    },
-    {
-      name      = "HDTV-720p"
-      qualities = [{ id = 4, name = "HDTV-720p", source = "television", resolution = 720 }]
-    },
-    {
-      name      = "HDTV-1080p"
-      qualities = [{ id = 9, name = "HDTV-1080p", source = "television", resolution = 1080 }]
-    },
-    {
-      name      = "Raw-HD"
-      qualities = [{ id = 10, name = "Raw-HD", source = "televisionRaw", resolution = 1080 }]
-    },
-    {
-      id   = 1001
-      name = "WEB 720p"
-      qualities = [
-        { id = 14, name = "WEBRip-720p", source = "webRip", resolution = 720 },
-        { id = 5, name = "WEBDL-720p", source = "web", resolution = 720 },
-      ]
-    },
-    {
-      name      = "Bluray-720p"
-      qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
-    },
-    {
-      id   = 1002
-      name = "WEB 1080p"
-      qualities = [
-        { id = 15, name = "WEBRip-1080p", source = "webRip", resolution = 1080 },
-        { id = 3, name = "WEBDL-1080p", source = "web", resolution = 1080 },
-      ]
-    },
-    {
-      name      = "Bluray-1080p"
-      qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
-    },
-    {
-      name      = "Bluray-1080p Remux"
-      qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
-    },
-    {
-      name      = "HDTV-2160p"
-      qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
+      name      = "Bluray-2160p"
+      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
     },
     {
       id   = 1003
@@ -206,12 +168,76 @@ resource "sonarr_quality_profile" "sd" {
       ]
     },
     {
-      name      = "Bluray-2160p"
-      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
+      name      = "HDTV-2160p"
+      qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
     },
     {
-      name      = "Bluray-2160p Remux"
-      qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
+      name      = "Bluray-1080p Remux"
+      qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
+    },
+    {
+      name      = "Bluray-1080p"
+      qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
+    },
+    {
+      id   = 1002
+      name = "WEB 1080p"
+      qualities = [
+        { id = 15, name = "WEBRip-1080p", source = "webRip", resolution = 1080 },
+        { id = 3, name = "WEBDL-1080p", source = "web", resolution = 1080 },
+      ]
+    },
+    {
+      name      = "Bluray-720p"
+      qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
+    },
+    {
+      id   = 1001
+      name = "WEB 720p"
+      qualities = [
+        { id = 14, name = "WEBRip-720p", source = "webRip", resolution = 720 },
+        { id = 5, name = "WEBDL-720p", source = "web", resolution = 720 },
+      ]
+    },
+    {
+      name      = "Raw-HD"
+      qualities = [{ id = 10, name = "Raw-HD", source = "televisionRaw", resolution = 1080 }]
+    },
+    {
+      name      = "HDTV-1080p"
+      qualities = [{ id = 9, name = "HDTV-1080p", source = "television", resolution = 1080 }]
+    },
+    {
+      name      = "HDTV-720p"
+      qualities = [{ id = 4, name = "HDTV-720p", source = "television", resolution = 720 }]
+    },
+    {
+      name      = "Bluray-576p"
+      qualities = [{ id = 22, name = "Bluray-576p", source = "bluray", resolution = 576 }]
+    },
+    {
+      name      = "Bluray-480p"
+      qualities = [{ id = 13, name = "Bluray-480p", source = "bluray", resolution = 480 }]
+    },
+    {
+      name      = "DVD"
+      qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 480 }]
+    },
+    {
+      id   = 1000
+      name = "WEB 480p"
+      qualities = [
+        { id = 12, name = "WEBRip-480p", source = "webRip", resolution = 480 },
+        { id = 8, name = "WEBDL-480p", source = "web", resolution = 480 },
+      ]
+    },
+    {
+      name      = "SDTV"
+      qualities = [{ id = 1, name = "SDTV", source = "television", resolution = 480 }]
+    },
+    {
+      name      = "Unknown"
+      qualities = [{ id = 0, name = "Unknown", source = "unknown", resolution = 0 }]
     },
   ]
 }
@@ -221,80 +247,15 @@ resource "sonarr_quality_profile" "hd_720p" {
   name            = "HD-720p"
   upgrade_allowed = true
   cutoff          = 6 # Bluray-720p
-  lifecycle { ignore_changes = [quality_groups] }
 
   quality_groups = [
     {
-      name      = "Unknown"
-      qualities = [{ id = 0, name = "Unknown", source = "unknown", resolution = 0 }]
+      name      = "Bluray-2160p Remux"
+      qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
     },
     {
-      name      = "SDTV"
-      qualities = [{ id = 1, name = "SDTV", source = "television", resolution = 480 }]
-    },
-    {
-      id   = 1000
-      name = "WEB 480p"
-      qualities = [
-        { id = 12, name = "WEBRip-480p", source = "webRip", resolution = 480 },
-        { id = 8, name = "WEBDL-480p", source = "web", resolution = 480 },
-      ]
-    },
-    {
-      name      = "DVD"
-      qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 480 }]
-    },
-    {
-      name      = "Bluray-480p"
-      qualities = [{ id = 13, name = "Bluray-480p", source = "bluray", resolution = 480 }]
-    },
-    {
-      name      = "Bluray-576p"
-      qualities = [{ id = 22, name = "Bluray-576p", source = "bluray", resolution = 576 }]
-    },
-    {
-      name      = "HDTV-720p"
-      qualities = [{ id = 4, name = "HDTV-720p", source = "television", resolution = 720 }]
-    },
-    {
-      name      = "HDTV-1080p"
-      qualities = [{ id = 9, name = "HDTV-1080p", source = "television", resolution = 1080 }]
-    },
-    {
-      name      = "Raw-HD"
-      qualities = [{ id = 10, name = "Raw-HD", source = "televisionRaw", resolution = 1080 }]
-    },
-    {
-      id   = 1001
-      name = "WEB 720p"
-      qualities = [
-        { id = 14, name = "WEBRip-720p", source = "webRip", resolution = 720 },
-        { id = 5, name = "WEBDL-720p", source = "web", resolution = 720 },
-      ]
-    },
-    {
-      name      = "Bluray-720p"
-      qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
-    },
-    {
-      id   = 1002
-      name = "WEB 1080p"
-      qualities = [
-        { id = 15, name = "WEBRip-1080p", source = "webRip", resolution = 1080 },
-        { id = 3, name = "WEBDL-1080p", source = "web", resolution = 1080 },
-      ]
-    },
-    {
-      name      = "Bluray-1080p"
-      qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
-    },
-    {
-      name      = "Bluray-1080p Remux"
-      qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
-    },
-    {
-      name      = "HDTV-2160p"
-      qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
+      name      = "Bluray-2160p"
+      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
     },
     {
       id   = 1003
@@ -305,12 +266,76 @@ resource "sonarr_quality_profile" "hd_720p" {
       ]
     },
     {
-      name      = "Bluray-2160p"
-      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
+      name      = "HDTV-2160p"
+      qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
     },
     {
-      name      = "Bluray-2160p Remux"
-      qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
+      name      = "Bluray-1080p Remux"
+      qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
+    },
+    {
+      name      = "Bluray-1080p"
+      qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
+    },
+    {
+      id   = 1002
+      name = "WEB 1080p"
+      qualities = [
+        { id = 15, name = "WEBRip-1080p", source = "webRip", resolution = 1080 },
+        { id = 3, name = "WEBDL-1080p", source = "web", resolution = 1080 },
+      ]
+    },
+    {
+      name      = "Bluray-720p"
+      qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
+    },
+    {
+      id   = 1001
+      name = "WEB 720p"
+      qualities = [
+        { id = 14, name = "WEBRip-720p", source = "webRip", resolution = 720 },
+        { id = 5, name = "WEBDL-720p", source = "web", resolution = 720 },
+      ]
+    },
+    {
+      name      = "Raw-HD"
+      qualities = [{ id = 10, name = "Raw-HD", source = "televisionRaw", resolution = 1080 }]
+    },
+    {
+      name      = "HDTV-1080p"
+      qualities = [{ id = 9, name = "HDTV-1080p", source = "television", resolution = 1080 }]
+    },
+    {
+      name      = "HDTV-720p"
+      qualities = [{ id = 4, name = "HDTV-720p", source = "television", resolution = 720 }]
+    },
+    {
+      name      = "Bluray-576p"
+      qualities = [{ id = 22, name = "Bluray-576p", source = "bluray", resolution = 576 }]
+    },
+    {
+      name      = "Bluray-480p"
+      qualities = [{ id = 13, name = "Bluray-480p", source = "bluray", resolution = 480 }]
+    },
+    {
+      name      = "DVD"
+      qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 480 }]
+    },
+    {
+      id   = 1000
+      name = "WEB 480p"
+      qualities = [
+        { id = 12, name = "WEBRip-480p", source = "webRip", resolution = 480 },
+        { id = 8, name = "WEBDL-480p", source = "web", resolution = 480 },
+      ]
+    },
+    {
+      name      = "SDTV"
+      qualities = [{ id = 1, name = "SDTV", source = "television", resolution = 480 }]
+    },
+    {
+      name      = "Unknown"
+      qualities = [{ id = 0, name = "Unknown", source = "unknown", resolution = 0 }]
     },
   ]
 }
@@ -320,80 +345,15 @@ resource "sonarr_quality_profile" "hd_1080p" {
   name            = "HD-1080p"
   upgrade_allowed = true
   cutoff          = 7 # Bluray-1080p — stops short of Bluray-1080p Remux
-  lifecycle { ignore_changes = [quality_groups] }
 
   quality_groups = [
     {
-      name      = "Unknown"
-      qualities = [{ id = 0, name = "Unknown", source = "unknown", resolution = 0 }]
+      name      = "Bluray-2160p Remux"
+      qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
     },
     {
-      name      = "SDTV"
-      qualities = [{ id = 1, name = "SDTV", source = "television", resolution = 480 }]
-    },
-    {
-      id   = 1000
-      name = "WEB 480p"
-      qualities = [
-        { id = 12, name = "WEBRip-480p", source = "webRip", resolution = 480 },
-        { id = 8, name = "WEBDL-480p", source = "web", resolution = 480 },
-      ]
-    },
-    {
-      name      = "DVD"
-      qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 480 }]
-    },
-    {
-      name      = "Bluray-480p"
-      qualities = [{ id = 13, name = "Bluray-480p", source = "bluray", resolution = 480 }]
-    },
-    {
-      name      = "Bluray-576p"
-      qualities = [{ id = 22, name = "Bluray-576p", source = "bluray", resolution = 576 }]
-    },
-    {
-      name      = "HDTV-720p"
-      qualities = [{ id = 4, name = "HDTV-720p", source = "television", resolution = 720 }]
-    },
-    {
-      name      = "HDTV-1080p"
-      qualities = [{ id = 9, name = "HDTV-1080p", source = "television", resolution = 1080 }]
-    },
-    {
-      name      = "Raw-HD"
-      qualities = [{ id = 10, name = "Raw-HD", source = "televisionRaw", resolution = 1080 }]
-    },
-    {
-      id   = 1001
-      name = "WEB 720p"
-      qualities = [
-        { id = 14, name = "WEBRip-720p", source = "webRip", resolution = 720 },
-        { id = 5, name = "WEBDL-720p", source = "web", resolution = 720 },
-      ]
-    },
-    {
-      name      = "Bluray-720p"
-      qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
-    },
-    {
-      id   = 1002
-      name = "WEB 1080p"
-      qualities = [
-        { id = 15, name = "WEBRip-1080p", source = "webRip", resolution = 1080 },
-        { id = 3, name = "WEBDL-1080p", source = "web", resolution = 1080 },
-      ]
-    },
-    {
-      name      = "Bluray-1080p"
-      qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
-    },
-    {
-      name      = "Bluray-1080p Remux"
-      qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
-    },
-    {
-      name      = "HDTV-2160p"
-      qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
+      name      = "Bluray-2160p"
+      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
     },
     {
       id   = 1003
@@ -404,12 +364,76 @@ resource "sonarr_quality_profile" "hd_1080p" {
       ]
     },
     {
-      name      = "Bluray-2160p"
-      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
+      name      = "HDTV-2160p"
+      qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
     },
     {
-      name      = "Bluray-2160p Remux"
-      qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
+      name      = "Bluray-1080p Remux"
+      qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
+    },
+    {
+      name      = "Bluray-1080p"
+      qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
+    },
+    {
+      id   = 1002
+      name = "WEB 1080p"
+      qualities = [
+        { id = 15, name = "WEBRip-1080p", source = "webRip", resolution = 1080 },
+        { id = 3, name = "WEBDL-1080p", source = "web", resolution = 1080 },
+      ]
+    },
+    {
+      name      = "Bluray-720p"
+      qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
+    },
+    {
+      id   = 1001
+      name = "WEB 720p"
+      qualities = [
+        { id = 14, name = "WEBRip-720p", source = "webRip", resolution = 720 },
+        { id = 5, name = "WEBDL-720p", source = "web", resolution = 720 },
+      ]
+    },
+    {
+      name      = "Raw-HD"
+      qualities = [{ id = 10, name = "Raw-HD", source = "televisionRaw", resolution = 1080 }]
+    },
+    {
+      name      = "HDTV-1080p"
+      qualities = [{ id = 9, name = "HDTV-1080p", source = "television", resolution = 1080 }]
+    },
+    {
+      name      = "HDTV-720p"
+      qualities = [{ id = 4, name = "HDTV-720p", source = "television", resolution = 720 }]
+    },
+    {
+      name      = "Bluray-576p"
+      qualities = [{ id = 22, name = "Bluray-576p", source = "bluray", resolution = 576 }]
+    },
+    {
+      name      = "Bluray-480p"
+      qualities = [{ id = 13, name = "Bluray-480p", source = "bluray", resolution = 480 }]
+    },
+    {
+      name      = "DVD"
+      qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 480 }]
+    },
+    {
+      id   = 1000
+      name = "WEB 480p"
+      qualities = [
+        { id = 12, name = "WEBRip-480p", source = "webRip", resolution = 480 },
+        { id = 8, name = "WEBDL-480p", source = "web", resolution = 480 },
+      ]
+    },
+    {
+      name      = "SDTV"
+      qualities = [{ id = 1, name = "SDTV", source = "television", resolution = 480 }]
+    },
+    {
+      name      = "Unknown"
+      qualities = [{ id = 0, name = "Unknown", source = "unknown", resolution = 0 }]
     },
   ]
 }
@@ -419,80 +443,15 @@ resource "sonarr_quality_profile" "ultra_hd" {
   name            = "Ultra-HD"
   upgrade_allowed = true
   cutoff          = 19 # Bluray-2160p — stops short of Bluray-2160p Remux
-  lifecycle { ignore_changes = [quality_groups] }
 
   quality_groups = [
     {
-      name      = "Unknown"
-      qualities = [{ id = 0, name = "Unknown", source = "unknown", resolution = 0 }]
+      name      = "Bluray-2160p Remux"
+      qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
     },
     {
-      name      = "SDTV"
-      qualities = [{ id = 1, name = "SDTV", source = "television", resolution = 480 }]
-    },
-    {
-      id   = 1000
-      name = "WEB 480p"
-      qualities = [
-        { id = 12, name = "WEBRip-480p", source = "webRip", resolution = 480 },
-        { id = 8, name = "WEBDL-480p", source = "web", resolution = 480 },
-      ]
-    },
-    {
-      name      = "DVD"
-      qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 480 }]
-    },
-    {
-      name      = "Bluray-480p"
-      qualities = [{ id = 13, name = "Bluray-480p", source = "bluray", resolution = 480 }]
-    },
-    {
-      name      = "Bluray-576p"
-      qualities = [{ id = 22, name = "Bluray-576p", source = "bluray", resolution = 576 }]
-    },
-    {
-      name      = "HDTV-720p"
-      qualities = [{ id = 4, name = "HDTV-720p", source = "television", resolution = 720 }]
-    },
-    {
-      name      = "HDTV-1080p"
-      qualities = [{ id = 9, name = "HDTV-1080p", source = "television", resolution = 1080 }]
-    },
-    {
-      name      = "Raw-HD"
-      qualities = [{ id = 10, name = "Raw-HD", source = "televisionRaw", resolution = 1080 }]
-    },
-    {
-      id   = 1001
-      name = "WEB 720p"
-      qualities = [
-        { id = 14, name = "WEBRip-720p", source = "webRip", resolution = 720 },
-        { id = 5, name = "WEBDL-720p", source = "web", resolution = 720 },
-      ]
-    },
-    {
-      name      = "Bluray-720p"
-      qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
-    },
-    {
-      id   = 1002
-      name = "WEB 1080p"
-      qualities = [
-        { id = 15, name = "WEBRip-1080p", source = "webRip", resolution = 1080 },
-        { id = 3, name = "WEBDL-1080p", source = "web", resolution = 1080 },
-      ]
-    },
-    {
-      name      = "Bluray-1080p"
-      qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
-    },
-    {
-      name      = "Bluray-1080p Remux"
-      qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
-    },
-    {
-      name      = "HDTV-2160p"
-      qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
+      name      = "Bluray-2160p"
+      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
     },
     {
       id   = 1003
@@ -503,12 +462,76 @@ resource "sonarr_quality_profile" "ultra_hd" {
       ]
     },
     {
-      name      = "Bluray-2160p"
-      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
+      name      = "HDTV-2160p"
+      qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
     },
     {
-      name      = "Bluray-2160p Remux"
-      qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
+      name      = "Bluray-1080p Remux"
+      qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
+    },
+    {
+      name      = "Bluray-1080p"
+      qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
+    },
+    {
+      id   = 1002
+      name = "WEB 1080p"
+      qualities = [
+        { id = 15, name = "WEBRip-1080p", source = "webRip", resolution = 1080 },
+        { id = 3, name = "WEBDL-1080p", source = "web", resolution = 1080 },
+      ]
+    },
+    {
+      name      = "Bluray-720p"
+      qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
+    },
+    {
+      id   = 1001
+      name = "WEB 720p"
+      qualities = [
+        { id = 14, name = "WEBRip-720p", source = "webRip", resolution = 720 },
+        { id = 5, name = "WEBDL-720p", source = "web", resolution = 720 },
+      ]
+    },
+    {
+      name      = "Raw-HD"
+      qualities = [{ id = 10, name = "Raw-HD", source = "televisionRaw", resolution = 1080 }]
+    },
+    {
+      name      = "HDTV-1080p"
+      qualities = [{ id = 9, name = "HDTV-1080p", source = "television", resolution = 1080 }]
+    },
+    {
+      name      = "HDTV-720p"
+      qualities = [{ id = 4, name = "HDTV-720p", source = "television", resolution = 720 }]
+    },
+    {
+      name      = "Bluray-576p"
+      qualities = [{ id = 22, name = "Bluray-576p", source = "bluray", resolution = 576 }]
+    },
+    {
+      name      = "Bluray-480p"
+      qualities = [{ id = 13, name = "Bluray-480p", source = "bluray", resolution = 480 }]
+    },
+    {
+      name      = "DVD"
+      qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 480 }]
+    },
+    {
+      id   = 1000
+      name = "WEB 480p"
+      qualities = [
+        { id = 12, name = "WEBRip-480p", source = "webRip", resolution = 480 },
+        { id = 8, name = "WEBDL-480p", source = "web", resolution = 480 },
+      ]
+    },
+    {
+      name      = "SDTV"
+      qualities = [{ id = 1, name = "SDTV", source = "television", resolution = 480 }]
+    },
+    {
+      name      = "Unknown"
+      qualities = [{ id = 0, name = "Unknown", source = "unknown", resolution = 0 }]
     },
   ]
 }
@@ -518,80 +541,15 @@ resource "sonarr_quality_profile" "hd_720p_1080p" {
   name            = "HD - 720p/1080p"
   upgrade_allowed = true
   cutoff          = 7 # Bluray-1080p — was 4 (HDTV-720p), which capped this profile at 720p
-  lifecycle { ignore_changes = [quality_groups] }
 
   quality_groups = [
     {
-      name      = "Unknown"
-      qualities = [{ id = 0, name = "Unknown", source = "unknown", resolution = 0 }]
+      name      = "Bluray-2160p Remux"
+      qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
     },
     {
-      name      = "SDTV"
-      qualities = [{ id = 1, name = "SDTV", source = "television", resolution = 480 }]
-    },
-    {
-      id   = 1000
-      name = "WEB 480p"
-      qualities = [
-        { id = 12, name = "WEBRip-480p", source = "webRip", resolution = 480 },
-        { id = 8, name = "WEBDL-480p", source = "web", resolution = 480 },
-      ]
-    },
-    {
-      name      = "DVD"
-      qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 480 }]
-    },
-    {
-      name      = "Bluray-480p"
-      qualities = [{ id = 13, name = "Bluray-480p", source = "bluray", resolution = 480 }]
-    },
-    {
-      name      = "Bluray-576p"
-      qualities = [{ id = 22, name = "Bluray-576p", source = "bluray", resolution = 576 }]
-    },
-    {
-      name      = "HDTV-720p"
-      qualities = [{ id = 4, name = "HDTV-720p", source = "television", resolution = 720 }]
-    },
-    {
-      name      = "HDTV-1080p"
-      qualities = [{ id = 9, name = "HDTV-1080p", source = "television", resolution = 1080 }]
-    },
-    {
-      name      = "Raw-HD"
-      qualities = [{ id = 10, name = "Raw-HD", source = "televisionRaw", resolution = 1080 }]
-    },
-    {
-      id   = 1001
-      name = "WEB 720p"
-      qualities = [
-        { id = 14, name = "WEBRip-720p", source = "webRip", resolution = 720 },
-        { id = 5, name = "WEBDL-720p", source = "web", resolution = 720 },
-      ]
-    },
-    {
-      name      = "Bluray-720p"
-      qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
-    },
-    {
-      id   = 1002
-      name = "WEB 1080p"
-      qualities = [
-        { id = 15, name = "WEBRip-1080p", source = "webRip", resolution = 1080 },
-        { id = 3, name = "WEBDL-1080p", source = "web", resolution = 1080 },
-      ]
-    },
-    {
-      name      = "Bluray-1080p"
-      qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
-    },
-    {
-      name      = "Bluray-1080p Remux"
-      qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
-    },
-    {
-      name      = "HDTV-2160p"
-      qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
+      name      = "Bluray-2160p"
+      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
     },
     {
       id   = 1003
@@ -602,12 +560,76 @@ resource "sonarr_quality_profile" "hd_720p_1080p" {
       ]
     },
     {
-      name      = "Bluray-2160p"
-      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
+      name      = "HDTV-2160p"
+      qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
     },
     {
-      name      = "Bluray-2160p Remux"
-      qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
+      name      = "Bluray-1080p Remux"
+      qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
+    },
+    {
+      name      = "Bluray-1080p"
+      qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
+    },
+    {
+      id   = 1002
+      name = "WEB 1080p"
+      qualities = [
+        { id = 15, name = "WEBRip-1080p", source = "webRip", resolution = 1080 },
+        { id = 3, name = "WEBDL-1080p", source = "web", resolution = 1080 },
+      ]
+    },
+    {
+      name      = "Bluray-720p"
+      qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
+    },
+    {
+      id   = 1001
+      name = "WEB 720p"
+      qualities = [
+        { id = 14, name = "WEBRip-720p", source = "webRip", resolution = 720 },
+        { id = 5, name = "WEBDL-720p", source = "web", resolution = 720 },
+      ]
+    },
+    {
+      name      = "Raw-HD"
+      qualities = [{ id = 10, name = "Raw-HD", source = "televisionRaw", resolution = 1080 }]
+    },
+    {
+      name      = "HDTV-1080p"
+      qualities = [{ id = 9, name = "HDTV-1080p", source = "television", resolution = 1080 }]
+    },
+    {
+      name      = "HDTV-720p"
+      qualities = [{ id = 4, name = "HDTV-720p", source = "television", resolution = 720 }]
+    },
+    {
+      name      = "Bluray-576p"
+      qualities = [{ id = 22, name = "Bluray-576p", source = "bluray", resolution = 576 }]
+    },
+    {
+      name      = "Bluray-480p"
+      qualities = [{ id = 13, name = "Bluray-480p", source = "bluray", resolution = 480 }]
+    },
+    {
+      name      = "DVD"
+      qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 480 }]
+    },
+    {
+      id   = 1000
+      name = "WEB 480p"
+      qualities = [
+        { id = 12, name = "WEBRip-480p", source = "webRip", resolution = 480 },
+        { id = 8, name = "WEBDL-480p", source = "web", resolution = 480 },
+      ]
+    },
+    {
+      name      = "SDTV"
+      qualities = [{ id = 1, name = "SDTV", source = "television", resolution = 480 }]
+    },
+    {
+      name      = "Unknown"
+      qualities = [{ id = 0, name = "Unknown", source = "unknown", resolution = 0 }]
     },
   ]
 }


### PR DESCRIPTION
## Why

#1090 turned upgrades on and corrected every cutoff, and the apply succeeded — I verified `Applied successfully / NoDrift` on both Terraform CRs and all 12 profiles live. **Nothing upgrades anyway**, because the quality *ranking* is upside-down in both apps.

Radarr and Sonarr rank quality by position in a profile's item list, **index 0 = worst**. The live `Any` profile read:

```
 0 Unknown        9 Remux-1080p    17 WEBDL-720p    27 SDTV
 1 BR-DISK       10 Bluray-1080p   ...              32 CAM
 3 Remux-2160p   ...               23 Bluray-480p   33 WORKPRINT
```

A 720p WEB-DL (17) outranks a 1080p Blu-ray (10). So Radarr reports `qualityCutoffNotMet: false` on those files and rejects everything with `Existing file meets cutoff`.

Measured:

| | |
|---|---|
| sub-1080p movies Radarr flags as upgrade-eligible | **1** of ~315 |
| releases rejected for one test title on cutoff grounds | **97** of 99 |

**It is worse than blocked upgrades.** In `Any` — 519 movies, every quality allowed — `WORKPRINT` ranks **29** and `CAM` **28**, against `Remux-2160p` at **3**. A cam rip outranks a 4K remux on a fresh grab. Imports since the 2026-05-14 tofu run are consistent: 17 WEBDL-720p, 8 WEBRip-720p and 6 SDTV against 1 Bluray-1080p.

## Root cause

**The devopsarr provider writes `quality_groups` reversed.** These files listed worst-first, so the apps received best-first.

Evidence, because this is the exact thing that went in backwards last time:

1. tf order vs live read are exact reverses on **two** profiles independently — `Any` (all qualities allowed) and `HD-720p` (three allowed, which land at the end of the live list in reverse tf order).
2. The API itself round-trips order faithfully — I POSTed a scratch profile with a known order, read it back byte-identical, and deleted it. So the reversal is the provider's, not the API's.
3. Radarr's own `qualityCutoffNotMet: false` verdict on a WEBDL-720p file under a Bluray-1080p cutoff confirms index 0 = worst independently of how I read the list.

`lifecycle { ignore_changes = [quality_groups] }` on every profile is why this survived from May until now.

## What changed

- **both apps:** `quality_groups` reversed to best-first, so the provider's reversal produces a correct worst-first ranking live
- **both apps:** `ignore_changes = [quality_groups]` removed from all 12 profiles — it hides exactly this class of bug
- **both apps:** a banner at the top of each file explaining why the list reads best-first, so nobody "corrects" it back

Deliberately untouched:

- **inner `qualities` lists** — grouped qualities rank equal, so their order is cosmetic
- **which qualities are allowed** — narrowing Sonarr's misnamed profiles would drop 4K from the 6 series on `HD - 720p/1080p`. That is a product decision, not a bug fix.

## This change cannot regress

Live is fully inverted today. If the provider ever stops reversing, the result is the order that is *already deployed*. Worst case is the status quo; there is no scenario where this is worse than now.

## Verification

CI does not check terraform and tofu-controller runs `approvePlan: auto`, so a merge applies straight to the live instances. Checked locally against the providers that actually resolve:

```
tofu fmt -check -recursive   -> clean
radarr  validate: Success!   (devopsarr/radarr 2.4.0)
sonarr  validate: Success!   (devopsarr/sonarr 3.4.2)
```

**After merge, confirm index 0 is the worst quality** — the banner in each file carries this command:

```bash
kubectl exec -n mediastack <pod> -c <app> -- sh -c \
  "curl -s -H 'X-Api-Key: $KEY' 'http://localhost:<port>/api/v3/qualityprofile/1'" \
  | python3 -c "import json,sys;print([i.get('quality',{}).get('name') for i in json.load(sys.stdin)['items']][:4])"
```

Expect `Unknown, WORKPRINT, CAM, TELESYNC`. If it still reads `Unknown, BR-DISK, Raw-HD, Remux-2160p`, the provider stopped reversing and the lists need flipping back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014H1QY7REDHYX2AcRuDuSnF