### PR TITLE
fix(sonarr): cap every profile except Ultra-HD at 1080p

### DIFF
--- a/terraform/sonarr/quality-profiles.tf
+++ b/terraform/sonarr/quality-profiles.tf
@@ -39,12 +39,19 @@
 #     "curl -s -H 'X-Api-Key: $KEY' 'http://localhost:<port>/api/v3/qualityprofile/1'" \
 #     | python3 -c "import json,sys;print([i.get('quality',{}).get('name') for i in json.load(sys.stdin)['items']][:4])"
 #
-# KNOWN DEFECT, still not addressed here: live state has *every* quality flagged allowed on
-# *every* profile, so the names SD / HD-720p / HD-1080p / Ultra-HD / HD - 720p/1080p describe
-# nothing — all six differ only by cutoff. Radarr's equivalents are correctly restricted.
-# This PR fixes the *ranking* of those qualities, not *which* are allowed; narrowing them
-# would drop 4K from the 6 series on HD - 720p/1080p, which is a product decision, not a bug
-# fix, so it stays separate.
+# 2160p is deliberately absent from every profile except Ultra-HD. TV is where uncapped
+# growth hurts: 3,005 of 3,934 episode files sit below cutoff, and the per-quality size
+# ceilings in quality-definitions.tf bound each file, not the total. At the 2160p ceilings
+# that backlog tops out around 39 TB; capped at 1080p it is ~17 TB. Free space on the pool
+# behind /tv is ~12.8 TiB and is shared with /movies, so 4K on the default profile is not
+# something the pool can absorb. Ultra-HD keeps 4K because that is the profile's entire
+# purpose; it currently has 0 series, so assigning one is a deliberate act.
+#
+# PARTIALLY REMAINING DEFECT: below 2160p these profiles still allow everything, so the
+# names SD / HD-720p / HD-1080p / HD - 720p/1080p still do not describe what they permit —
+# they now differ only by cutoff and by the 2160p exclusion. Radarr's equivalents are
+# properly restricted. Narrowing the rest is cosmetic once 4K is out of the picture, since
+# cutoff already governs where upgrading stops.
 #
 # upgrade_allowed is true on every profile. With it false (the previous state) Sonarr treats the
 # highest allowed quality as the cutoff, so any existing file "meets cutoff" and nothing is ever
@@ -52,30 +59,13 @@
 # list (SDTV / HDTV-720p / HDTV-1080p / HDTV-2160p) under a comment saying "cutoff irrelevant",
 # which is only true while upgrades are off.
 
-# Profile: Any (id=1) — 82 of 88 series. Every quality is allowed live, up to Bluray-2160p Remux.
+# Profile: Any (id=1) — 82 of 88 series. Everything up to Bluray-1080p Remux; no 2160p.
 resource "sonarr_quality_profile" "any" {
   name            = "Any"
   upgrade_allowed = true
   cutoff          = 7 # Bluray-1080p — stop upgrading once a 1080p Blu-ray is in place
 
   quality_groups = [
-    {
-      qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
-    },
-    {
-      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
-    },
-    {
-      id   = 1003
-      name = "WEB 2160p"
-      qualities = [
-        { id = 17, name = "WEBRip-2160p", source = "webRip", resolution = 2160 },
-        { id = 18, name = "WEBDL-2160p", source = "web", resolution = 2160 },
-      ]
-    },
-    {
-      qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
-    },
     {
       qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
     },
@@ -144,23 +134,6 @@ resource "sonarr_quality_profile" "sd" {
 
   quality_groups = [
     {
-      qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
-    },
-    {
-      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
-    },
-    {
-      id   = 1003
-      name = "WEB 2160p"
-      qualities = [
-        { id = 17, name = "WEBRip-2160p", source = "webRip", resolution = 2160 },
-        { id = 18, name = "WEBDL-2160p", source = "web", resolution = 2160 },
-      ]
-    },
-    {
-      qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
-    },
-    {
       qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
     },
     {
@@ -227,23 +200,6 @@ resource "sonarr_quality_profile" "hd_720p" {
   cutoff          = 6 # Bluray-720p
 
   quality_groups = [
-    {
-      qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
-    },
-    {
-      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
-    },
-    {
-      id   = 1003
-      name = "WEB 2160p"
-      qualities = [
-        { id = 17, name = "WEBRip-2160p", source = "webRip", resolution = 2160 },
-        { id = 18, name = "WEBDL-2160p", source = "web", resolution = 2160 },
-      ]
-    },
-    {
-      qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
-    },
     {
       qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
     },
@@ -312,23 +268,6 @@ resource "sonarr_quality_profile" "hd_1080p" {
 
   quality_groups = [
     {
-      qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
-    },
-    {
-      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
-    },
-    {
-      id   = 1003
-      name = "WEB 2160p"
-      qualities = [
-        { id = 17, name = "WEBRip-2160p", source = "webRip", resolution = 2160 },
-        { id = 18, name = "WEBDL-2160p", source = "web", resolution = 2160 },
-      ]
-    },
-    {
-      qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
-    },
-    {
       qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
     },
     {
@@ -388,7 +327,7 @@ resource "sonarr_quality_profile" "hd_1080p" {
   ]
 }
 
-# Profile: Ultra-HD (id=5) — unused (0 series).
+# Profile: Ultra-HD (id=5) — unused (0 series). The only profile that still permits 2160p.
 resource "sonarr_quality_profile" "ultra_hd" {
   name            = "Ultra-HD"
   upgrade_allowed = true
@@ -479,23 +418,6 @@ resource "sonarr_quality_profile" "hd_720p_1080p" {
   cutoff          = 7 # Bluray-1080p — was 4 (HDTV-720p), which capped this profile at 720p
 
   quality_groups = [
-    {
-      qualities = [{ id = 21, name = "Bluray-2160p Remux", source = "blurayRaw", resolution = 2160 }]
-    },
-    {
-      qualities = [{ id = 19, name = "Bluray-2160p", source = "bluray", resolution = 2160 }]
-    },
-    {
-      id   = 1003
-      name = "WEB 2160p"
-      qualities = [
-        { id = 17, name = "WEBRip-2160p", source = "webRip", resolution = 2160 },
-        { id = 18, name = "WEBDL-2160p", source = "web", resolution = 2160 },
-      ]
-    },
-    {
-      qualities = [{ id = 16, name = "HDTV-2160p", source = "television", resolution = 2160 }]
-    },
     {
       qualities = [{ id = 20, name = "Bluray-1080p Remux", source = "blurayRaw", resolution = 1080 }]
     },


### PR DESCRIPTION
## Why

All six Sonarr profiles allowed every quality **up to Bluray-2160p Remux** — including `Any`, which 82 of 88 series use. With upgrades now enabled (#1090/#1092), that is the single largest storage exposure in the cluster.

**3,005 of 3,934 episode files sit below cutoff.** Per-quality size ceilings bound each *file*, not the total, so the backlog's ceiling depends entirely on which qualities are permitted:

| if all 3,005 upgraded to | per ep | net growth |
|---|---|---|
| WEBDL-1080p (cap 130 MB/min) | 4.8 GB | 14.3 TB |
| Bluray-1080p (cap 155) | 5.7 GB | 17.1 TB |
| WEBDL-2160p (cap 250) | 9.2 GB | **27.6 TB** |
| Bluray-2160p Remux (cap 350) | 12.8 GB | **38.6 TB** |

Free space behind `/tv` is **~12.8 TiB and shared with `/movies`**. 4K on the default profile is not something the pool can absorb. Removing 2160p takes the ceiling from ~39 TB to ~17 TB.

## What changed

| profile | series | 2160p |
|---|---|---|
| `Any` | 82 | **removed** |
| `HD - 720p/1080p` | 6 | **removed** |
| `SD` / `HD-720p` / `HD-1080p` | 0 | **removed** |
| `Ultra-HD` | 0 | **kept** |

`Ultra-HD` keeps 2160p — that's the profile's entire purpose, and with 0 series assigned, putting something on it stays a deliberate act.

## Context worth keeping in mind

Nothing sweeps the back catalogue on a schedule — `RssSync` is the only scheduled search in Sonarr — and **2,370 of the 3,005 are from *ended* series** that rarely get re-posted. So this was always going to be a trickle rather than a flood. This PR bounds where the trickle can end up rather than fixing an active fire.

Below 2160p the profiles still allow everything, so the names remain imprecise. Noted in the file; that part is cosmetic once 4K is excluded, because `cutoff` already governs where upgrading stops.

## Verification

```
cutoff still within each profile's remaining allowed set:
  any 7 ✓   sd 22 ✓   hd_720p 6 ✓   hd_1080p 7 ✓   ultra_hd 19 ✓   hd_720p_1080p 7 ✓

2160p ids remaining: [] in all profiles except ultra_hd [16,17,18,19,21]
top-of-list:         Bluray-1080p Remux (Bluray-2160p Remux for ultra_hd)

tofu fmt -check -recursive -> clean
sonarr validate: Success!  (devopsarr/sonarr 3.4.2)
```

Ordering stays best-first per the banner added in #1092 — the provider reverses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014H1QY7REDHYX2AcRuDuSnF