### PR TITLE
fix(kyverno): make require-resources enforce, minus the CPU limit

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-vendor-resources.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-vendor-resources.yaml
@@ -1,0 +1,115 @@
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: ignore-vendor-resource-requirements
+  namespace: kyverno
+  labels:
+    app: kyverno
+    env: production
+    category: security
+spec:
+  # Workloads exempt from require-resources ONLY. Every one of these is either
+  # impossible to configure from this repo, or small enough that a memory limit
+  # buys nothing and only adds an OOMKill mode. Peaks below are 30d maxima from
+  # VictoriaMetrics, measured 2026-08-19.
+  #
+  # This exception deliberately does NOT cover trivy-system/trivy-operator
+  # (1117Mi peak) or harbor/harbor-registry (532Mi peak) — those are the two
+  # genuinely large unbounded consumers and are chart-settable, so they get
+  # real limits instead of an exemption.
+  match:
+    any:
+      # --- Created at runtime by longhorn-manager, not by the Helm chart. -----
+      # These carry `app: longhorn` rather than their own component name, so
+      # inject-resource-requirements cannot target them either.
+      # Peaks: csi-plugin 383Mi, driver-deployer 12Mi, engine-image ~21Mi.
+      - resources:
+          kinds:
+            - DaemonSet
+          namespaces:
+            - longhorn-system
+          names:
+            - "longhorn-csi-plugin"
+            - "engine-image-ei-*"
+      - resources:
+          kinds:
+            - Deployment
+          namespaces:
+            - longhorn-system
+          names:
+            - "longhorn-driver-deployer"
+
+      # --- Owned by kubeadm; no Helm values exist. Peak 79Mi. ----------------
+      - resources:
+          kinds:
+            - DaemonSet
+          namespaces:
+            - kube-system
+          names:
+            - "kube-proxy"
+
+      # --- Created by the authentik operator itself. Peak 42Mi. --------------
+      - resources:
+          kinds:
+            - Deployment
+          namespaces:
+            - authentik
+          names:
+            - "ak-outpost-*"
+
+      # --- kube-prometheus-stack + loki. -------------------------------------
+      # The StatefulSets fail only on their sidecars (config-reloader 37Mi,
+      # loki-sc-rules 89Mi); the main containers are already limited. Grafana
+      # fails on grafana-sc-dashboard 92Mi / grafana-sc-datasources 85Mi.
+      # Operator 35Mi, node-exporter 62Mi.
+      - resources:
+          kinds:
+            - Deployment
+            - StatefulSet
+            - DaemonSet
+          namespaces:
+            - monitoring
+          names:
+            - "kube-prometheus-stack-grafana"
+            - "kube-prometheus-stack-operator"
+            - "kube-prometheus-stack-prometheus-node-exporter"
+            - "alertmanager-kube-prometheus-stack-alertmanager"
+            - "prometheus-kube-prometheus-stack-prometheus"
+            - "loki"
+
+      # --- metallb speaker stack. Peaks: frr 43Mi, statuscleaner 28Mi. -------
+      - resources:
+          kinds:
+            - DaemonSet
+            - Deployment
+          namespaces:
+            - metallb-system
+          names:
+            - "metallb-frr-k8s"
+            - "metallb-frr-k8s-statuscleaner"
+
+      # --- tailscale operator. Peak 95Mi. -----------------------------------
+      - resources:
+          kinds:
+            - Deployment
+          namespaces:
+            - tailscale
+          names:
+            - "operator"
+
+      # --- harbor front-end pieces. Peaks: nginx 23Mi, portal 13Mi, ----------
+      # redis 12Mi. harbor-registry is excluded on purpose (see above).
+      - resources:
+          kinds:
+            - Deployment
+            - StatefulSet
+          namespaces:
+            - harbor
+          names:
+            - "harbor-nginx"
+            - "harbor-portal"
+            - "harbor-redis"
+  exceptions:
+    - policyName: require-resources
+      ruleNames:
+        - require-limits

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/kustomization.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - exceptions-calico.yaml
   - exceptions-ci-test-namespaces.yaml
   - exceptions-tailscale.yaml
+  - exceptions-vendor-resources.yaml
   - exceptions-kyverno-hooks.yaml
   - exceptions-kubeadm-cert-renew.yaml
   - exceptions-longhorn-dynamic.yaml

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/require-resources.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/require-resources.yaml
@@ -3,10 +3,10 @@ kind: ClusterPolicy
 metadata:
   name: require-resources
   annotations:
-    policies.kyverno.io/title: Require CPU/Memory Requests & Limits
+    policies.kyverno.io/title: Require Resource Requests & a Memory Limit
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
-    policies.kyverno.io/description: "Ensures that all containers define CPU and memory requests and limits."
+    policies.kyverno.io/description: "Ensures every container declares CPU and memory requests and a memory limit. A CPU limit is deliberately not required — CFS throttling degrades latency-sensitive workloads without protecting the node, which is why coredns and kyverno omit theirs upstream."
     kyverno.io/enable-background: "true"
   labels:
     app: kyverno
@@ -32,15 +32,14 @@ spec:
               app.kubernetes.io/part-of: flux
       skipBackgroundRequests: false
       validate:
-        message: "All containers must have CPU and memory requests and limits."
+        message: "All containers must declare CPU and memory requests and a memory limit."
         foreach:
-          - list: "spec.template.spec.containers"
+          - list: "request.object.spec.template.spec.containers"
             pattern:
               resources:
                 requests:
                   cpu: "?*"
                   memory: "?*"
                 limits:
-                  cpu: "?*"
                   memory: "?*"
         # allowExistingViolations: false  # Not supported in current Kyverno CLI version

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/require-resources.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/require-resources.yaml
@@ -6,7 +6,11 @@ metadata:
     policies.kyverno.io/title: Require Resource Requests & a Memory Limit
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
-    policies.kyverno.io/description: "Ensures every container declares CPU and memory requests and a memory limit. A CPU limit is deliberately not required — CFS throttling degrades latency-sensitive workloads without protecting the node, which is why coredns and kyverno omit theirs upstream."
+    policies.kyverno.io/description: "Ensures every container declares CPU and memory requests and a memory limit."
+    # A CPU limit is deliberately NOT required. Throttling degrades
+    # latency-sensitive workloads and cannot protect the node from
+    # exhaustion the way a memory limit does, which is why coredns and
+    # kyverno-admission-controller both omit theirs upstream.
     kyverno.io/enable-background: "true"
   labels:
     app: kyverno


### PR DESCRIPTION
## Problem

`require-resources` carried the same defect as the two policies fixed in #1104 — `foreach.list` was `spec.template.spec.containers` instead of `request.object.spec.template.spec.containers`, so it iterated nothing and emitted no result. It has never enforced anything.

## Changes

**1. Fixed the list path** — the policy now actually evaluates.

**2. Dropped the `limits.cpu` requirement.** A CPU limit throttles rather than protects: it cannot stop a node being exhausted (that's the memory limit's job) and CFS throttling degrades exactly the latency-sensitive components most likely to hit it. `coredns` and `kyverno-admission-controller` both omit theirs deliberately upstream — and both now pass unchanged. New bar: **CPU + memory requests, and a memory limit.**

**3. Added `exceptions-vendor-resources.yaml`** covering 21 workloads, scoped to `require-resources/require-limits` only:

| Group | Why |
|---|---|
| `longhorn-csi-plugin`, `engine-image-ei-*`, `longhorn-driver-deployer` | Created at runtime by longhorn-manager; carry `app: longhorn` so the mutate can't target them either |
| `kube-proxy` | kubeadm-owned, no Helm values exist |
| `ak-outpost-*` | Created by the authentik operator |
| kube-prometheus-stack + loki (6 objects) | Fail only on sidecars — `config-reloader` 37Mi, `loki-sc-rules` 89Mi, `grafana-sc-*` 85–92Mi; main containers already limited |
| metallb, tailscale operator, harbor nginx/portal/redis | All under 100Mi peak |

Each entry carries its measured 30d peak as a comment, so the next person can re-judge rather than guess.

## Deliberately left failing

`trivy-system/trivy-operator` (**1117Mi** peak) and `harbor/harbor-registry` (**532Mi** peak) are the only genuinely large unbounded consumers, and both are chart-settable. They get real limits in a follow-up rather than an exemption.

Note this leaves a narrow gap until that lands: `allowExistingViolations` defaults true so they keep updating, but a fresh create — i.e. a DR rebuild — would be blocked. The follow-up should land promptly.

## Verification

`kyverno apply` against all live Deployments/StatefulSets/DaemonSets, mutate policy applied first to match admission order, all 7 exceptions loaded:

```
pass: 87, fail: 2, warn: 0, error: 0, skip: 30
```

The 2 failures are the two named above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5reMTCRpW929DxF6xeLXD