### PR TITLE
docs(velero): explain why loki and alertmanager are unbacked

### DIFF
--- a/.claude/rules/velero.md
+++ b/.claude/rules/velero.md
@@ -61,10 +61,40 @@ That is correct — the metrics are the bulk of it and Velero is the wrong tool:
 - **grafana** IS backed up (`grafana-b2`), because grafana.db holds UI-created dashboards,
   users and API keys that exist nowhere else. The 35 sidecar dashboards are
   ConfigMap-provisioned and reproducible from git; grafana.db is not.
+- **loki** stores its chunks in **S3, not on its PVC** — `object_store: s3`, bucket `loki`,
+  endpoint `minio.minio.svc.cluster.local:9000`. `storage-loki-0` holds only the local TSDB
+  index and WAL, measured **79.7 MB of a 5.2 GB volume**; FSB would copy a rebuildable cache
+  and still miss every log line. The durable copy is the `loki` bucket in MinIO — which is
+  itself unbacked, because `minio` is excluded to prevent the backup store being backed up
+  into itself (see *Circular backup check*). So a MinIO loss loses the logs outright. That is
+  accepted: retention is 720h, and everything that consumes those logs (alert rules,
+  dashboards) is in git.
+- **alertmanager** (3 × 1Gi, measured **0 MB used**) holds only silences and the notification
+  dedup log. The routing config comes from the `alertmanager-pushover-config` ExternalSecret,
+  so the sole loss on a rebuild is whichever silences were active — and a silence expires on
+  its own anyway.
 
 Before excluding a namespace, ask which of its PVCs hold state that is not reproducible
 from git and not already stored elsewhere. Here that was exactly one, and it was the one
 thing the broken schedule wasn't covering.
+
+**Every PVC in an excluded namespace needs a stated reason in that list.** An entry that is
+merely absent is indistinguishable from one that was forgotten — which is the same failure
+as an empty backup reporting `Completed`. `loki` and `alertmanager` sat unlisted here until
+2026-08-19; both turned out to be fine, but nothing in the setup would have said so.
+
+To re-check the whole cluster — which PVCs are protected by neither Velero nor VolSync:
+
+```bash
+kubectl get replicationsources.volsync.backube -A          # the other backup system
+kubectl get podvolumebackups.velero.io -n velero \
+  -o jsonpath='{range .items[*]}{.spec.pod.namespace}/{.spec.pod.name}/{.spec.volume}{"\n"}{end}'
+```
+
+**Map PVBs to PVCs per *pod*, not per namespace.** A PVB records the pod's *volume* name, and
+names like `storage`, `data` and `pgdata` repeat across pods in one namespace. Keying on
+`(namespace, volume)` silently collapses them — doing exactly that on 2026-08-19 reported
+Grafana as never backed up and the live CNPG primaries as orphans. All three were false.
 - **Node-agents:** DaemonSet with DMZ toleration; 9 pods (6 workers + 3 CPs)
 - **`loadConcurrency` is pinned at the default 1 per node — do not raise it.** All worker
   VMDKs share one datastore; a full FSB pass already drives PSI full I/O-stall to 26-48%


### PR DESCRIPTION
## Why

`.claude/rules/velero.md` justifies each excluded `monitoring` volume — victoria-metrics (both tiers), prometheus, grafana — but never mentions **loki** or **alertmanager**. Both live in that namespace, neither is backed up, and the list reads as exhaustive. An entry that is merely absent is indistinguishable from one that was forgotten.

Found while auditing every PVC in the cluster after the Portainer data loss, checking for anything else with the "zero backups, forever, silently" property. Nothing else had it — but these two were unexplained rather than deliberately excluded.

## What they actually hold

Both are fine. The reasons are worth recording:

**loki** — chunks are in **S3, not on the PVC**: `object_store: s3`, bucket `loki`, endpoint `minio.minio.svc.cluster.local:9000`. `storage-loki-0` is just the local TSDB index and WAL, measured **79.7 MB of a 5.2 GB volume**. FSB would copy a rebuildable cache *and still miss every log line*.

There is a chain worth being explicit about: the durable copy is the `loki` bucket in MinIO, and `minio` is itself excluded to stop the backup store being backed up into itself. **So a MinIO loss loses the logs outright.** Accepted — retention is 720h, and the alert rules and dashboards consuming those logs are in git — but it should be a decision on the page, not an accident.

**alertmanager** — 3 × 1Gi, measured **0 MB used**. Silences and the notification dedup log only. Routing comes from the `alertmanager-pushover-config` ExternalSecret (verified present, `SecretSynced`), so a rebuild loses at most the active silences, which expire anyway.

## Also added

- **The rule:** every PVC in an excluded namespace needs a stated reason. Same failure shape as an empty backup reporting `Completed` — the absence of a signal is not a negative signal.
- **The re-check commands**, both verified to run as written.
- **A measurement trap from the audit itself.** A PVB records the pod's *volume* name, and `storage`, `data` and `pgdata` repeat across pods in a namespace. Keying PVBs to PVCs on `(namespace, volume)` silently collapses them — which reported Grafana as never backed up and the live CNPG primaries as orphans. All three false. Key per pod.

Docs only; no manifest changes.