### PR TITLE
fix(minio): allow vollmint CNPG backups, unbreaking WAL archiving

### DIFF
--- a/clusters/vollminlab-cluster/minio/networkpolicies/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/minio/networkpolicies/networkpolicy.yaml
@@ -66,8 +66,13 @@ spec:
         - protocol: TCP
           port: 9001
 ---
-# Allow CNPG backup traffic from all namespaces with managed clusters
-# (authentik-db, harbor-db, jellystat-db in mediastack, shlink-db in shlink)
+# Allow CNPG backup traffic from all namespaces with managed clusters.
+# Keep this list in sync with every CNPG Cluster in the repo -- the far side
+# (the app namespace's own egress rule) is not enough on its own, and a missing
+# entry here fails silently: the Cluster still reports "healthy", only
+# .status.conditions ContinuousArchiving flips to False.
+# Current CNPG clusters: authentik-db, harbor-db, shlink-db,
+# jellystat-db (mediastack), vollmint-db (vollmint).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -95,6 +100,9 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: mediastack
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: vollmint
       ports:
         - protocol: TCP
           port: 9000


### PR DESCRIPTION
## 🔴 `vollmint-db` has never completed a backup

Its ScheduledBackup has existed for **24 days**. `.status.lastSuccessfulBackup` is empty:

```
NS         NAME           STATUS                     LASTBACKUP
authentik  authentik-db   Cluster in healthy state   2026-08-19T01:00:30Z
harbor     harbor-db      Cluster in healthy state   2026-08-19T01:15:06Z
mediastack jellystat-db   Cluster in healthy state   2026-08-19T03:00:41Z
shlink     shlink-db      Cluster in healthy state   2026-08-19T01:30:05Z
vollmint   vollmint-db    Cluster in healthy state   <none>      <-- 
```

```
ContinuousArchiving=False  reason=ContinuousArchivingFailing
LastBackupSucceeded=False
```

## Root cause: a missing peer in this policy

The error is a **network timeout, not credentials**:

```
ERROR: Barman cloud WAL archive check exception: Connect timeout on
endpoint URL: "http://minio.minio.svc.cluster.local:9000/cnpg-backups"
```

`allow-cnpg-backups` admitted `authentik`, `harbor`, `shlink`, `mediastack` — but not `vollmint`, which was added last. vollmint already had the **egress** half; only minio's **ingress** side was missing, so the packet was dropped at the destination.

A TCP probe from `vollmint-db-1` to `minio.minio.svc:9000` **times out** rather than being refused — the signature of a NetworkPolicy drop:

```
$ kubectl exec -n vollmint vollmint-db-1 -c postgres -- \
    timeout 8 bash -c 'cat < /dev/null > /dev/tcp/minio.minio.svc.cluster.local/9000'
command terminated with exit code 124
```

## Why it hid for 24 days

- The Cluster reports **`Cluster in healthy state`** throughout. Archiving failure lives only in `.status.conditions`, never in `phase`.
- The failing segment is `000000010000000000000001` — **the very first WAL**. There was never a working state to regress from, so no alert on "stopped working".

## It is not harmless

PostgreSQL cannot recycle a WAL segment it hasn't archived:

```
pg_wal: 2.3G  (142 segments)
volume: 4.9G total, 2.3G used, 47%
```

This was on track to fill the PVC and stop the database. There is also **no PITR** for this database today.

## Also: rewrote the comment

The old comment enumerated the four databases it covered — exactly the shape that lets a fifth be added without anyone noticing the list needs updating. It now states the sync requirement and the silent-failure mode explicitly.

## After merge

Archiving should recover on its own (CNPG retries continuously). Worth confirming `ContinuousArchiving=True` and that `pg_wal` drains back down.