### PR TITLE
fix(trivy,harbor): bound the two unbounded memory consumers

### DIFF
--- a/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
@@ -89,6 +89,24 @@ data:
     registry:
       credentials:
         existingSecret: harbor-core-credentials
+      # Both containers ran unbounded until 2026-08-19. Sized from 30d peaks
+      # in VictoriaMetrics: registry 532Mi, registryctl 10Mi. No CPU limit —
+      # throttling degrades push/pull latency and cannot protect the node the
+      # way a memory ceiling does (see require-resources).
+      registry:
+        resources:
+          requests:
+            cpu: 50m
+            memory: 256Mi
+          limits:
+            memory: 1Gi
+      controller:
+        resources:
+          requests:
+            cpu: 20m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
 
     core:
       resources:

--- a/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/trivy-system/trivy-operator/app/configmap.yaml
@@ -29,14 +29,6 @@ data:
           operator: Equal
           value: "true"
           effect: NoSchedule
-      resources:
-        requests:
-          cpu: 100m
-          memory: 384Mi
-        limits:
-          cpu: 500m
-          memory: 768Mi
-
     trivy:
       ignoreUnfixed: true
       # Use an in-memory analysis cache for scan jobs. Trivy >=0.66 added a
@@ -69,3 +61,17 @@ data:
 
     serviceMonitor:
       enabled: true
+
+    # The trivy-operator Deployment reads TOP-LEVEL `resources`. These lived
+    # under `operator.resources` until 2026-08-19, which the chart does not
+    # reference at all (same silent-drop as scanJobTolerations above), so the
+    # operator ran completely unbounded — 1117Mi 30d peak, the largest
+    # unbounded consumer in the cluster. The old dead values capped memory at
+    # 768Mi, below that peak, so simply re-nesting them would have OOMKilled it.
+    # No CPU limit: throttling a scan backlog buys nothing (see require-resources).
+    resources:
+      requests:
+        cpu: 100m
+        memory: 512Mi
+      limits:
+        memory: 1536Mi


### PR DESCRIPTION
## Why

These are the only two workloads #1109 left failing `require-resources`, and they are the two largest unbounded memory consumers in the cluster. Landing this takes the cluster to zero violations and closes the DR-rebuild gap #1109 noted.

## trivy-operator — the values were in a key the chart ignores

Its values already carried a `resources` block under **`operator.resources`**, which chart 0.35.0 never references. `grep -r 'Values.operator.resources'` across the chart returns nothing; the Deployment reads **top-level `.Values.resources`**. This is the same silent-drop as `scanJobTolerations`, documented three lines above it in the same file.

So the operator has always run unbounded — **1117Mi 30d peak**, the largest in the cluster.

The trap worth noting: the dead block capped memory at **768Mi**, *below* the observed peak. Re-nesting it unchanged would have OOMKilled the thing it was meant to protect.

`trivy.resources` is untouched — that one is live (it renders into `trivy-operator-trivy-config` as the scan-job settings).

## harbor-registry — never had resources at all

Chart 1.19.2 reads `registry.registry.resources` and `registry.controller.resources`, confirmed in `templates/registry/registry-dpl.yaml`. Not inferred from values.yaml — harbor declares no default for these, exactly as it declares none for `core.resources`, which demonstrably works today.

## Sizing (30d maxima from VictoriaMetrics)

| Container | Peak | Request | Limit |
|---|---|---|---|
| trivy-operator | 1117Mi | 100m / 512Mi | 1536Mi |
| harbor registry | 532Mi | 50m / 256Mi | 1Gi |
| harbor registryctl | 10Mi | 20m / 64Mi | 128Mi |

No CPU limits, consistent with #1109 — throttling cannot protect a node the way a memory ceiling does, and degrades the workload instead.

## Verification

Rendered both charts with these values and ran the output through `require-resources`:

```
pass: 6, fail: 0, warn: 0, error: 0, skip: 3
```

Both Deployments carry the resources in the rendered manifest — which is the check that would have caught the original `operator.resources` mistake, and the reason this PR renders rather than trusting the values file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5reMTCRpW929DxF6xeLXD