### PR TITLE
fix(harbor): raise trivy memory to the chart default to stop OOMKills

### DIFF
--- a/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
@@ -136,14 +136,20 @@ data:
       readinessProbe:
         timeoutSeconds: 5
 
+    # Sized from measured usage, not the chart default. Steady state is ~136Mi, so the
+    # old 64Mi request under-declared it to the scheduler by 2x. The old 256Mi limit was
+    # 1/4 of upstream's and OOMKilled the scanner 7 times (last 2026-08-19T03:19Z, exit
+    # 137); peak samples pinned at exactly 255Mi, which is the ceiling truncating demand
+    # rather than the real requirement. Limit now matches the chart default (1Gi).
+    # container_oom_events_total read 0 throughout — the kubelet lastState is the truth.
     trivy:
       resources:
         requests:
           cpu: 100m
-          memory: 64Mi
+          memory: 256Mi
         limits:
           cpu: 500m
-          memory: 256Mi
+          memory: 1Gi
 
     # The exporter deployment template only applies exporter.podLabels — the global
     # podLabels below does not reach it, so the Kyverno-required labels must be set here.


### PR DESCRIPTION
## What

Raises `trivy` memory in the harbor Helm values: limit `256Mi` → `1Gi`, request `64Mi` → `256Mi`.

## Why

`harbor-trivy-0` has been OOMKilled **7 times**, most recently `2026-08-19T03:19:07Z` (exit 137). It was running a 256Mi limit against a ~136Mi steady-state working set.

Every peak memory sample pinned at **exactly 255Mi** — that is the ceiling truncating demand, not a measurement of what the scanner actually needs.

| | request | limit |
|---|---|---|
| before | 64Mi | 256Mi |
| upstream harbor 1.19.2 default | 512Mi | 1Gi |
| after | 256Mi | 1Gi |

The cluster was running a **quarter** of the chart's default limit, and the 64Mi request under-declared steady-state usage to the scheduler by 2x.

## Sizing rationale

- **Limit → 1Gi**: matches the upstream chart default. Scans are the bursty part, so the headroom belongs here.
- **Request → 256Mi**: kept below upstream's 512Mi deliberately — 256Mi is above what the container actually holds at rest here (~136Mi), so scheduling is honest without over-reserving.
- **CPU untouched**: a CPU limit is not required by this cluster's policy, and throttling was not implicated in the kills. Out of scope for a memory fix.
- **Node fit**: `k8sworker02` is at 44% memory used, requests 34%, limits 77% — the larger limit fits.

## Verification note

`container_oom_events_total` read **0** for this container across 30d while the kills were happening. The kubelet's `lastState.terminated` was the only truthful signal. Worth remembering next time a container looks healthy by metrics.

Kyverno `require-resources` remains satisfied (cpu + memory requests, memory limit present).