### PR TITLE
feat(monitoring): alert on TrueNAS media pool free space

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -421,6 +421,75 @@ spec:
             summary: "MinIO PVC {{ $labels.persistentvolumeclaim }} below 10% free"
             description: "MinIO PVC {{ $labels.persistentvolumeclaim }} has {{ $value | humanizePercentage }} free. Immediate action required — node kubelet eviction threshold is ~10-15%."
 
+    # The TrueNAS media pool backs /movies and /tv over SMB and holds ~8 TB of library.
+    # Nothing else watches it: node-exporter only sees host filesystems, and the shares
+    # are mounted inside pods via the SMB CSI driver, so they never appear in
+    # node_filesystem_*. The existing disk alerts cover VMware datastores, Longhorn and
+    # MinIO — none of them this pool.
+    #
+    # Source is the exportarr sidecars already running in radarr and sonarr, which surface
+    # the arr's own /api/v3/diskspace. Both root folders report the same underlying pool,
+    # so the two series track together; alerting on min() over both means a single alert
+    # regardless of which app notices first, and it still fires if one exporter is down.
+    #
+    # Thresholds are absolute, not percentages: the two SMB shares advertise different
+    # capacities (16T vs 18T) for one shared pool, so a percentage is meaningless here.
+    #
+    # This matters now that Radarr/Sonarr upgrades are enabled (#1090/#1092): 274 movies
+    # and 3,005 episodes sit below cutoff. Per-quality size ceilings bound each file, not
+    # the total, so the aggregate ceiling exceeds free space if it ever ran to completion.
+    - name: media-pool
+      rules:
+        - alert: MediaPoolSpaceLow
+          expr: |
+            min(
+              radarr_rootfolder_freespace_bytes
+              or sonarr_rootfolder_freespace_bytes
+            ) < 2199023255552
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "TrueNAS media pool below 2 TiB free"
+            description: >-
+              The pool behind /movies and /tv has {{ $value | humanize1024 }}B free.
+              Check the Radarr and Sonarr queues for an upgrade backlog, and confirm
+              nobody has run "Search for Cutoff Unmet" — that queues every below-cutoff
+              item at once.
+
+        - alert: MediaPoolSpaceCritical
+          expr: |
+            min(
+              radarr_rootfolder_freespace_bytes
+              or sonarr_rootfolder_freespace_bytes
+            ) < 805306368000
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "TrueNAS media pool critically low — take action now"
+            description: >-
+              The pool behind /movies and /tv has {{ $value | humanize1024 }}B free.
+              Pause the Radarr/Sonarr queues and SABnzbd before imports start failing
+              mid-write.
+
+        # The alerts above are blind if the exporters stop reporting, and a silent
+        # exporter looks identical to a healthy pool. Watch for the series disappearing.
+        - alert: MediaPoolSpaceMetricMissing
+          expr: |
+            absent(radarr_rootfolder_freespace_bytes)
+              or absent(sonarr_rootfolder_freespace_bytes)
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Media pool free-space metric has stopped reporting"
+            description: >-
+              radarr_rootfolder_freespace_bytes or sonarr_rootfolder_freespace_bytes is
+              absent, so MediaPoolSpaceLow/Critical cannot fire. Check the exportarr
+              sidecar in the radarr and sonarr pods and the radarr-metrics /
+              sonarr-metrics ServiceMonitors.
+
     # Harbor is on the image-pull critical path: all 9 nodes proxy docker.io through
     # the Harbor proxy cache, so an unhealthy Harbor blocks new pod scheduling
     # cluster-wide once local image caches miss. Metrics come from the harbor-exporter


### PR DESCRIPTION
## Why

**Nothing watches the pool behind `/movies` and `/tv`.** node-exporter only sees host filesystems, and the shares are mounted inside pods via the SMB CSI driver, so they never appear in `node_filesystem_*`. The existing disk alerts cover VMware datastores, Longhorn, MinIO and node filesystems — **none of them this pool**, which holds ~8 TB of library and has 12.8 TiB free.

That gap matters now. #1090/#1092 enabled quality upgrades, and **274 movies plus 3,005 episodes sit below cutoff**. The per-quality size ceilings bound each *file*, not the total:

| if all 3,005 episodes upgraded to | net growth |
|---|---|
| WEBDL-1080p (cap 130 MB/min) | 14.3 TB |
| Bluray-1080p (cap 155) | 17.1 TB |
| WEBDL-2160p (cap 250) | 27.6 TB |
| Bluray-2160p Remux (cap 350) | 38.6 TB |

against **12.8 TiB free**. Nothing sweeps the back catalogue on a schedule — `RssSync` is the only scheduled search in either app, and 2,370 of those 3,005 episodes are from *ended* series that rarely get re-posted — so it should stay a trickle. But "should" isn't something to leave unmonitored.

## No new exporter needed

The exportarr sidecars **already running** in the radarr and sonarr pods surface the arr's own `/api/v3/diskspace`. Both targets are up and the series are already being scraped:

```
radarr_rootfolder_freespace_bytes{path="/movies", service="radarr-metrics"} => 14090307239936
sonarr_rootfolder_freespace_bytes{path="/tv",     service="sonarr-metrics"} => 14090307108864
```

## Rules

| alert | severity | condition |
|---|---|---|
| `MediaPoolSpaceLow` | warning | < 2 TiB for 30m |
| `MediaPoolSpaceCritical` | critical | < 750 GiB for 10m |
| `MediaPoolSpaceMetricMissing` | warning | either series absent for 1h |

**Thresholds are absolute, not percentages** — the two SMB shares advertise different capacities (16T vs 18T) for one shared pool, so a percentage is meaningless here.

Both root folders report that same pool, so the alerts take `min()` over the two series: one alert regardless of which app notices first, and it still fires if one exporter dies.

The third rule exists because **a silent exporter looks exactly like a healthy pool** — the first two alerts are blind without it.

## Verification

```
promtool check rules            -> SUCCESS: 32 rules found
MediaPoolSpaceLow expr          -> no result (not firing)
MediaPoolSpaceMetricMissing expr-> no result (not firing)
current free                    -> 12.82 TiB
```

Both expressions were evaluated against live Prometheus via `promtool query instant`, not just parsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014H1QY7REDHYX2AcRuDuSnF