### PR TITLE
docs(kyverno): make the policy tables match the cluster

### DIFF
--- a/.claude/rules/kyverno.md
+++ b/.claude/rules/kyverno.md
@@ -6,19 +6,59 @@ description: Kyverno policy rules, required labels, DMZ constraints, and enforce
 
 ## Enforce-mode policies (will block pod creation)
 
-| Policy               | Rule                                                                      |
-| -------------------- | ------------------------------------------------------------------------- |
-| Resource limits      | Every pod must have CPU + memory requests and limits                      |
-| No `:latest` tags    | Image tags must be pinned — `:latest` is blocked                          |
-| No privileged        | Privileged containers are blocked                                         |
-| No `hostPath`        | `hostPath` volumes are blocked                                            |
-| No default namespace | Pods may not run in the `default` namespace                               |
-| DMZ placement        | DMZ pods must run on `k8sworker05`/`k8sworker06` (injected automatically) |
-| Required labels      | Every pod/controller/namespace must have `app`, `env`, `category` labels  |
+| Policy                           | Rule                                                                          |
+| -------------------------------- | ----------------------------------------------------------------------------- |
+| `require-resources`              | Every container needs CPU + memory **requests** and a **memory limit**         |
+| `restrict-latest-tag`            | Image tags must be pinned — `:latest` is blocked                              |
+| `restrict-privileged`            | Privileged containers are blocked                                             |
+| `restrict-hostpath-usage`        | `hostPath` volumes are blocked                                                |
+| `restrict-default-namespace`     | Pods may not run in the `default` namespace                                   |
+| `restrict-image-registries`      | Images must come from the approved registry list                              |
+| `restrict-loadbalancer-services` | `type: LoadBalancer` only in `ingress-nginx` and `dmz`                        |
+| `require-standard-labels`        | Every pod/controller/namespace must have `app`, `env`, `category` labels      |
+| `dmz-restrict-external-access`   | `external-access` / `internet-egress` labels only inside `dmz`                |
+
+**A CPU limit is deliberately NOT required.** Throttling degrades latency-sensitive
+workloads and cannot protect a node from exhaustion the way a memory limit does —
+`coredns` and `kyverno-admission-controller` both omit theirs upstream. Set requests
+plus a memory limit; add a CPU limit only when you have a specific reason.
 
 ## Audit-mode policies (violations logged, not blocked)
 
-- None currently — all policies are in Enforce mode
+Every mutate policy runs in Audit mode — a mutation either applies or it doesn't,
+there is nothing to block.
+
+| Policy                            | What it does                                                    |
+| --------------------------------- | --------------------------------------------------------------- |
+| `dmz-enforce-node-placement`      | Injects `nodeSelector` + toleration on `dmz` pods                |
+| `inject-namespace-labels`         | Copies `app`/`env`/`category` from namespace to workload         |
+| `inject-pod-labels`               | Copies the same labels onto pods                                 |
+| `inject-resource-requirements`    | Injects resources for Longhorn workloads the chart can't set     |
+| `mutate-default-sa-automount`     | Disables token automount on the `default` ServiceAccount         |
+| `mutate-default-sa-pod-automount` | Same, for pods using the `default` ServiceAccount                |
+
+## A policy with zero pass results is not enforcing
+
+`foreach.list` is a JMESPath against the rule context, so it **must** be rooted at
+`request.object` — a bare `spec.template.spec.containers` resolves to null, the loop
+iterates nothing, and the rule emits **no result at all**. Policy Reporter then shows
+0 fail because it also shows 0 pass, and admission lets everything through. Three
+policies here were silently inert this way until 2026-08-19 (#1104, #1109).
+
+```bash
+# Any deployed policy absent from this list is evaluating nothing.
+kubectl get polr -A -o json | python3 -c "
+import json,sys,collections
+c=collections.Counter()
+for r in json.load(sys.stdin)['items']:
+    for res in r.get('results',[]): c[(res['policy'],res['result'])]+=1
+[print(k,v) for k,v in sorted(c.items())]"
+```
+
+Before enabling a dormant **mutate**, diff every value it will write against measured
+usage — its numbers have never been tested. Fixing one here would have OOMKilled
+`longhorn-manager` (512Mi limit vs a 563Mi p95), and re-nesting `trivy-operator`'s
+misplaced block would have capped it at 768Mi against a 1117Mi peak.
 
 ## Valid `category` label values
 

--- a/docs/cluster-reference.md
+++ b/docs/cluster-reference.md
@@ -222,19 +222,50 @@ All volumes are `ReadWriteMany`, `100Gi`, backed by SMB shares at `192.168.150.2
 
 | Policy | Mode | Action | Rule |
 |---|---|---|---|
-| `restrict-default` | enforce | validate | Block all workloads in `default` namespace |
+| `restrict-default-namespace` | enforce | validate | Block all workloads in `default` namespace |
 | `restrict-privileged` | enforce | validate | Block privileged containers; exempts: kube-system, calico-system, longhorn-system, metallb-system, csi-driver, tigera-operator, ingress-nginx |
 | `restrict-hostpath-usage` | enforce | validate | Block hostPath volumes; exempts: kube-system, calico-system, longhorn-system, monitoring, tigera-operator |
 | `restrict-latest-tag` | enforce | validate | Block `:latest` image tags on Deployment/StatefulSet/DaemonSet |
 | `restrict-loadbalancer-services` | enforce | validate | LoadBalancer type only allowed in `ingress-nginx` and `dmz` namespaces |
-| `require-standard-labels` | audit | validate | Require `app`, `env`, `category` labels on Deployments, StatefulSets, DaemonSets, Pods, Namespaces, Services; exempts: kube-system, default |
-| `require-resources` | enforce | validate | Require CPU/memory requests and limits on all containers; exempts Flux deployments |
-| `dmz-enforce-node-placement` | enforce | mutate | Auto-inject `nodeSelector: role=dmz` and toleration `dmz=Exists:NoSchedule` on all pods in `dmz` namespace |
+| `require-standard-labels` | enforce | validate | Require `app`, `env`, `category` labels on Deployments, StatefulSets, DaemonSets, Pods, Namespaces, Services; exempts: kube-system, default |
+| `require-resources` | enforce | validate | Require CPU + memory **requests** and a **memory limit** on every container; exempts Flux deployments. A CPU limit is deliberately not required — see below |
+| `restrict-image-registries` | enforce | validate | Images must come from: harbor.vollminlab.com, ghcr.io, quay.io, registry.k8s.io, docker.io, mirror.gcr.io, oci.trueforge.org, reg.kyverno.io, us-docker.pkg.dev (short names without a domain also allowed) |
 | `dmz-restrict-external-access` | enforce | validate | Block `external-access=true` and `internet-egress=true` labels outside `dmz` namespace |
-| `inject-namespace-labels` | — | mutate | Auto-copy `app`, `env`, `category` labels from namespace to workloads; exempts: longhorn-system, flux-system, monitoring |
-| `inject-resource-requirements` | — | mutate | Auto-inject resource limits for Longhorn sidecar containers (CSI attacher, provisioner, resizer, snapshotter, UI, manager, driver) |
+| `dmz-enforce-node-placement` | audit | mutate | Auto-inject `nodeSelector: role=dmz` and toleration `dmz=Exists:NoSchedule` on all pods in `dmz` namespace |
+| `inject-namespace-labels` | audit | mutate | Auto-copy `app`, `env`, `category` labels from namespace to workloads; exempts: longhorn-system, flux-system, monitoring |
+| `inject-pod-labels` | audit | mutate | Auto-copy the same labels onto pods |
+| `inject-resource-requirements` | audit | mutate | Inject resources for Longhorn workloads the chart cannot set: csi-attacher, csi-provisioner, csi-resizer, csi-snapshotter, longhorn-ui, longhorn-manager |
+| `mutate-default-sa-automount` | audit | mutate | Disable token automount on the `default` ServiceAccount |
+| `mutate-default-sa-pod-automount` | audit | mutate | Same, for pods that use the `default` ServiceAccount |
 
-**PolicyException: `ignore-flux-core`** — Exempts all Flux controllers and the `kyverno` HelmRelease from all policies.
+Every mutate policy is Audit — a mutation either applies or it does not, so there is
+nothing for it to block.
+
+**Why `require-resources` does not require a CPU limit.** CPU throttling degrades
+latency-sensitive workloads and cannot protect a node from exhaustion the way a memory
+limit does. `coredns` and `kyverno-admission-controller` both omit theirs upstream and
+pass the policy unchanged. Set requests plus a memory limit; add a CPU limit only for a
+specific reason.
+
+### PolicyExceptions
+
+| Name | Scope |
+|---|---|
+| `ignore-flux-core` | All Flux controllers and the `kyverno` HelmRelease, from all policies |
+| `ignore-calico-cni` | Calico / tigera-operator workloads |
+| `ignore-longhorn-dynamic-pods` | Longhorn objects created by the controller, not by GitOps |
+| `ignore-tailscale-connector` | Tailscale Connector StatefulSets |
+| `ignore-kyverno-hook-pods` | Kyverno's own Helm hook pods |
+| `ignore-kubeadm-cert-renew` | kubeadm certificate-renewal pods |
+| `ignore-ci-test-namespaces` | `ci-test-*` namespaces, for the label policy |
+| `ignore-vendor-resource-requirements` | 17 name patterns covering 21 live vendor workloads, `require-resources` only — each entry carries its measured 30d memory peak. Also scoped to `ci-test-*`, because CI dry-runs charts into an ephemeral namespace where the production scope would not match |
+
+**A policy with zero pass results is enforcing nothing.** `foreach.list` is a JMESPath
+against the rule context and must be rooted at `request.object`; a bare
+`spec.template.spec.containers` resolves to null, the loop iterates nothing, and the rule
+emits no result at all — so Policy Reporter shows 0 fail because it also shows 0 pass.
+`require-resources`, `restrict-image-registries` and `inject-resource-requirements` were
+all silently inert this way until 2026-08-19 (#1104, #1107, #1109).
 
 ### Policy Reporter
 

--- a/docs/cluster-reference.md
+++ b/docs/cluster-reference.md
@@ -224,15 +224,15 @@ All volumes are `ReadWriteMany`, `100Gi`, backed by SMB shares at `192.168.150.2
 |---|---|---|---|
 | `restrict-default-namespace` | enforce | validate | Block all workloads in `default` namespace |
 | `restrict-privileged` | enforce | validate | Block privileged containers; exempts: kube-system, calico-system, longhorn-system, metallb-system, csi-driver, tigera-operator, ingress-nginx |
-| `restrict-hostpath-usage` | enforce | validate | Block hostPath volumes; exempts: kube-system, calico-system, longhorn-system, monitoring, tigera-operator |
+| `restrict-hostpath-usage` | enforce | validate | Block hostPath volumes; exempts: kube-system, calico-system, longhorn-system, monitoring, tigera-operator, velero |
 | `restrict-latest-tag` | enforce | validate | Block `:latest` image tags on Deployment/StatefulSet/DaemonSet |
-| `restrict-loadbalancer-services` | enforce | validate | LoadBalancer type only allowed in `ingress-nginx` and `dmz` namespaces |
-| `require-standard-labels` | enforce | validate | Require `app`, `env`, `category` labels on Deployments, StatefulSets, DaemonSets, Pods, Namespaces, Services; exempts: kube-system, default |
+| `restrict-loadbalancer-services` | enforce | validate | LoadBalancer type only allowed in `ingress-nginx`, `dmz`, `harbor` and `ci-test-*` namespaces |
+| `require-standard-labels` | enforce | validate | Require `app`, `env`, `category` labels on Deployments, StatefulSets, DaemonSets, Pods, Namespaces, Services; exempts: kube-system, kyverno |
 | `require-resources` | enforce | validate | Require CPU + memory **requests** and a **memory limit** on every container; exempts Flux deployments. A CPU limit is deliberately not required — see below |
 | `restrict-image-registries` | enforce | validate | Images must come from: harbor.vollminlab.com, ghcr.io, quay.io, registry.k8s.io, docker.io, mirror.gcr.io, oci.trueforge.org, reg.kyverno.io, us-docker.pkg.dev (short names without a domain also allowed) |
 | `dmz-restrict-external-access` | enforce | validate | Block `external-access=true` and `internet-egress=true` labels outside `dmz` namespace |
 | `dmz-enforce-node-placement` | audit | mutate | Auto-inject `nodeSelector: role=dmz` and toleration `dmz=Exists:NoSchedule` on all pods in `dmz` namespace |
-| `inject-namespace-labels` | audit | mutate | Auto-copy `app`, `env`, `category` labels from namespace to workloads; exempts: longhorn-system, flux-system, monitoring |
+| `inject-namespace-labels` | audit | mutate | Auto-copy `app`, `env`, `category` labels from namespace to workloads (no namespace exclusions) |
 | `inject-pod-labels` | audit | mutate | Auto-copy the same labels onto pods |
 | `inject-resource-requirements` | audit | mutate | Inject resources for Longhorn workloads the chart cannot set: csi-attacher, csi-provisioner, csi-resizer, csi-snapshotter, longhorn-ui, longhorn-manager |
 | `mutate-default-sa-automount` | audit | mutate | Disable token automount on the `default` ServiceAccount |


### PR DESCRIPTION
## Why

#1109 changed what `require-resources` requires. Checking the docs against `kubectl get cpol` turned up drift that predates it — `.claude/rules/kyverno.md` is loaded into every session, so wrong content there is actively misleading.

## Corrected

| Claim | Reality |
|---|---|
| `require-resources` requires "CPU and memory requests and limits" | A CPU limit is no longer required (#1109) |
| `require-standard-labels` — **audit** | It is **Enforce** |
| `dmz-enforce-node-placement` — **enforce** | It is **Audit** |
| `restrict-default` | No such policy — it is `restrict-default-namespace` |
| `restrict-image-registries` | Missing from the table entirely |
| `inject-pod-labels`, `mutate-default-sa-automount`, `mutate-default-sa-pod-automount` | All missing |
| "Audit-mode policies: none currently — all policies are in Enforce mode" | Six mutate policies run in Audit |
| `inject-resource-requirements` covers "…UI, manager, driver" | #1107 removed driver-deployer and the CSI plugin — it could never match them |
| One PolicyException documented | There are eight |

## Added

Both files now state the detection rule this whole episode turned on:

> A policy with zero pass results is enforcing nothing — a `foreach.list` that doesn't resolve emits **no result**, so 0 fail and 0 pass look identical to a clean board.

`.claude/rules/kyverno.md` gets the one-liner that finds it, and the warning that enabling a dormant mutate arms numbers nobody has validated — which would have OOMKilled `longhorn-manager` and capped `trivy-operator` at 768Mi against a 1117Mi peak.

## Verification

Diffed every documented policy name and mode against live `cpol`, and every documented exception against live `polex`:

```
policy mismatches: NONE — doc matches live exactly
exception mismatches: NONE — all 8 documented, none invented
```

The `21 vendor workloads` figure is also checked: 17 name patterns, with `engine-image-ei-*` and `ak-outpost-*` covering 5 and 1 live objects.

Docs only — no cluster change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5reMTCRpW929DxF6xeLXD