### PR TITLE
fix(kyverno): root foreach list paths at request.object

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/inject-resource-requirements.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/inject-resource-requirements.yaml
@@ -35,7 +35,7 @@ spec:
                       - engine-image-ei-db6c2b6f
       mutate:
         foreach:
-          - list: "spec.template.spec.containers || `[]`"
+          - list: "request.object.spec.template.spec.containers || `[]`"
             preconditions:
               all:
                 - key: "{{element.name}}"
@@ -54,7 +54,7 @@ spec:
                           limits:
                             cpu: "100m"
                             memory: "128Mi"
-          - list: "spec.template.spec.containers || `[]`"
+          - list: "request.object.spec.template.spec.containers || `[]`"
             preconditions:
               all:
                 - key: "{{element.name}}"
@@ -73,7 +73,7 @@ spec:
                           limits:
                             cpu: "100m"
                             memory: "128Mi"
-          - list: "spec.template.spec.containers || `[]`"
+          - list: "request.object.spec.template.spec.containers || `[]`"
             preconditions:
               all:
                 - key: "{{element.name}}"
@@ -92,7 +92,7 @@ spec:
                           limits:
                             cpu: "100m"
                             memory: "128Mi"
-          - list: "spec.template.spec.containers || `[]`"
+          - list: "request.object.spec.template.spec.containers || `[]`"
             preconditions:
               all:
                 - key: "{{element.name}}"
@@ -111,7 +111,7 @@ spec:
                           limits:
                             cpu: "100m"
                             memory: "128Mi"
-          - list: "spec.template.spec.containers || `[]`"
+          - list: "request.object.spec.template.spec.containers || `[]`"
             preconditions:
               all:
                 - key: "{{element.name}}"
@@ -130,7 +130,7 @@ spec:
                           limits:
                             cpu: "50m"
                             memory: "64Mi"
-          - list: "spec.template.spec.containers || `[]`"
+          - list: "request.object.spec.template.spec.containers || `[]`"
             preconditions:
               all:
                 - key: "{{element.name}}"
@@ -149,7 +149,7 @@ spec:
                           limits:
                             cpu: "20m"
                             memory: "32Mi"
-          - list: "spec.template.spec.containers || `[]`"
+          - list: "request.object.spec.template.spec.containers || `[]`"
             preconditions:
               all:
                 - key: "{{element.name}}"
@@ -168,7 +168,7 @@ spec:
                           limits:
                             cpu: "300m"
                             memory: "512Mi"
-          - list: "spec.template.spec.containers || `[]`"
+          - list: "request.object.spec.template.spec.containers || `[]`"
             preconditions:
               all:
                 - key: "{{element.name}}"
@@ -187,7 +187,7 @@ spec:
                           limits:
                             cpu: "100m"
                             memory: "128Mi"
-          - list: "spec.template.spec.containers || `[]`"
+          - list: "request.object.spec.template.spec.containers || `[]`"
             preconditions:
               all:
                 - key: "{{element.name}}"

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-image-registries.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-image-registries.yaml
@@ -35,7 +35,7 @@ spec:
           mirror.gcr.io, oci.trueforge.org, reg.kyverno.io, us-docker.pkg.dev.
           Short names without an explicit domain are also permitted.
         foreach:
-          - list: "spec.template.spec.containers || `[]`"
+          - list: "request.object.spec.template.spec.containers || `[]`"
             deny:
               conditions:
                 all:
@@ -60,7 +60,7 @@ spec:
           mirror.gcr.io, oci.trueforge.org, reg.kyverno.io, us-docker.pkg.dev.
           Short names without an explicit domain are also permitted.
         foreach:
-          - list: "spec.template.spec.initContainers || `[]`"
+          - list: "request.object.spec.template.spec.initContainers || `[]`"
             deny:
               conditions:
                 all:


### PR DESCRIPTION
## Problem

`restrict-image-registries` (Enforce) and `inject-resource-requirements` (mutate) both declared their foreach list as a bare `spec.template.spec.containers`.

Kyverno resolves `foreach.list` as a JMESPath against the rule context, where the resource lives under `request.object`. The bare path resolves to null, the loop iterates zero elements, and the rule emits **no result at all** — so the policy reports neither pass nor fail and admission lets everything through.

Both have been inert since they were written.

| Policy | Should do | Actually did |
|---|---|---|
| `restrict-image-registries` | Deny untrusted registries | Nothing — `evil.example.com/nope:1.0` was admitted by server-side dry-run |
| `inject-resource-requirements` | Inject CPU/mem on longhorn containers | Nothing — `longhorn-ui` and `longhorn-manager` run with `resources: {}` |

This is why Policy Reporter showed a clean board: 0 fail, but also 0 pass.

## Fix

Prefix the `list:` JMESPath with `request.object.` — 11 lines, no logic change.

## Verification

`kyverno apply` against all 119 live Deployments/StatefulSets/DaemonSets, with all 6 PolicyExceptions loaded:

```
restrict-image-registries      132 pass / 0 fail / 0 error
inject-resource-requirements     6 pass / 0 fail / 0 error
```

No existing workload becomes non-compliant. The mutate correctly produces `cpu: 20m/5m, memory: 32Mi/16Mi` on `longhorn-ui`.

Negative case confirmed: the bad-registry Deployment passes `0 fail` before this change and `1 fail` after.

## Not in this PR

`require-resources` carries the identical defect. Fixing it makes 29 existing controllers non-compliant — all upstream charts (monitoring 7, longhorn-system 11, harbor 5, metallb 2, kube-system 2, plus kyverno/tailscale/trivy/authentik). `allowExistingViolations: true` means they keep updating, but a DR rebuild would hit them. Separate PR once we decide between chart-level limits and a scoped exception.

Also noted for later: `inject-resource-requirements` selects `engine-image-ei-db6c2b6f` by hash, and there are 5 live `engine-image-ei-*` DaemonSets. That list goes stale on every Longhorn upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5reMTCRpW929DxF6xeLXD