### PR TITLE
docs(runbooks): record the PVC rename trap that destroyed Portainer's data

### DIFF
--- a/docs/runbooks/pvc-storageclass-migration.md
+++ b/docs/runbooks/pvc-storageclass-migration.md
@@ -13,6 +13,57 @@ re-mounts the claim before `pvc-protection` releases it, and the old PVC survive
 The workload must be scaled to zero first — and for a Helm-managed app, Flux must be
 suspended so it does not immediately scale it back.
 
+## The rename trap — this destroyed Portainer's data on 2026-08-19
+
+**A PVC rename in a Flux manifest is not a rename. It is a delete plus a create.**
+
+Flux Kustomizations here run with `prune: true`. Flux does not diff resource *fields*, it
+diffs the *set of objects* the manifests declare. Change `metadata.name` from
+`portainer-data` to `portainer` in `pvc.yaml` and Flux reads that as: `portainer` is new,
+and `portainer-data` is no longer declared — so it garbage-collects it. The PVC, the PV and
+the Longhorn volume are all deleted, on the next reconcile, before anyone has copied a byte.
+
+That is exactly what happened in #1103. The intent was "shrink the claim from 10Gi to 1Gi";
+the effect was the immediate and unrecoverable deletion of Portainer's database. There was
+no snapshot, no Longhorn backup, and — because the source was `local-path` — no Velero
+PodVolumeBackup either. Nothing was recoverable.
+
+### The rule
+
+**The old claim's declaration must remain in git for the entire migration.** The new claim
+is *added alongside* it, never substituted for it. That means two PRs, in this order:
+
+1. **PR 1 — add.** Add the new claim as a new file. **Do not touch the old claim's
+   manifest.** Both declarations are now in git, so Flux prunes neither. Migrate the data,
+   point the app at the new claim, verify it comes up on real data.
+2. **PR 2 — remove.** Only once the app is verified on the new volume, delete the old
+   claim's declaration. This is the step that is allowed to be destructive, and by then the
+   data exists in two places.
+
+If you find yourself editing `metadata.name` on an existing PVC manifest, stop — that edit
+can only ever mean "delete the old volume".
+
+### Before starting, know what your safety net actually is
+
+Confirm the source volume has a recoverable copy *before* the first PR, and confirm it by
+looking, not by assuming a schedule covers it:
+
+```bash
+# Velero: has this namespace EVER produced a PodVolumeBackup? Zero means no safety net.
+kubectl get podvolumebackups.velero.io -n velero \
+  -o jsonpath='{range .items[*]}{.spec.pod.namespace}{"\n"}{end}' | grep -c "^$NS$"
+
+# Longhorn snapshots/backups for the volume (local-path has neither, by construction)
+kubectl get volumes.longhorn.io -n longhorn-system -o custom-columns='NAME:.metadata.name,PVC:.status.kubernetesStatus.pvcName'
+```
+
+**`local-path` volumes have no safety net at all.** Velero's filesystem backup path skips
+hostPath-backed volumes unconditionally, so a `local-path` PVC silently produces zero PVBs
+forever while the schedule reports `Completed` — and `local-path` PVs are
+`reclaimPolicy: Delete`, so a prune is instantly irreversible. Migrating *away* from
+`local-path` is therefore the most dangerous direction to run this procedure in, because it
+is precisely the case with nothing to fall back on.
+
 ## Procedure
 
 Use a **new claim name** and point the app at it. That keeps the old data intact until
@@ -117,3 +168,5 @@ Leave it for a few days if the volume is small. On `local-path` the PV has
 - **Check `kubelet_volume_stats_*` afterwards.** `local-path`/hostPath volumes publish no
   volume metrics, so a claim that was invisible to `KubePersistentVolumeFillingUp` should
   start reporting once it is on a CSI driver. That is the confirmation the swap really took.
+- **A rename is a delete.** See the rename trap above. The old claim's declaration stays in
+  git until the app is verified on the new volume — always two PRs, never one.


### PR DESCRIPTION
## What went wrong

#1103 set out to shrink Portainer's claim from 10Gi to 1Gi. It did that by editing `metadata.name` on the existing PVC manifest — and that is not a rename.

Flux Kustomizations here run `prune: true`, and Flux diffs the **set of declared objects**, not their fields. So the edit read as: `portainer` is new, `portainer-data` is no longer declared. Flux garbage-collected `portainer-data` — PVC, PV and Longhorn volume — on the next reconcile, before a single byte had been copied.

## Why nothing could restore it

| Safety net | Present? |
|---|---|
| Longhorn snapshot | no |
| Longhorn backup | no |
| Velero PodVolumeBackup | **no — zero, ever** |
| Original local-path PV | already deleted (`reclaimPolicy: Delete`) |

The Velero line is the one worth internalising: the source was `local-path`, and Velero's FSB path skips hostPath-backed volumes unconditionally. So Portainer produced **0 PVBs out of 6704 cluster-wide** across its entire life, while `daily-full` reported `Completed` every single night. Same shape as the `velero-victoria-metrics-b2` empty-backup finding — a schedule's phase tells you nothing about whether it covered anything.

That makes migrating *away* from `local-path` the most dangerous direction to run this procedure in, because it is precisely the case with no fallback.

## What the runbook now says

- **The rename trap**, with the mechanism spelled out — a rename in a Flux manifest is a delete plus a create.
- **The two-PR rule.** PR 1 *adds* the new claim as a new file and leaves the old manifest completely untouched; migrate and verify; only PR 2 removes the old declaration. If you are editing `metadata.name` on an existing PVC, that edit can only mean "delete the old volume".
- **A pre-flight safety-net check** — confirm a recoverable copy exists by *looking*, not by assuming a schedule covers it. Both commands are verified to run as written (the Velero one returns 0 for `portainer` today, which is the gap itself).
- A matching entry in Gotchas.

## Related

Portainer is otherwise recovered: admin re-initialised, environment re-registered, OAuth self-healed from tofu. #1105 closes the underlying gap by declaring the environment so a wiped database rebuilds itself. The new claim is on `longhorn`, and it was the last `local-path` PVC in the cluster — there are now zero, so this particular backup blind spot is closed cluster-wide.