### PR TITLE
fix(kyverno): extend the vendor exception to CI's dry-run namespace

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-vendor-resources.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-vendor-resources.yaml
@@ -13,6 +13,13 @@ spec:
   # buys nothing and only adds an OOMKill mode. Peaks below are 30d maxima from
   # VictoriaMetrics, measured 2026-08-19.
   #
+  # Every namespace list also carries "ci-test-*": the Integration Test job
+  # renders each changed chart and server-side dry-runs it into an ephemeral
+  # ci-test-<run-id> namespace. Without this, any chart containing one of these
+  # workloads is rejected in CI even though it is exempt in production. Scoping
+  # by workload NAME rather than blanket-exempting the CI namespace keeps CI
+  # honest: a new in-repo app with no limits still fails.
+  #
   # This exception deliberately does NOT cover trivy-system/trivy-operator
   # (1117Mi peak) or harbor/harbor-registry (532Mi peak) — those are the two
   # genuinely large unbounded consumers and are chart-settable, so they get
@@ -28,6 +35,7 @@ spec:
             - DaemonSet
           namespaces:
             - longhorn-system
+            - "ci-test-*"
           names:
             - "longhorn-csi-plugin"
             - "engine-image-ei-*"
@@ -36,6 +44,7 @@ spec:
             - Deployment
           namespaces:
             - longhorn-system
+            - "ci-test-*"
           names:
             - "longhorn-driver-deployer"
 
@@ -45,6 +54,7 @@ spec:
             - DaemonSet
           namespaces:
             - kube-system
+            - "ci-test-*"
           names:
             - "kube-proxy"
 
@@ -54,6 +64,7 @@ spec:
             - Deployment
           namespaces:
             - authentik
+            - "ci-test-*"
           names:
             - "ak-outpost-*"
 
@@ -69,6 +80,7 @@ spec:
             - DaemonSet
           namespaces:
             - monitoring
+            - "ci-test-*"
           names:
             - "kube-prometheus-stack-grafana"
             - "kube-prometheus-stack-operator"
@@ -84,6 +96,7 @@ spec:
             - Deployment
           namespaces:
             - metallb-system
+            - "ci-test-*"
           names:
             - "metallb-frr-k8s"
             - "metallb-frr-k8s-statuscleaner"
@@ -94,6 +107,7 @@ spec:
             - Deployment
           namespaces:
             - tailscale
+            - "ci-test-*"
           names:
             - "operator"
 
@@ -105,6 +119,7 @@ spec:
             - StatefulSet
           namespaces:
             - harbor
+            - "ci-test-*"
           names:
             - "harbor-nginx"
             - "harbor-portal"


### PR DESCRIPTION
## Problem

#1109's `ignore-vendor-resource-requirements` is namespace-scoped to where each workload actually runs (`harbor`, `monitoring`, `metallb-system`, …).

The **Integration Test** job renders every changed chart and server-side dry-runs it into an ephemeral `ci-test-<run-id>` namespace. None of those scopes match there, so the enforce policy rejects workloads that are exempt in production.

It caught harbor immediately in #1110 — `harbor-nginx` and `harbor-portal` blocked by `require-resources`, chart validation failed:

```
admission webhook "validate.kyverno.svc-fail" denied the request:
resource Deployment/ci-test-32209862663-3114/harbor-nginx was blocked
```

`monitoring`, `metallb-system` and `tailscale` would have hit the same wall on their next change.

## Fix

Added `"ci-test-*"` to all 8 namespace lists in the exception.

Deliberately **not** a blanket exemption of the CI namespace from `require-resources` — that would stop CI catching a new in-repo app shipped without limits, which is the main reason to run the policy there at all. Scoping stays per workload name, so only these specific vendor workloads are exempt, in CI exactly as in production.

## Verification

Live harbor workloads relocated into a `ci-test-*` namespace and run through the policy:

| Config | Result |
|---|---|
| main's exception | pass 4, **fail 4** |
| this branch | pass 4, **fail 1** (`harbor-registry`) |
| this branch + #1110's values | pass 5, **fail 0** |

The remaining failure is `harbor-registry`, which #1110 fixes. The two together take CI to zero.

## Merge order

This should land **before** #1110 — that PR's Integration Test cannot pass without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5reMTCRpW929DxF6xeLXD