### PR TITLE
fix(portainer): move the last local-path PVC onto Longhorn

### DIFF
--- a/clusters/vollminlab-cluster/portainer/portainer/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/portainer/portainer/app/configmap.yaml
@@ -16,7 +16,12 @@ data:
       enabled: false
     persistence:
       enabled: true
-      existingClaim: portainer
+      # portainer-data (Longhorn) replaces the old `portainer` claim, which was
+      # local-path -> hostPath on k8sworker02: unbacked, unreplicated, node-pinned
+      # and invisible to volume metrics. See pvc.yaml.
+      # The claim is declared in pvc.yaml rather than left to the chart so it is
+      # GitOps-managed -- the old one existed only in the cluster, in no manifest.
+      existingClaim: portainer-data
     resources:
       limits:
         cpu: 100m

--- a/clusters/vollminlab-cluster/portainer/portainer/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/portainer/portainer/app/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 metadata:
   name: portainer-app
 resources:
+  - pvc.yaml
   - helmrelease.yaml
   - configmap.yaml
   - ingress.yaml

--- a/clusters/vollminlab-cluster/portainer/portainer/app/pvc.yaml
+++ b/clusters/vollminlab-cluster/portainer/portainer/app/pvc.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: portainer-data
+  namespace: portainer
+  labels:
+    app: portainer
+    env: production
+    category: apps
+spec:
+  accessModes:
+    - ReadWriteOnce
+  # Replaces a `local-path` claim, which local-path-provisioner backs with a
+  # hostPath directory on one node. That cost four things, none of them obvious
+  # from the pod spec (which declares an ordinary PVC, so Kyverno's hostPath
+  # policy never saw it):
+  #   - no backup at all: velero's FSB path skips hostPath volumes
+  #     unconditionally, and portainer has no VolSync ReplicationSource
+  #   - hard-pinned to k8sworker02 by a *required* PV nodeAffinity
+  #   - a single unreplicated copy, with reclaimPolicy Delete
+  #   - invisible to monitoring: kubelet publishes no volume_stats for it, so
+  #     KubePersistentVolumeFillingUp could never fire on it
+  # Longhorn fixes all four for free and makes portainer consistent with every
+  # other stateful workload here -- this was the last local-path PVC in the cluster.
+  storageClassName: longhorn
+  resources:
+    requests:
+      # Portainer's BoltDB + certs are tens of MB; the old claim was 10Gi
+      # because local-path costs nothing to over-provision. On Longhorn this is
+      # x3 replicas, so size it for the data. Longhorn expands online if needed.
+      storage: 5Gi

--- a/docs/runbooks/pvc-storageclass-migration.md
+++ b/docs/runbooks/pvc-storageclass-migration.md
@@ -1,0 +1,119 @@
+# Migrating a PVC to a different StorageClass
+
+`storageClassName` is immutable on a bound PVC, so switching storage backends means
+creating a **new** claim and copying the data across. This is the general form of the
+procedure used for Prometheus (`longhorn` → `longhorn-r2`) and Portainer
+(`local-path` → `longhorn`).
+
+## Why the obvious approach fails
+
+Deleting the PVC and letting the controller recreate it does **not** work when an
+operator or Deployment is still running: the controller recreates the pod, which
+re-mounts the claim before `pvc-protection` releases it, and the old PVC survives.
+The workload must be scaled to zero first — and for a Helm-managed app, Flux must be
+suspended so it does not immediately scale it back.
+
+## Procedure
+
+Use a **new claim name** and point the app at it. That keeps the old data intact until
+you have verified the migration, and makes rollback a one-line revert.
+
+```bash
+NS=portainer
+OLD=portainer          # existing claim
+NEW=portainer-data     # new claim, declared in git on the target StorageClass
+HR=portainer           # HelmRelease name
+```
+
+**1. Suspend Flux so it cannot roll the app onto the empty new volume.**
+
+```bash
+flux suspend helmrelease $HR -n $NS
+```
+
+Suspend **before merging** the PR. The claim itself is applied by the Flux
+*Kustomization* (it is a plain manifest), so it is created even while the HelmRelease
+is suspended — which is exactly what you want: new volume present, app still on the old one.
+
+**2. Merge the PR and confirm the new claim is Bound.**
+
+```bash
+kubectl get pvc -n $NS $NEW    # must reach Bound before copying
+```
+
+**3. Scale the app to zero.** An RWO volume cannot be mounted by the copy job while the
+app holds it.
+
+```bash
+kubectl scale deployment/$HR -n $NS --replicas=0
+kubectl wait --for=delete pod -l app.kubernetes.io/name=$HR -n $NS --timeout=120s
+```
+
+**4. Copy the data with a throwaway pod that mounts both claims.** Do not rely on
+`kubectl cp` — many app images are distroless and have neither `tar` nor a shell
+(Portainer's has neither).
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pvc-migrate
+  namespace: portainer
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels: {app: pvc-migrate, env: production, category: apps}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: copy
+          image: alpine:3.23.4
+          # -a preserves ownership/permissions/timestamps; Portainer runs as
+          # root (runAsUser 0) and cares about the mode on its BoltDB.
+          command: ["sh", "-c", "set -e; du -sh /old; cp -a /old/. /new/; sync; du -sh /new; ls -la /new"]
+          volumeMounts:
+            - {name: old, mountPath: /old}
+            - {name: new, mountPath: /new}
+          resources:
+            requests: {cpu: 50m, memory: 64Mi}
+            limits: {cpu: 500m, memory: 256Mi}
+      volumes:
+        - {name: old, persistentVolumeClaim: {claimName: portainer}}
+        - {name: new, persistentVolumeClaim: {claimName: portainer-data}}
+```
+
+**Compare the two `du -sh` lines in the job log before continuing.** They should match.
+
+**5. Resume Flux.** The app comes back on the new claim.
+
+```bash
+flux resume helmrelease $HR -n $NS
+kubectl rollout status deployment/$HR -n $NS
+```
+
+**6. Verify the app in its own terms** — not just that the pod is Running. For
+Portainer: log in and confirm the Kubernetes environment, teams and registries are
+still there.
+
+**7. Only then, delete the old claim.**
+
+```bash
+kubectl delete pvc -n $NS $OLD
+```
+
+Leave it for a few days if the volume is small. On `local-path` the PV has
+`reclaimPolicy: Delete`, so deleting the claim destroys the data irreversibly.
+
+## Gotchas
+
+- **Node-pinned source volumes.** A `local-path` PV carries a *required* nodeAffinity, so
+  the copy job is forced onto that node. If the target StorageClass cannot schedule a
+  replica there, the job stays `Pending` — check Longhorn's per-node schedulable space first.
+- **RWO means one mounter.** The app must be at zero replicas; a `Recreate` strategy alone
+  is not enough.
+- **Size for the new backend.** 10Gi on `local-path` is free; on Longhorn it is 10Gi × the
+  replica count. Size for the data and expand online later.
+- **Check `kubelet_volume_stats_*` afterwards.** `local-path`/hostPath volumes publish no
+  volume metrics, so a claim that was invisible to `KubePersistentVolumeFillingUp` should
+  start reporting once it is on a CSI driver. That is the confirmation the swap really took.


### PR DESCRIPTION
## Where this came from

The 2026-08-18 `daily-b2` backup completed cleanly with exactly one warning:

```
Volume data in pod portainer/portainer-... is a hostPath volume
which is not supported for pod volume backup, skipping
```

Worth pulling on, because that's Portainer's database.

## What's actually going on

The pod spec declares an ordinary PVC — **this is not a Kyverno violation**. The hostPath is a layer down, in the PV: the claim sits on `local-path`, and local-path-provisioner backs claims with a directory on the node (`/opt/local-path-provisioner/...`). Kyverno inspects the pod spec, so it never saw it.

That indirection hid four things:

| | |
|---|---|
| **No backup at all** | Velero's FSB path skips hostPath unconditionally, and portainer has no VolSync ReplicationSource (only `harbor` and `mediastack` do) |
| **Node-pinned** | *required* PV nodeAffinity to `k8sworker02` — portainer can't start anywhere else |
| **Unreplicated** | one copy on one local disk, `reclaimPolicy: Delete` |
| **Invisible to monitoring** | `kubelet_volume_stats_used_bytes{namespace="portainer"}` returns nothing while 44 other PVCs report — `KubePersistentVolumeFillingUp` could never fire on it |

It's also the **only local-path PVC left in the cluster**, which reads as a leftover rather than a decision.

## Severity, honestly

Low. Portainer is a management UI, not a system of record, and the cluster is GitOps-driven — nothing depends on it being up. Its OAuth config is Terraform-managed (`terraform/authentik/portainer.tf`) and `oauth_auto_create_users = true` regenerates users on login.

What you'd lose rebuilding: the Kubernetes endpoint definition, teams/RBAC, registry configs, UI-created stacks, API keys. A short reconfigure, not a disaster — but there's no reason to keep the gap.

## Changes

- **`pvc.yaml`** — new `portainer-data` claim on `longhorn`, declared in git. The old `portainer` PVC existed **only in the cluster**, in no manifest, so nothing would have recreated it.
- **`configmap.yaml`** — `existingClaim` repointed.
- **`docs/runbooks/pvc-storageclass-migration.md`** — the migration procedure.

**Sized 5Gi, down from 10Gi.** 10Gi is free on local-path but is ×3 replicas on Longhorn, and Portainer's BoltDB is tens of MB. Verified all six Longhorn nodes have 80–140 GB schedulable before choosing. Expands online if wrong.

The chart already sets `strategy: Recreate`, so the RWO requirement is satisfied — no change needed.

## ⚠️ Merge order matters

`storageClassName` is immutable, so this needs a data copy. **Suspend the HelmRelease before merging**, or Flux rolls Portainer onto an empty volume:

```bash
flux suspend helmrelease portainer -n portainer
```

The PVC is applied by the Flux *Kustomization*, not the HelmRelease, so it still gets created while suspended — new volume present, app still on the old one. Then scale to zero, run the copy job, resume.

Full procedure in the runbook, including why `kubectl cp` is not an option here (the Portainer image has neither a shell nor `tar` — I checked).

The old claim is left in place. Deleting it is a separate, deliberate step after verifying Portainer's own state came across.