### PR TITLE
feat(portainer): declare the Kubernetes environment in tofu

### DIFF
--- a/terraform/authentik/portainer.tf
+++ b/terraform/authentik/portainer.tf
@@ -24,3 +24,32 @@ resource "portainer_settings" "main" {
     ignore_changes = [oauth_settings[0].hide_internal_auth]
   }
 }
+
+# The Kubernetes environment Portainer manages. Portainer runs in-cluster and
+# talks to the API server with the portainer-sa-clusteradmin ServiceAccount, so
+# this is a local Kubernetes environment (type 5) — no agent, no credentials.
+#
+# This was the one piece of Portainer's configuration that lived only in
+# portainer.db. When the database was lost on 2026-08-19 the OAuth settings
+# above came back on the next reconcile and this did not, because nothing
+# declared it. Registering it here closes that gap: a wiped database now
+# rebuilds to a working Portainer without anyone clicking through the setup
+# wizard.
+resource "portainer_environment" "local" {
+  name = "local"
+  type = 5
+
+  # Portainer rewrites an empty URL to this for type 5 regardless of what is
+  # sent, so declaring the same value is what keeps the plan empty.
+  environment_address = "https://kubernetes.default.svc"
+  group_id            = 1
+
+  # On update the provider mirrors environment_address into PublicURL whenever
+  # public_ip is unset, then reads it straight back into public_ip — so leaving
+  # it undeclared produces a diff on every 10-minute reconcile, forever. Same
+  # failure mode as hide_internal_auth above; same remedy. PublicURL only
+  # decorates published-port links, which a Kubernetes environment never uses.
+  lifecycle {
+    ignore_changes = [public_ip]
+  }
+}


### PR DESCRIPTION
## Why

Losing `portainer.db` on 2026-08-19 split Portainer's configuration cleanly in two, and the split is the whole point of this PR:

| | Declared in tofu? | Survived the wipe? |
|---|---|---|
| OAuth / Authentik SSO | yes (`portainer_settings.main`) | **yes** — restored on the next reconcile, untouched by hand |
| Kubernetes environment | no — lived only in `portainer.db` | **no** — Portainer had no cluster to manage and fell back to the setup wizard |

The half that was declarative healed itself. The half that wasn't is what had to be rebuilt by hand. This closes the gap so a wiped database rebuilds to a working Portainer on its own.

## What

One resource: the local Kubernetes environment. Portainer runs in-cluster against `portainer-sa-clusteradmin` (bound to `cluster-admin`), so it is type 5 — no agent, no credentials, no TLS material.

## Two details that are load-bearing

Both are commented in place, because both are silent perpetual-reapply loops rather than errors:

- **`environment_address` is pinned to `https://kubernetes.default.svc`.** Portainer rewrites an empty URL to exactly that string for type 5, whatever you send. Verified against the live API — sending `URL=` came back `URL='https://kubernetes.default.svc'`. Declaring anything else is a diff that never converges.
- **`public_ip` is ignored.** On update the provider mirrors `environment_address` into `PublicURL` whenever `public_ip` is unset, then `Read` pulls it straight back into `public_ip`. Leaving it undeclared re-applies every 10 minutes forever. This is the same failure mode `hide_internal_auth` already carries an `ignore_changes` for, and the same one behind the earlier authentik-config drift churn and CNPG WAL bloat. `PublicURL` only decorates published-port links, which a Kubernetes environment never uses.

## On the hand-registered environment

Portainer was left with no admin account and had already hit its security timeout, so the admin was re-initialised and the environment registered by hand to get it usable again. `portainer_environment` looks up an existing environment **by name** and adopts it rather than failing on conflict, so tofu takes that one over in place — it will not create a duplicate.