### PR TITLE
feat(monitoring): warn before the vCenter metrics password expires

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kustomization.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kustomization.yaml
@@ -15,5 +15,6 @@ resources:
   - kube-prometheus-stack/app
   - loki/app
   - promtail/app
+  - vcenter-credential-age/app
   - victoria-metrics/app
   - victoria-metrics-lt/app

--- a/clusters/vollminlab-cluster/monitoring/vcenter-credential-age/app/check.sh
+++ b/clusters/vollminlab-cluster/monitoring/vcenter-credential-age/app/check.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Warn BEFORE the vCenter metrics account's password expires.
+#
+# vCenter does not expose password age: `govc sso.user.ls -json` returns only
+# Disabled/Locked/Details/groups, and the SSO API has no last-set field. So expiry
+# has to be derived from the rotation date plus the SSO Local Password Policy
+# (`govc sso.lpp.info` -> PasswordLifetimeDays, 90 as of 2026-08-18).
+#
+# Deliberately takes NO credentials -- it is pure date arithmetic. It must never
+# be a reason for vCenter or 1Password access to exist inside the cluster.
+#
+# On "expiring soon" it exits non-zero so the existing KubeJobFailed alert fires.
+# That reuses alerting we already have instead of adding an exporter or a rule.
+set -eu
+
+: "${ACCOUNT:?ACCOUNT not set}"
+: "${ROTATED_AT:?ROTATED_AT not set (YYYY-MM-DD)}"
+: "${LIFETIME_DAYS:?LIFETIME_DAYS not set}"
+: "${WARN_DAYS:?WARN_DAYS not set}"
+
+# busybox needs -D for an explicit input format; GNU date rejects -D and parses
+# ISO dates natively. Try busybox first, fall back to GNU, so the same script runs
+# in the alpine image and under a developer's shell.
+to_epoch() {
+  date -u -D '%Y-%m-%d' -d "$1" +%s 2>/dev/null \
+    || date -u -d "$1" +%s 2>/dev/null
+}
+
+rot_epoch=$(to_epoch "$ROTATED_AT") || rot_epoch=""
+if [ -z "$rot_epoch" ]; then
+  echo "ERROR: could not parse ROTATED_AT='$ROTATED_AT' (want YYYY-MM-DD)"
+  exit 2
+fi
+
+# NOW_EPOCH is a test seam; unset in production.
+now_epoch=${NOW_EPOCH:-$(date -u +%s)}
+exp_epoch=$((rot_epoch + LIFETIME_DAYS * 86400))
+days_left=$(((exp_epoch - now_epoch) / 86400))
+exp_date=$(date -u -d "@${exp_epoch}" +%Y-%m-%d 2>/dev/null || echo "epoch ${exp_epoch}")
+
+echo "account=${ACCOUNT} rotated=${ROTATED_AT} lifetime=${LIFETIME_DAYS}d expires=${exp_date} days_left=${days_left}"
+
+if [ "$days_left" -gt "$WARN_DAYS" ]; then
+  echo "OK: ${days_left} days remaining (warn at ${WARN_DAYS})"
+  exit 0
+fi
+
+if [ "$days_left" -lt 0 ]; then
+  echo "EXPIRED ${days_left#-} days ago -- the exporter is probably already failing."
+else
+  echo "EXPIRING in ${days_left} days (warn threshold ${WARN_DAYS})."
+fi
+
+cat <<'MSG'
+
+Rotate it (see docs/runbooks/vcenter-metrics-credential-rotation.md):
+  1. govc sso.user.update -p <new> prometheus-exporter     # the ONLY vSphere write
+  2. update 1Password item "vCenter Metrics" (field: password)
+  3. kubectl annotate externalsecret -n monitoring vmware-exporter-credentials \
+       force-sync="$(date +%s)" --overwrite                # ESO refreshInterval is 24h --
+                                                           # without this the old password
+                                                           # is re-rendered by Helm
+  4. flux reconcile helmrelease vmware-exporter -n monitoring --with-source
+  5. bump ROTATED_AT in the vcenter-credential-age CronJob and merge
+
+This job failing IS the alert. It takes no credentials and cannot rotate anything itself.
+MSG
+exit 1

--- a/clusters/vollminlab-cluster/monitoring/vcenter-credential-age/app/check_test.sh
+++ b/clusters/vollminlab-cluster/monitoring/vcenter-credential-age/app/check_test.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Pure-shell tests for check.sh. No cluster, no credentials, no network.
+# Must pass under BOTH dash and busybox ash (the image is alpine).
+#   sh check_test.sh   /   dash check_test.sh   /   busybox ash check_test.sh
+set -u
+DIR=$(dirname "$0")
+SCRIPT="$DIR/check.sh"
+pass=0; fail=0
+
+# 2026-08-18T00:00:00Z = 1787011200
+run() { # desc, expected_rc, NOW_EPOCH, ROTATED_AT, [expect_substring]
+  desc=$1; want=$2; now=$3; rot=$4; needle=${5:-}
+  out=$(ACCOUNT=test ROTATED_AT="$rot" LIFETIME_DAYS=90 WARN_DAYS=14 NOW_EPOCH="$now" \
+        sh "$SCRIPT" 2>&1); got=$?
+  ok=1
+  [ "$got" = "$want" ] || ok=0
+  if [ -n "$needle" ]; then
+    echo "$out" | grep -q "$needle" || ok=0
+  fi
+  if [ "$ok" = 1 ]; then pass=$((pass+1)); echo "  PASS  $desc"
+  else fail=$((fail+1)); echo "  FAIL  $desc (rc=$got want=$want)"; echo "$out" | sed 's/^/        /'; fi
+}
+
+echo "check.sh tests"
+# rotated today -> 90 days left -> OK
+run "fresh rotation exits 0"            0 1787011200 2026-08-18 "days_left=90"
+# 75 days later -> 15 left -> still above warn(14)
+run "15 days left still OK"             0 $((1787011200 + 75*86400)) 2026-08-18 "days_left=15"
+# 76 days later -> 14 left -> at threshold -> alert
+run "14 days left alerts"               1 $((1787011200 + 76*86400)) 2026-08-18 "EXPIRING in 14 days"
+# past expiry
+run "expired alerts and says so"        1 $((1787011200 + 95*86400)) 2026-08-18 "EXPIRED 5 days ago"
+# unparseable date -> rc 2, not a false OK
+run "bad date exits 2 (not 0)"          2 1787011200 "not-a-date" "could not parse"
+
+# missing env must fail loudly rather than default to OK
+out=$(ACCOUNT=test LIFETIME_DAYS=90 WARN_DAYS=14 sh "$SCRIPT" 2>&1); rc=$?
+if [ "$rc" != 0 ]; then pass=$((pass+1)); echo "  PASS  missing ROTATED_AT is fatal"
+else fail=$((fail+1)); echo "  FAIL  missing ROTATED_AT returned 0"; fi
+
+echo "passed=$pass failed=$fail"
+[ "$fail" = 0 ]

--- a/clusters/vollminlab-cluster/monitoring/vcenter-credential-age/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/monitoring/vcenter-credential-age/app/cronjob.yaml
@@ -1,0 +1,73 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: vcenter-credential-age
+  namespace: monitoring
+  labels:
+    app: vcenter-credential-age
+    env: production
+    category: observability
+spec:
+  # Weekly. The thing being watched moves one day per day, so anything more
+  # frequent is noise; WARN_DAYS 14 leaves two checks before expiry.
+  schedule: "17 8 * * 1"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      # Not 0: a transient pod failure would otherwise mark the Job Failed and
+      # fire a false alert. The check is deterministic, so retries cannot flip a
+      # genuine "expiring" result to OK -- they only absorb infrastructure blips.
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app: vcenter-credential-age
+            env: production
+            category: observability
+        spec:
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: check
+              image: alpine:3.23.4
+              command: ["/bin/sh", "/scripts/check.sh"]
+              env:
+                # Update ROTATED_AT whenever the password is rotated -- that is the
+                # single manual step this design trades for needing no credentials.
+                # Forgetting it makes the alert fire EARLY, never late.
+                - name: ACCOUNT
+                  value: prometheus-exporter@vsphere.local
+                - name: ROTATED_AT
+                  value: "2026-08-18"
+                # vCenter SSO Local Password Policy PasswordLifetimeDays.
+                # Read it back with: govc sso.lpp.info
+                - name: LIFETIME_DAYS
+                  value: "90"
+                - name: WARN_DAYS
+                  value: "14"
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 16Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+          volumes:
+            - name: scripts
+              configMap:
+                name: vcenter-credential-age-scripts
+                defaultMode: 0555

--- a/clusters/vollminlab-cluster/monitoring/vcenter-credential-age/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/monitoring/vcenter-credential-age/app/cronjob.yaml
@@ -16,6 +16,19 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      # WITHOUT THIS THE ALERT NEVER CLEARS. kube_job_failed is reported per Job
+      # OBJECT, and failedJobsHistoryLimit only evicts a failed Job when three
+      # NEWER failures replace it -- so once this fires, rotating the password and
+      # bumping ROTATED_AT makes later runs succeed while the old failed Job keeps
+      # kube_job_failed=1 and KubeJobFailed pinned on forever. Proof this is real:
+      # velero/sealed-secrets-minio-kopia-maintain-job-1782995457971 failed on
+      # 2026-07-02 and STILL reports kube_job_failed=1 six weeks later (it is quiet
+      # only because KubeJobFailed excludes velero kopia-maintain jobs).
+      #
+      # 3 days on a weekly schedule: the alert fires Monday, self-clears Thursday,
+      # and re-fires the next Monday if still unrotated -- a weekly nag rather than
+      # a stuck alert. Once rotated, it simply never comes back.
+      ttlSecondsAfterFinished: 259200
       # Not 0: a transient pod failure would otherwise mark the Job Failed and
       # fire a false alert. The check is deterministic, so retries cannot flip a
       # genuine "expiring" result to OK -- they only absorb infrastructure blips.

--- a/clusters/vollminlab-cluster/monitoring/vcenter-credential-age/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/monitoring/vcenter-credential-age/app/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: vcenter-credential-age
+# Required: configMapGenerator emits a ConfigMap with NO namespace, and the
+# monitoring Flux Kustomization sets no targetNamespace -- so the generated
+# object is rejected ("namespace not specified" / Kyverno block-default-namespace)
+# and takes the whole monitoring Kustomization down with it. cronjob.yaml already
+# carries namespace: monitoring; this makes the generated object match.
+# Same trap documented in velero/velero-pvb-healer/app/kustomization.yaml.
+namespace: monitoring
+resources:
+  - cronjob.yaml
+configMapGenerator:
+  - name: vcenter-credential-age-scripts
+    files:
+      - check.sh
+generatorOptions:
+  disableNameSuffixHash: true
+  labels:
+    app: vcenter-credential-age
+    env: production
+    category: observability

--- a/docs/runbooks/vcenter-metrics-credential-rotation.md
+++ b/docs/runbooks/vcenter-metrics-credential-rotation.md
@@ -1,0 +1,100 @@
+# Rotating the vCenter metrics credential
+
+`vmware-exporter` authenticates to vCenter as **`prometheus-exporter@vsphere.local`**. That is an
+SSO local account, and the vsphere.local **Local Password Policy** expires passwords after
+`PasswordLifetimeDays` (90 as of 2026-08-18). When it lapses, the exporter's scrape fails and
+`TargetDown` fires.
+
+## Why this is a manual rotation
+
+- **The expiry cannot be queried.** `govc sso.user.ls -json` returns only `Disabled`, `Locked`,
+  `Details` and group membership — there is no password-last-set or expiry field anywhere in the
+  SSO API. Expiry is only knowable as *rotation date + policy*.
+- **There is no per-user "never expires".** `govc sso.lpp.update -PasswordLifetimeDays 0` sets it
+  for **every** vsphere.local account including `administrator@`, which is a security-posture change
+  we deliberately rejected. A per-user override needs `dir-cli` on the VCSA appliance shell.
+- **Automating the rotation would need vCenter credentials inside the cluster** — the cluster whose
+  nodes are VMs on that vCenter. That is the same layering violation that rules out managing vSphere
+  from the in-cluster tofu-controller.
+
+So the `vcenter-credential-age` CronJob only *warns*; a human rotates.
+
+## The warning
+
+`monitoring/vcenter-credential-age` runs weekly and is pure date arithmetic — **it holds no
+credentials and can reach neither vCenter nor 1Password**. When fewer than `WARN_DAYS` (14) remain it
+**exits non-zero**, so the existing `KubeJobFailed` alert fires. That is deliberate: it reuses
+alerting we already have rather than adding an exporter, a Pushgateway or a new rule.
+
+Because it derives expiry from `ROTATED_AT`, forgetting to bump that makes the alert fire **early,
+never late**.
+
+## Rotation procedure
+
+Confirm which account you are touching first — there are three similar 1Password items:
+
+| 1P item | account |
+|---|---|
+| `vCenter Admin SSO` | `administrator@vsphere.local` |
+| **`vCenter Metrics`** | **`prometheus-exporter@vsphere.local`** — this one |
+| `vCenter local user SSO` | `vollmin@vsphere.local` |
+
+1. **Generate** a password meeting the policy: 8-20 chars, at least one upper, lower, digit and
+   special, no more than 3 identical adjacent, and not one of the last 5. Restrict specials to
+   `-_.!@#%` so nothing downstream needs escaping. Check the live policy with `govc sso.lpp.info`.
+
+2. **Set it in vCenter** as administrator. This is the *only* vSphere write required:
+
+   ```bash
+   govc sso.user.update -p '<new>' prometheus-exporter
+   ```
+
+   Pass **only** `-p`. `-R` (role), `-C` (cert) and `-A` (ActAsUser) would change other attributes.
+   Verify afterwards that `govc sso.user.ls -json` still shows `Disabled:false Locked:false`.
+
+3. **Update 1Password first**, before the cluster — it is the source of truth:
+   item `vCenter Metrics`, field `password`.
+
+4. **Force the ExternalSecret to re-read it.** This step is the one that bites:
+
+   ```bash
+   kubectl annotate externalsecret -n monitoring vmware-exporter-credentials \
+     force-sync="$(date +%s)" --overwrite
+   ```
+
+   `vmware-exporter-credentials` has `refreshInterval: 24h`. Without this it keeps serving the old
+   password for up to a day, and since the chart renders `vmware-exporter-secret` **from** it, the
+   next HelmRelease reconcile silently re-applies the expired password — hours after the fix looked
+   complete.
+
+5. **Reconcile and restart:**
+
+   ```bash
+   flux reconcile helmrelease vmware-exporter -n monitoring --with-source
+   kubectl rollout restart deployment/vmware-exporter -n monitoring
+   ```
+
+6. **Bump `ROTATED_AT`** in `monitoring/vcenter-credential-age/app/cronjob.yaml` and merge, or the
+   warning keeps firing.
+
+## Verify by evidence, not by pod status
+
+The exporter reports `Service is UP` on its own health endpoint even when vCenter auth is broken, and
+logs only a downstream `AttributeError: 'NoneType' object has no attribute 'RetrieveContent'` — never
+the login failure. So check the data:
+
+```bash
+# target is scraping
+promtool query instant http://localhost:9090 'up{job="vmware-exporter"}'          # want 1
+# and returning real inventory, not just answering
+promtool query instant http://localhost:9090 'count(vmware_host_power_state)'     # want 3 (ESXi hosts)
+promtool query instant http://localhost:9090 'count(vmware_datastore_capacity_size)'  # want 6
+```
+
+Also confirm the log shows `Finished collecting metrics from vcenter.vollminlab.com` with no
+`RetrieveContent` lines.
+
+## Tests
+
+`sh check_test.sh` in the app directory — pure shell, no cluster. Must pass under `sh`, `dash` and
+`busybox ash`, since the image is alpine.

--- a/docs/runbooks/vcenter-metrics-credential-rotation.md
+++ b/docs/runbooks/vcenter-metrics-credential-rotation.md
@@ -29,6 +29,23 @@ alerting we already have rather than adding an exporter, a Pushgateway or a new 
 Because it derives expiry from `ROTATED_AT`, forgetting to bump that makes the alert fire **early,
 never late**.
 
+## What the alert looks like, and when it clears
+
+`KubeJobFailed` is `severity: warning` with `for: 15m`. Alertmanager's default route sends warnings
+to **Pushover at priority 0**, repeating every 12h; only `severity: critical` goes to the priority-1
+`pushover-critical` route. So expect a normal-priority phone notification roughly 15 minutes after
+the Monday 08:17 run, repeating twice a day until it resolves.
+
+**The Job carries `ttlSecondsAfterFinished: 259200` (3 days) and that is load-bearing.**
+`kube_job_failed` is reported per Job *object*, and `failedJobsHistoryLimit` only evicts a failed Job
+once three newer failures replace it. Without the TTL, rotating the password would make later runs
+succeed while the original failed Job kept `kube_job_failed=1` and the alert pinned on permanently.
+(Not hypothetical: `velero/sealed-secrets-minio-kopia-maintain-job-1782995457971` failed on
+2026-07-02 and still reported `kube_job_failed=1` six weeks later.)
+
+With the TTL the behaviour is: fires Monday, self-clears Thursday, re-fires the next Monday if still
+unrotated — a weekly nag rather than a stuck alert. Once you rotate and bump `ROTATED_AT`, it stops.
+
 ## Rotation procedure
 
 Confirm which account you are touching first — there are three similar 1Password items:


### PR DESCRIPTION
## Why

The exporter's vCenter account expired on 2026-08-18 and we found out from `TargetDown` — *after* it broke.

**vCenter cannot tell us when it will happen again.** `govc sso.user.ls -json` returns only `Disabled`, `Locked`, `Details` and groups; the SSO API has no password-last-set or expiry field anywhere. Expiry is only knowable as **rotation date + `sso.lpp.info` PasswordLifetimeDays** (90).

## What

A weekly CronJob doing exactly that arithmetic. Under `WARN_DAYS` (14) it **exits non-zero**, so the existing `KubeJobFailed` alert fires — no new exporter, Pushgateway, or PrometheusRule needed.

**It takes no credentials.** Pure date math; it can reach neither vCenter nor 1Password. That's deliberate: automating the *rotation* would mean putting vCenter credentials inside the cluster whose nodes are VMs on that vCenter — the same layering violation that rules out managing vSphere from the in-cluster tofu-controller. So this warns; a human rotates.

Because expiry is derived from `ROTATED_AT`, forgetting to bump it makes the alert fire **early, never late** — the safe direction.

## Rejected alternatives

| option | why not |
|---|---|
| `sso.lpp.update -PasswordLifetimeDays 0` | Global — removes expiry for `administrator@` too. Security-posture change we don't want. |
| per-user never-expire | Needs `dir-cli` on the VCSA appliance shell; much larger footprint. |
| probe the credential | Only detects expiry *after* it breaks — exactly what already happened. |
| auto-rotation | Requires vCenter credentials in-cluster. Layering violation. |

## A real bug the dry-run caught

`configMapGenerator` emits a ConfigMap with **no namespace**, and the `monitoring` Flux Kustomization sets no `targetNamespace` — so the generated object is rejected and would have taken **the whole monitoring Kustomization** down with it.

This trap is already documented in `velero/velero-pvb-healer/app/kustomization.yaml`; I hit it anyway and only caught it because `kubectl apply --dry-run=server` returned Kyverno's `block-default-namespace`. Fixed with an explicit `namespace: monitoring` plus a comment pointing at the precedent.

## Verification

- `check_test.sh` — **6/6 passing under `sh`, `dash` and `busybox ash`** (image is alpine). Covers the boundary (15 days OK / 14 alerts), post-expiry, an unparseable date exiting **2** rather than a false OK, and missing env being fatal.
- `kubectl kustomize` renders both objects in `monitoring`
- `kubectl apply --dry-run=server` — both accepted by the API server and Kyverno
- yamllint clean

## Runbook

`docs/runbooks/vcenter-metrics-credential-rotation.md` documents the rotation, including the two non-obvious steps:

- `govc sso.user.update -p` is the **only** vSphere write needed — passing `-R`/`-C`/`-A` would change other attributes
- **force-sync the ExternalSecret afterwards.** `vmware-exporter-credentials` has `refreshInterval: 24h`, and the chart renders `vmware-exporter-secret` *from* it — so without the force-sync, the next HelmRelease reconcile silently re-applies the expired password hours after the fix looked complete. That nearly happened during this incident.

First alert lands ~2026-11-02, two weeks before the ~2026-11-16 expiry.