### PR TITLE
fix(radarr,sonarr): drop group-level name from single-quality groups

### DIFF
--- a/terraform/radarr/quality-profiles.tf
+++ b/terraform/radarr/quality-profiles.tf
@@ -24,6 +24,12 @@
 # is why the inversion survived from the 2026-05-14 import until now. Do not re-add it —
 # it hides exactly this class of bug.
 #
+# A single-quality group must NOT carry a group-level `name`. Radarr and Sonarr only
+# store a name for real multi-quality groups (the WEB tiers, ids 1000-1003); for a group
+# of one they return `name: null`, and the provider then fails the apply with
+# "Provider produced inconsistent result after apply ... .name: was cty.StringVal(\"CAM\"),
+# but now null". The old `ignore_changes = [quality_groups]` masked this.
+#
 # To verify after any change to this file, read the live order back and confirm index 0
 # is the worst quality:
 #   kubectl exec -n mediastack <pod> -c <app> -- sh -c \
@@ -51,11 +57,9 @@ resource "radarr_quality_profile" "any" {
 
   quality_groups = [
     {
-      name      = "Remux-2160p"
       qualities = [{ id = 31, name = "Remux-2160p", source = "bluray", resolution = 2160 }]
     },
     {
-      name      = "Bluray-2160p"
       qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
     },
     {
@@ -67,15 +71,12 @@ resource "radarr_quality_profile" "any" {
       ]
     },
     {
-      name      = "HDTV-2160p"
       qualities = [{ id = 16, name = "HDTV-2160p", source = "tv", resolution = 2160 }]
     },
     {
-      name      = "Remux-1080p"
       qualities = [{ id = 30, name = "Remux-1080p", source = "bluray", resolution = 1080 }]
     },
     {
-      name      = "Bluray-1080p"
       qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
     },
     {
@@ -87,11 +88,9 @@ resource "radarr_quality_profile" "any" {
       ]
     },
     {
-      name      = "HDTV-1080p"
       qualities = [{ id = 9, name = "HDTV-1080p", source = "tv", resolution = 1080 }]
     },
     {
-      name      = "Bluray-720p"
       qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
     },
     {
@@ -103,15 +102,12 @@ resource "radarr_quality_profile" "any" {
       ]
     },
     {
-      name      = "HDTV-720p"
       qualities = [{ id = 4, name = "HDTV-720p", source = "tv", resolution = 720 }]
     },
     {
-      name      = "Bluray-576p"
       qualities = [{ id = 21, name = "Bluray-576p", source = "bluray", resolution = 576 }]
     },
     {
-      name      = "Bluray-480p"
       qualities = [{ id = 20, name = "Bluray-480p", source = "bluray", resolution = 480 }]
     },
     {
@@ -123,39 +119,30 @@ resource "radarr_quality_profile" "any" {
       ]
     },
     {
-      name      = "DVD-R"
       qualities = [{ id = 23, name = "DVD-R", source = "dvd", resolution = 480 }]
     },
     {
-      name      = "DVD"
       qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 0 }]
     },
     {
-      name      = "SDTV"
       qualities = [{ id = 1, name = "SDTV", source = "tv", resolution = 480 }]
     },
     {
-      name      = "DVDSCR"
       qualities = [{ id = 28, name = "DVDSCR", source = "dvd", resolution = 480 }]
     },
     {
-      name      = "REGIONAL"
       qualities = [{ id = 29, name = "REGIONAL", source = "dvd", resolution = 480 }]
     },
     {
-      name      = "TELECINE"
       qualities = [{ id = 27, name = "TELECINE", source = "telecine", resolution = 0 }]
     },
     {
-      name      = "TELESYNC"
       qualities = [{ id = 26, name = "TELESYNC", source = "telesync", resolution = 0 }]
     },
     {
-      name      = "CAM"
       qualities = [{ id = 25, name = "CAM", source = "cam", resolution = 0 }]
     },
     {
-      name      = "WORKPRINT"
       qualities = [{ id = 24, name = "WORKPRINT", source = "workprint", resolution = 0 }]
     },
   ]
@@ -173,11 +160,9 @@ resource "radarr_quality_profile" "sd" {
 
   quality_groups = [
     {
-      name      = "Bluray-576p"
       qualities = [{ id = 21, name = "Bluray-576p", source = "bluray", resolution = 576 }]
     },
     {
-      name      = "Bluray-480p"
       qualities = [{ id = 20, name = "Bluray-480p", source = "bluray", resolution = 480 }]
     },
     {
@@ -189,35 +174,27 @@ resource "radarr_quality_profile" "sd" {
       ]
     },
     {
-      name      = "DVD"
       qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 0 }]
     },
     {
-      name      = "SDTV"
       qualities = [{ id = 1, name = "SDTV", source = "tv", resolution = 480 }]
     },
     {
-      name      = "DVDSCR"
       qualities = [{ id = 28, name = "DVDSCR", source = "dvd", resolution = 480 }]
     },
     {
-      name      = "REGIONAL"
       qualities = [{ id = 29, name = "REGIONAL", source = "dvd", resolution = 480 }]
     },
     {
-      name      = "TELECINE"
       qualities = [{ id = 27, name = "TELECINE", source = "telecine", resolution = 0 }]
     },
     {
-      name      = "TELESYNC"
       qualities = [{ id = 26, name = "TELESYNC", source = "telesync", resolution = 0 }]
     },
     {
-      name      = "CAM"
       qualities = [{ id = 25, name = "CAM", source = "cam", resolution = 0 }]
     },
     {
-      name      = "WORKPRINT"
       qualities = [{ id = 24, name = "WORKPRINT", source = "workprint", resolution = 0 }]
     },
   ]
@@ -235,7 +212,6 @@ resource "radarr_quality_profile" "hd_720p" {
 
   quality_groups = [
     {
-      name      = "Bluray-720p"
       qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
     },
     {
@@ -247,7 +223,6 @@ resource "radarr_quality_profile" "hd_720p" {
       ]
     },
     {
-      name      = "HDTV-720p"
       qualities = [{ id = 4, name = "HDTV-720p", source = "tv", resolution = 720 }]
     },
   ]
@@ -265,11 +240,9 @@ resource "radarr_quality_profile" "hd_1080p" {
 
   quality_groups = [
     {
-      name      = "Remux-1080p"
       qualities = [{ id = 30, name = "Remux-1080p", source = "bluray", resolution = 1080 }]
     },
     {
-      name      = "Bluray-1080p"
       qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
     },
     {
@@ -281,7 +254,6 @@ resource "radarr_quality_profile" "hd_1080p" {
       ]
     },
     {
-      name      = "HDTV-1080p"
       qualities = [{ id = 9, name = "HDTV-1080p", source = "tv", resolution = 1080 }]
     },
   ]
@@ -299,11 +271,9 @@ resource "radarr_quality_profile" "ultra_hd" {
 
   quality_groups = [
     {
-      name      = "Remux-2160p"
       qualities = [{ id = 31, name = "Remux-2160p", source = "bluray", resolution = 2160 }]
     },
     {
-      name      = "Bluray-2160p"
       qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
     },
     {
@@ -315,7 +285,6 @@ resource "radarr_quality_profile" "ultra_hd" {
       ]
     },
     {
-      name      = "HDTV-2160p"
       qualities = [{ id = 16, name = "HDTV-2160p", source = "tv", resolution = 2160 }]
     },
   ]
@@ -333,11 +302,9 @@ resource "radarr_quality_profile" "hd_720p_1080p" {
 
   quality_groups = [
     {
-      name      = "Remux-1080p"
       qualities = [{ id = 30, name = "Remux-1080p", source = "bluray", resolution = 1080 }]
     },
     {
-      name      = "Bluray-1080p"
       qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
     },
     {
@@ -349,11 +316,9 @@ resource "radarr_quality_profile" "hd_720p_1080p" {
       ]
     },
     {
-      name      = "HDTV-1080p"
       qualities = [{ id = 9, name = "HDTV-1080p", source = "tv", resolution = 1080 }]
     },
     {
-      name      = "Bluray-720p"
       qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
     },
     {
@@ -365,7 +330,6 @@ resource "radarr_quality_profile" "hd_720p_1080p" {
       ]
     },
     {
-      name      = "HDTV-720p"
       qualities = [{ id = 4, name = "HDTV-720p", source = "tv", resolution = 720 }]
     },
   ]

--- a/terraform/sonarr/quality-profiles.tf
+++ b/terraform/sonarr/quality-profiles.tf
@@ -27,6 +27,12 @@
 # is why the inversion survived from the 2026-05-14 import until now. Do not re-add it —
 # it hides exactly this class of bug.
 #
+# A single-quality group must NOT carry a group-level `name`. Radarr and Sonarr only
+# store a name for real multi-quality groups (the WEB tiers, ids 1000-1003); for a group
+# of one they return `name: null`, and the provider then fails the apply with
+# "Provider produced inconsistent result after apply ... .name: was cty.StringVal(\"CAM\"),
+# but now null". The old `ignore_changes = [quality_groups]` masked this.
+#
 # To verify after any change to this file, read the live order back and confirm index 0
 # is the worst quality:
 #   kubectl exec -n mediastack <pod> -c <app> -- sh -c \
@@ -54,11 +60,9 @@ resource "sonarr_quality_profile" "any" {
 
   quality_groups = [
     {
-      name      = "Bluray-2160p Remux"
       qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
     },
     {
-      name      = "Bluray-2160p"
       qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
     },
     {
@@ -70,15 +74,12 @@ resource "sonarr_quality_profile" "any" {
       ]
     },
     {
-      name      = "HDTV-2160p"
       qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
     },
     {
-      name      = "Bluray-1080p Remux"
       qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
     },
     {
-      name      = "Bluray-1080p"
       qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
     },
     {
@@ -90,7 +91,6 @@ resource "sonarr_quality_profile" "any" {
       ]
     },
     {
-      name      = "Bluray-720p"
       qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
     },
     {
@@ -102,27 +102,21 @@ resource "sonarr_quality_profile" "any" {
       ]
     },
     {
-      name      = "Raw-HD"
       qualities = [{ id = 10, name = "Raw-HD", source = "televisionRaw", resolution = 1080 }]
     },
     {
-      name      = "HDTV-1080p"
       qualities = [{ id = 9, name = "HDTV-1080p", source = "television", resolution = 1080 }]
     },
     {
-      name      = "HDTV-720p"
       qualities = [{ id = 4, name = "HDTV-720p", source = "television", resolution = 720 }]
     },
     {
-      name      = "Bluray-576p"
       qualities = [{ id = 22, name = "Bluray-576p", source = "bluray", resolution = 576 }]
     },
     {
-      name      = "Bluray-480p"
       qualities = [{ id = 13, name = "Bluray-480p", source = "bluray", resolution = 480 }]
     },
     {
-      name      = "DVD"
       qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 480 }]
     },
     {
@@ -134,11 +128,9 @@ resource "sonarr_quality_profile" "any" {
       ]
     },
     {
-      name      = "SDTV"
       qualities = [{ id = 1, name = "SDTV", source = "television", resolution = 480 }]
     },
     {
-      name      = "Unknown"
       qualities = [{ id = 0, name = "Unknown", source = "unknown", resolution = 0 }]
     },
   ]
@@ -152,11 +144,9 @@ resource "sonarr_quality_profile" "sd" {
 
   quality_groups = [
     {
-      name      = "Bluray-2160p Remux"
       qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
     },
     {
-      name      = "Bluray-2160p"
       qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
     },
     {
@@ -168,15 +158,12 @@ resource "sonarr_quality_profile" "sd" {
       ]
     },
     {
-      name      = "HDTV-2160p"
       qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
     },
     {
-      name      = "Bluray-1080p Remux"
       qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
     },
     {
-      name      = "Bluray-1080p"
       qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
     },
     {
@@ -188,7 +175,6 @@ resource "sonarr_quality_profile" "sd" {
       ]
     },
     {
-      name      = "Bluray-720p"
       qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
     },
     {
@@ -200,27 +186,21 @@ resource "sonarr_quality_profile" "sd" {
       ]
     },
     {
-      name      = "Raw-HD"
       qualities = [{ id = 10, name = "Raw-HD", source = "televisionRaw", resolution = 1080 }]
     },
     {
-      name      = "HDTV-1080p"
       qualities = [{ id = 9, name = "HDTV-1080p", source = "television", resolution = 1080 }]
     },
     {
-      name      = "HDTV-720p"
       qualities = [{ id = 4, name = "HDTV-720p", source = "television", resolution = 720 }]
     },
     {
-      name      = "Bluray-576p"
       qualities = [{ id = 22, name = "Bluray-576p", source = "bluray", resolution = 576 }]
     },
     {
-      name      = "Bluray-480p"
       qualities = [{ id = 13, name = "Bluray-480p", source = "bluray", resolution = 480 }]
     },
     {
-      name      = "DVD"
       qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 480 }]
     },
     {
@@ -232,11 +212,9 @@ resource "sonarr_quality_profile" "sd" {
       ]
     },
     {
-      name      = "SDTV"
       qualities = [{ id = 1, name = "SDTV", source = "television", resolution = 480 }]
     },
     {
-      name      = "Unknown"
       qualities = [{ id = 0, name = "Unknown", source = "unknown", resolution = 0 }]
     },
   ]
@@ -250,11 +228,9 @@ resource "sonarr_quality_profile" "hd_720p" {
 
   quality_groups = [
     {
-      name      = "Bluray-2160p Remux"
       qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
     },
     {
-      name      = "Bluray-2160p"
       qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
     },
     {
@@ -266,15 +242,12 @@ resource "sonarr_quality_profile" "hd_720p" {
       ]
     },
     {
-      name      = "HDTV-2160p"
       qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
     },
     {
-      name      = "Bluray-1080p Remux"
       qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
     },
     {
-      name      = "Bluray-1080p"
       qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
     },
     {
@@ -286,7 +259,6 @@ resource "sonarr_quality_profile" "hd_720p" {
       ]
     },
     {
-      name      = "Bluray-720p"
       qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
     },
     {
@@ -298,27 +270,21 @@ resource "sonarr_quality_profile" "hd_720p" {
       ]
     },
     {
-      name      = "Raw-HD"
       qualities = [{ id = 10, name = "Raw-HD", source = "televisionRaw", resolution = 1080 }]
     },
     {
-      name      = "HDTV-1080p"
       qualities = [{ id = 9, name = "HDTV-1080p", source = "television", resolution = 1080 }]
     },
     {
-      name      = "HDTV-720p"
       qualities = [{ id = 4, name = "HDTV-720p", source = "television", resolution = 720 }]
     },
     {
-      name      = "Bluray-576p"
       qualities = [{ id = 22, name = "Bluray-576p", source = "bluray", resolution = 576 }]
     },
     {
-      name      = "Bluray-480p"
       qualities = [{ id = 13, name = "Bluray-480p", source = "bluray", resolution = 480 }]
     },
     {
-      name      = "DVD"
       qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 480 }]
     },
     {
@@ -330,11 +296,9 @@ resource "sonarr_quality_profile" "hd_720p" {
       ]
     },
     {
-      name      = "SDTV"
       qualities = [{ id = 1, name = "SDTV", source = "television", resolution = 480 }]
     },
     {
-      name      = "Unknown"
       qualities = [{ id = 0, name = "Unknown", source = "unknown", resolution = 0 }]
     },
   ]
@@ -348,11 +312,9 @@ resource "sonarr_quality_profile" "hd_1080p" {
 
   quality_groups = [
     {
-      name      = "Bluray-2160p Remux"
       qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
     },
     {
-      name      = "Bluray-2160p"
       qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
     },
     {
@@ -364,15 +326,12 @@ resource "sonarr_quality_profile" "hd_1080p" {
       ]
     },
     {
-      name      = "HDTV-2160p"
       qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
     },
     {
-      name      = "Bluray-1080p Remux"
       qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
     },
     {
-      name      = "Bluray-1080p"
       qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
     },
     {
@@ -384,7 +343,6 @@ resource "sonarr_quality_profile" "hd_1080p" {
       ]
     },
     {
-      name      = "Bluray-720p"
       qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
     },
     {
@@ -396,27 +354,21 @@ resource "sonarr_quality_profile" "hd_1080p" {
       ]
     },
     {
-      name      = "Raw-HD"
       qualities = [{ id = 10, name = "Raw-HD", source = "televisionRaw", resolution = 1080 }]
     },
     {
-      name      = "HDTV-1080p"
       qualities = [{ id = 9, name = "HDTV-1080p", source = "television", resolution = 1080 }]
     },
     {
-      name      = "HDTV-720p"
       qualities = [{ id = 4, name = "HDTV-720p", source = "television", resolution = 720 }]
     },
     {
-      name      = "Bluray-576p"
       qualities = [{ id = 22, name = "Bluray-576p", source = "bluray", resolution = 576 }]
     },
     {
-      name      = "Bluray-480p"
       qualities = [{ id = 13, name = "Bluray-480p", source = "bluray", resolution = 480 }]
     },
     {
-      name      = "DVD"
       qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 480 }]
     },
     {
@@ -428,11 +380,9 @@ resource "sonarr_quality_profile" "hd_1080p" {
       ]
     },
     {
-      name      = "SDTV"
       qualities = [{ id = 1, name = "SDTV", source = "television", resolution = 480 }]
     },
     {
-      name      = "Unknown"
       qualities = [{ id = 0, name = "Unknown", source = "unknown", resolution = 0 }]
     },
   ]
@@ -446,11 +396,9 @@ resource "sonarr_quality_profile" "ultra_hd" {
 
   quality_groups = [
     {
-      name      = "Bluray-2160p Remux"
       qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
     },
     {
-      name      = "Bluray-2160p"
       qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
     },
     {
@@ -462,15 +410,12 @@ resource "sonarr_quality_profile" "ultra_hd" {
       ]
     },
     {
-      name      = "HDTV-2160p"
       qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
     },
     {
-      name      = "Bluray-1080p Remux"
       qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
     },
     {
-      name      = "Bluray-1080p"
       qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
     },
     {
@@ -482,7 +427,6 @@ resource "sonarr_quality_profile" "ultra_hd" {
       ]
     },
     {
-      name      = "Bluray-720p"
       qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
     },
     {
@@ -494,27 +438,21 @@ resource "sonarr_quality_profile" "ultra_hd" {
       ]
     },
     {
-      name      = "Raw-HD"
       qualities = [{ id = 10, name = "Raw-HD", source = "televisionRaw", resolution = 1080 }]
     },
     {
-      name      = "HDTV-1080p"
       qualities = [{ id = 9, name = "HDTV-1080p", source = "television", resolution = 1080 }]
     },
     {
-      name      = "HDTV-720p"
       qualities = [{ id = 4, name = "HDTV-720p", source = "television", resolution = 720 }]
     },
     {
-      name      = "Bluray-576p"
       qualities = [{ id = 22, name = "Bluray-576p", source = "bluray", resolution = 576 }]
     },
     {
-      name      = "Bluray-480p"
       qualities = [{ id = 13, name = "Bluray-480p", source = "bluray", resolution = 480 }]
     },
     {
-      name      = "DVD"
       qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 480 }]
     },
     {
@@ -526,11 +464,9 @@ resource "sonarr_quality_profile" "ultra_hd" {
       ]
     },
     {
-      name      = "SDTV"
       qualities = [{ id = 1, name = "SDTV", source = "television", resolution = 480 }]
     },
     {
-      name      = "Unknown"
       qualities = [{ id = 0, name = "Unknown", source = "unknown", resolution = 0 }]
     },
   ]
@@ -544,11 +480,9 @@ resource "sonarr_quality_profile" "hd_720p_1080p" {
 
   quality_groups = [
     {
-      name      = "Bluray-2160p Remux"
       qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
     },
     {
-      name      = "Bluray-2160p"
       qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
     },
     {
@@ -560,15 +494,12 @@ resource "sonarr_quality_profile" "hd_720p_1080p" {
       ]
     },
     {
-      name      = "HDTV-2160p"
       qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
     },
     {
-      name      = "Bluray-1080p Remux"
       qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
     },
     {
-      name      = "Bluray-1080p"
       qualities = [{ id = 7, name = "Bluray-1080p", source = "bluray", resolution = 1080 }]
     },
     {
@@ -580,7 +511,6 @@ resource "sonarr_quality_profile" "hd_720p_1080p" {
       ]
     },
     {
-      name      = "Bluray-720p"
       qualities = [{ id = 6, name = "Bluray-720p", source = "bluray", resolution = 720 }]
     },
     {
@@ -592,27 +522,21 @@ resource "sonarr_quality_profile" "hd_720p_1080p" {
       ]
     },
     {
-      name      = "Raw-HD"
       qualities = [{ id = 10, name = "Raw-HD", source = "televisionRaw", resolution = 1080 }]
     },
     {
-      name      = "HDTV-1080p"
       qualities = [{ id = 9, name = "HDTV-1080p", source = "television", resolution = 1080 }]
     },
     {
-      name      = "HDTV-720p"
       qualities = [{ id = 4, name = "HDTV-720p", source = "television", resolution = 720 }]
     },
     {
-      name      = "Bluray-576p"
       qualities = [{ id = 22, name = "Bluray-576p", source = "bluray", resolution = 576 }]
     },
     {
-      name      = "Bluray-480p"
       qualities = [{ id = 13, name = "Bluray-480p", source = "bluray", resolution = 480 }]
     },
     {
-      name      = "DVD"
       qualities = [{ id = 2, name = "DVD", source = "dvd", resolution = 480 }]
     },
     {
@@ -624,11 +548,9 @@ resource "sonarr_quality_profile" "hd_720p_1080p" {
       ]
     },
     {
-      name      = "SDTV"
       qualities = [{ id = 1, name = "SDTV", source = "television", resolution = 480 }]
     },
     {
-      name      = "Unknown"
       qualities = [{ id = 0, name = "Unknown", source = "unknown", resolution = 0 }]
     },
   ]


### PR DESCRIPTION
## Why

#1092 did its job — verified live: index 0 is now the worst quality, `CAM` sits below `Bluray-1080p` below `Remux-2160p`, and **all 315 sub-1080p movies are flagged cutoff-not-met (was 1)**.

But the apply *reports* failure and retries every 10 minutes, so `lastAppliedRevision` is stuck on the previous commit and both Terraform resources sit `Ready=False / TFExecApplyFailed`:

```
Error: Provider produced inconsistent result after apply
When applying changes to radarr_quality_profile.any, provider produced an
unexpected new value: .quality_groups[21].name: was cty.StringVal("CAM"),
but now null.
```

Radarr and Sonarr only store a group name for **real multi-quality groups** — the WEB tiers with explicit ids 1000-1003. A "group" wrapping a single quality is stored as a bare quality item with no name, so the provider reads back `null` and trips its own consistency check.

Confirmed from the controller log: every affected name is a single-quality group — `CAM`, `WORKPRINT`, `SDTV`, `Bluray-1080p`, `Remux-2160p`, `Unknown`, … — and **no `WEB` tier appears anywhere in the error set**.

`lifecycle { ignore_changes = [quality_groups] }` masked this until #1092 removed it.

## What changed

- radarr: group-level `name` removed from **42** single-quality groups
- sonarr: same for **84**
- multi-quality WEB groups keep their `name` and `id` — unchanged
- both files document the rule so it isn't reintroduced

## No behaviour change

The live ordering #1092 produced is already correct and this doesn't touch it. This only lets tofu converge and clears the failing reconcile loop.

## Verification

```
tofu fmt -check -recursive   -> clean
radarr  validate: Success!   (devopsarr/radarr 2.4.0)
sonarr  validate: Success!   (devopsarr/sonarr 3.4.2)
structural: 42/84 single-quality groups without a name, 10/24 multi-quality groups with one, 0 wrong
```

After merge, expect both Terraform CRs back to `Ready=True` at this revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014H1QY7REDHYX2AcRuDuSnF