### PR TITLE
fix(kyverno): size longhorn-manager injection to measured usage

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/inject-resource-requirements.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/inject-resource-requirements.yaml
@@ -19,20 +19,22 @@ spec:
                 - StatefulSet
               namespaces:
                 - longhorn-system
+              # longhorn-csi-plugin, longhorn-driver-deployer and every
+              # engine-image-ei-* object carry `app: longhorn`, not their own
+              # component name, so they cannot be targeted by this selector.
+              # Rules for them existed here but could never fire; they are
+              # covered by a PolicyException instead.
               selector:
                 matchExpressions:
                   - key: app
                     operator: In
                     values:
-                      - longhorn-driver-deployer
                       - longhorn-ui
                       - csi-attacher
                       - csi-provisioner
                       - csi-resizer
                       - csi-snapshotter
-                      - longhorn-csi-plugin
                       - longhorn-manager
-                      - engine-image-ei-db6c2b6f
       mutate:
         foreach:
           - list: "request.object.spec.template.spec.containers || `[]`"
@@ -116,25 +118,6 @@ spec:
               all:
                 - key: "{{element.name}}"
                   operator: Equals
-                  value: longhorn-driver-deployer
-            patchStrategicMerge:
-              spec:
-                template:
-                  spec:
-                    containers:
-                      - (name): longhorn-driver-deployer
-                        resources:
-                          requests:
-                            cpu: "10m"
-                            memory: "32Mi"
-                          limits:
-                            cpu: "50m"
-                            memory: "64Mi"
-          - list: "request.object.spec.template.spec.containers || `[]`"
-            preconditions:
-              all:
-                - key: "{{element.name}}"
-                  operator: Equals
                   value: longhorn-ui
             patchStrategicMerge:
               spec:
@@ -164,45 +147,7 @@ spec:
                         resources:
                           requests:
                             cpu: "100m"
-                            memory: "300Mi"
+                            memory: "384Mi"
                           limits:
-                            cpu: "300m"
-                            memory: "512Mi"
-          - list: "request.object.spec.template.spec.containers || `[]`"
-            preconditions:
-              all:
-                - key: "{{element.name}}"
-                  operator: Equals
-                  value: longhorn-csi-plugin
-            patchStrategicMerge:
-              spec:
-                template:
-                  spec:
-                    containers:
-                      - (name): longhorn-csi-plugin
-                        resources:
-                          requests:
-                            cpu: "20m"
-                            memory: "64Mi"
-                          limits:
-                            cpu: "100m"
-                            memory: "128Mi"
-          - list: "request.object.spec.template.spec.containers || `[]`"
-            preconditions:
-              all:
-                - key: "{{element.name}}"
-                  operator: Equals
-                  value: engine-image
-            patchStrategicMerge:
-              spec:
-                template:
-                  spec:
-                    containers:
-                      - (name): engine-image
-                        resources:
-                          requests:
-                            cpu: "10m"
-                            memory: "32Mi"
-                          limits:
-                            cpu: "50m"
-                            memory: "64Mi"
+                            cpu: "1"
+                            memory: "1Gi"


### PR DESCRIPTION
## Why

#1104 fixed the `foreach` list path, which made `inject-resource-requirements` fire for the first time. Its limits were written while the policy was inert, so they had never been validated against real usage — and one is below it.

`longhorn-manager`, 30 days from VictoriaMetrics:

| Metric | Observed | Injected limit |
|---|---|---|
| memory p95 | **563Mi** | 512Mi |
| memory max | **607Mi** | 512Mi |
| CPU peak | **452m** | 300m |

The p95 is already above the limit, so this isn't a tail risk. The next time that DaemonSet passes admission it would be OOMKilled on all 6 nodes — the storage control plane.

## Change

`longhorn-manager` → requests `100m / 384Mi`, limits `1 / 1Gi` (1.7x and 2.2x over observed peak).

The other five targets were measured the same way and are correctly sized, so they are unchanged:

| Container | Limit | 30d peak |
|---|---|---|
| csi-attacher | 128Mi | 55Mi |
| csi-provisioner | 128Mi | 54Mi |
| csi-resizer | 128Mi | 69Mi |
| csi-snapshotter | 128Mi | 64Mi |
| longhorn-ui | 32Mi | 6Mi |

## Dead rules removed

Three `foreach` blocks could never fire and are deleted:

- `longhorn-csi-plugin`, `longhorn-driver-deployer` and every `engine-image-ei-*` object carry `app: longhorn`, not their own component name, so the match selector never selected them.
- The engine-image rule additionally compared `element.name` to a literal `engine-image`, while the real container name is `engine-image-ei-<hash>`.

Removing them changes no live behaviour — those pods are unbounded today and stay unbounded. Leaving them in place would misrepresent the coverage, which is the same failure mode #1104 fixed. A PolicyException covers them in the follow-up.

## Verification

`kyverno apply` against all live `longhorn-system` controllers: 6 matched, 0 fail, 0 error — the same 6 objects as before the change, with `longhorn-manager` now at `1Gi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5reMTCRpW929DxF6xeLXD