### PR TITLE
feat(monitoring): alert on CNPG, VolSync and the two unwatched Velero schedules

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - prometheusrule-eso.yaml
   - prometheusrule-gitops.yaml
   - prometheusrule-victoria-metrics.yaml
+  - prometheusrule-volsync.yaml
   - nodes-dashboard-configmap.yaml
   - longhorn-dashboard-configmap.yaml
   - minio-dashboard-configmap.yaml

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-cnpg.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-cnpg.yaml
@@ -69,7 +69,9 @@ spec:
             severity: critical
           annotations:
             summary: "CNPG WAL archiving is backing up"
-            description: "{{ $labels.job }} has {{ $value }} WAL segments waiting to be archived. Postgres cannot recycle an unarchived segment, so pg_wal will grow until the PVC fills. Check the barman endpoint is reachable -- a NetworkPolicy drop shows as 'Connect timeout' in the instance log."
+            description: >-
+              {{ $labels.job }} has {{ $value }} WAL segments waiting to be archived. Postgres cannot recycle an unarchived segment, so pg_wal will grow until the
+              PVC fills. Check the barman endpoint is reachable -- a NetworkPolicy drop shows as 'Connect timeout' in the instance log.
         # The backstop: no recoverable point in time exists at all. Deliberately a
         # long `for` -- a freshly bootstrapped cluster legitimately has no
         # recoverability point until its ScheduledBackup first fires, which can be
@@ -81,7 +83,9 @@ spec:
             severity: critical
           annotations:
             summary: "CNPG cluster has no recoverable point in time"
-            description: "{{ $labels.job }} reports first_recoverability_point=0 -- there is no point-in-time recovery available for this database at all. Either it has never completed a base backup, or WAL archiving has never worked."
+            description: >-
+              {{ $labels.job }} reports first_recoverability_point=0 -- there is no point-in-time recovery available for this database at all. Either it has never
+              completed a base backup, or WAL archiving has never worked.
         # A backup did complete once, but not recently. Guarded on > 0 so it cannot
         # double-fire with CNPGNoRecoverabilityPoint above (a 0 timestamp would
         # otherwise read as ~56 years stale).
@@ -109,4 +113,6 @@ spec:
             severity: warning
           annotations:
             summary: "CNPG last backup attempt failed"
-            description: "{{ $labels.job }} has a failed backup attempt newer than its last successful one. If a Backup object is stuck in a non-terminal phase (e.g. walArchivingFailing) the controller will refuse to start any further backup until it is deleted."
+            description: >-
+              {{ $labels.job }} has a failed backup attempt newer than its last successful one. If a Backup object is stuck in a non-terminal phase (e.g.
+              walArchivingFailing) the controller will refuse to start any further backup until it is deleted.

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-cnpg.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-cnpg.yaml
@@ -43,3 +43,70 @@ spec:
           annotations:
             summary: "CNPG replication lag high"
             description: "Standby in cluster {{ $labels.namespace }}/{{ $labels.cluster }} is lagging by {{ $value | humanizeDuration }} (threshold 5m)."
+        # --- Backup / WAL-archiving health -------------------------------------
+        # Added 2026-08-19 after vollmint-db was found never to have completed a
+        # backup in the 24 days it had existed. Nothing here alerted, because every
+        # rule above watches liveness, not recoverability: the Cluster reported
+        # "Cluster in healthy state" throughout and the failure lived only in
+        # .status.conditions.
+        #
+        # Replicas report 0 for the backup timestamp series -- only the primary
+        # publishes real values -- so every rule below aggregates with max by(job)
+        # to take the primary's number. Comparing the raw series would fire on
+        # every standby permanently.
+        #
+        # These metrics carry `job` ("<ns>/<cluster>") and `namespace`, but NOT a
+        # `cluster` label, so annotations here use $labels.job.
+
+        # The fastest, least ambiguous signal that archiving has broken: WAL segments
+        # pile up in pg_wal marked "ready" when barman cannot ship them. vollmint sat
+        # at 142 for weeks. This fires within 30 minutes of archiving stopping, and it
+        # is what should have caught it on day one.
+        - alert: CNPGWALArchiveBacklog
+          expr: max by (job, namespace) (cnpg_collector_pg_wal_archive_status{value="ready"}) > 20
+          for: 30m
+          labels:
+            severity: critical
+          annotations:
+            summary: "CNPG WAL archiving is backing up"
+            description: "{{ $labels.job }} has {{ $value }} WAL segments waiting to be archived. Postgres cannot recycle an unarchived segment, so pg_wal will grow until the PVC fills. Check the barman endpoint is reachable -- a NetworkPolicy drop shows as 'Connect timeout' in the instance log."
+        # The backstop: no recoverable point in time exists at all. Deliberately a
+        # long `for` -- a freshly bootstrapped cluster legitimately has no
+        # recoverability point until its ScheduledBackup first fires, which can be
+        # most of a day away. 24h still catches a genuine break on day two.
+        - alert: CNPGNoRecoverabilityPoint
+          expr: max by (job, namespace) (cnpg_collector_first_recoverability_point) == 0
+          for: 24h
+          labels:
+            severity: critical
+          annotations:
+            summary: "CNPG cluster has no recoverable point in time"
+            description: "{{ $labels.job }} reports first_recoverability_point=0 -- there is no point-in-time recovery available for this database at all. Either it has never completed a base backup, or WAL archiving has never worked."
+        # A backup did complete once, but not recently. Guarded on > 0 so it cannot
+        # double-fire with CNPGNoRecoverabilityPoint above (a 0 timestamp would
+        # otherwise read as ~56 years stale).
+        - alert: CNPGBackupStale
+          expr: |
+            (max by (job, namespace) (cnpg_collector_last_available_backup_timestamp) > 0)
+            and
+            (time() - max by (job, namespace) (cnpg_collector_last_available_backup_timestamp) > 26 * 3600)
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: "CNPG backup is stale"
+            description: "{{ $labels.job }} last completed a backup {{ $value | humanizeDuration }} ago (threshold 26h). All CNPG schedules on this cluster are daily."
+        # The most recent backup attempt failed more recently than the last success.
+        # Warning rather than critical: a single failed attempt with a good backup
+        # behind it is recoverable, and CNPGBackupStale escalates if it persists.
+        - alert: CNPGBackupFailing
+          expr: |
+            max by (job, namespace) (cnpg_collector_last_failed_backup_timestamp)
+            >
+            max by (job, namespace) (cnpg_collector_last_available_backup_timestamp)
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "CNPG last backup attempt failed"
+            description: "{{ $labels.job }} has a failed backup attempt newer than its last successful one. If a Backup object is stuck in a non-terminal phase (e.g. walArchivingFailing) the controller will refuse to start any further backup until it is deleted."

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -182,6 +182,46 @@ spec:
             summary: "Velero daily-full backup metric absent — Velero may not be running"
             description: "velero_backup_last_status for schedule=velero-daily-full is missing. Velero may be down or metrics scraping has failed."
 
+        # --- Coverage for the two unwatched schedules -----------------------------
+        # Added 2026-08-19. Every rule above pins schedule="velero-daily-full" (4 of
+        # them) or "velero-daily-b2" (1), leaving velero-grafana-b2 and
+        # velero-monthly-b2 with no alerting at all. grafana-b2 is the one that
+        # matters most: grafana.db holds UI-created dashboards, users and API keys
+        # that exist nowhere else, and it was the only copy nothing watched.
+
+        # Schedule-agnostic failure catch. No time threshold needed -- a reported
+        # failure is a failure whatever the cadence -- so this covers monthly-b2 too,
+        # where any staleness threshold would have to be over a month wide.
+        - alert: VeleroAnyBackupFailed
+          expr: |
+            velero_backup_last_status == 0
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Velero backup failed for schedule {{ $labels.schedule }}"
+            description: "The most recent backup for schedule={{ $labels.schedule }} reported failure. This rule is deliberately not pinned to a schedule name so new schedules are covered the day they are created."
+        - alert: VeleroGrafanaBackupStale
+          expr: |
+            time() - velero_backup_last_successful_timestamp{schedule="velero-grafana-b2"} > 26 * 3600
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: "Velero grafana-b2 backup is stale"
+            description: "velero-grafana-b2 last succeeded {{ $value | humanizeDuration }} ago (threshold 26h). grafana.db holds dashboards, users and API keys that are not reproducible from git."
+        # Monthly cadence: threshold set to 32 days, matching the 768h override the
+        # velero-backup-content-guard CronJob already applies to this schedule.
+        - alert: VeleroMonthlyBackupStale
+          expr: |
+            time() - velero_backup_last_successful_timestamp{schedule="velero-monthly-b2"} > 768 * 3600
+          for: 6h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Velero monthly-b2 backup is stale"
+            description: "velero-monthly-b2 last succeeded {{ $value | humanizeDuration }} ago (threshold 32d, matching the content guard's 768h override for this schedule)."
+
     - name: node-disk
       rules:
         - alert: NodeDiskSpaceLow

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -200,7 +200,9 @@ spec:
             severity: critical
           annotations:
             summary: "Velero backup failed for schedule {{ $labels.schedule }}"
-            description: "The most recent backup for schedule={{ $labels.schedule }} reported failure. This rule is deliberately not pinned to a schedule name so new schedules are covered the day they are created."
+            description: >-
+              The most recent backup for schedule={{ $labels.schedule }} reported failure. This rule is deliberately not pinned to a schedule name so new schedules
+              are covered the day they are created.
         - alert: VeleroGrafanaBackupStale
           expr: |
             time() - velero_backup_last_successful_timestamp{schedule="velero-grafana-b2"} > 26 * 3600

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-volsync.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-volsync.yaml
@@ -35,7 +35,9 @@ spec:
             severity: critical
           annotations:
             summary: "VolSync replication source is out of sync"
-            description: "ReplicationSource {{ $labels.obj_namespace }}/{{ $labels.obj_name }} ({{ $labels.method }}) has been out of sync for over an hour. Its PVC is no longer being replicated to B2."
+            description: >-
+              ReplicationSource {{ $labels.obj_namespace }}/{{ $labels.obj_name }} ({{ $labels.method }}) has been out of sync for over an hour. Its PVC is no
+              longer being replicated to B2.
         # A source that misses its window repeatedly but recovers before the hour is up
         # never trips the rule above. Warning-level, because a single missed interval on
         # a daily schedule is usually contention rather than breakage.
@@ -58,4 +60,6 @@ spec:
             severity: warning
           annotations:
             summary: "No VolSync metrics being scraped"
-            description: "Prometheus has not scraped any volsync_volume_out_of_sync samples for 30 minutes -- the volsync controller or its ServiceMonitor may be down, which would also silence every other VolSync alert."
+            description: >-
+              Prometheus has not scraped any volsync_volume_out_of_sync samples for 30 minutes -- the volsync controller or its ServiceMonitor may be down, which
+              would also silence every other VolSync alert.

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-volsync.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-volsync.yaml
@@ -1,0 +1,61 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: volsync-alerts
+  namespace: monitoring
+  labels:
+    app: kube-prometheus-stack
+    env: production
+    category: observability
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: volsync
+      rules:
+        # Added 2026-08-19. Before this file, the only occurrence of "volsync" in any
+        # PrometheusRule on the cluster was an *exclusion* (pod!~"volsync-src-.*" inside
+        # PodNotReady). VolSync protects 13 PVCs and is the only backup system writing
+        # directly offsite to B2, and nothing watched it: a ReplicationSource that
+        # stopped syncing would have shown up solely as a stale status.lastSyncTime
+        # that no rule read.
+        #
+        # These series are exported by the volsync controller in volsync-system, so
+        # `namespace` is always volsync-system -- the PVC's own namespace is
+        # `obj_namespace` and the ReplicationSource is `obj_name`. Annotations use
+        # those, not $labels.namespace, or every alert would name volsync-system.
+
+        # VolSync's own freshness verdict: it sets this to 1 when a source has missed
+        # its trigger window. Preferred over reimplementing staleness from
+        # sync_duration timestamps, because the controller already knows each
+        # source's schedule (all 13 are daily, staggered 10 min apart 00:00-02:00).
+        - alert: VolSyncVolumeOutOfSync
+          expr: volsync_volume_out_of_sync > 0
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: "VolSync replication source is out of sync"
+            description: "ReplicationSource {{ $labels.obj_namespace }}/{{ $labels.obj_name }} ({{ $labels.method }}) has been out of sync for over an hour. Its PVC is no longer being replicated to B2."
+        # A source that misses its window repeatedly but recovers before the hour is up
+        # never trips the rule above. Warning-level, because a single missed interval on
+        # a daily schedule is usually contention rather than breakage.
+        - alert: VolSyncMissedIntervals
+          expr: increase(volsync_missed_intervals_total[24h]) > 1
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "VolSync source is missing its sync intervals"
+            description: "ReplicationSource {{ $labels.obj_namespace }}/{{ $labels.obj_name }} has missed {{ $value }} sync intervals in 24h."
+        # The metrics-absent case, matching CNPGClusterNoMetrics. If the volsync
+        # controller dies or its ServiceMonitor breaks, every rule above silently stops
+        # evaluating -- which is the same class of blind spot this whole file exists to
+        # close.
+        - alert: VolSyncNoMetrics
+          expr: absent(volsync_volume_out_of_sync)
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "No VolSync metrics being scraped"
+            description: "Prometheus has not scraped any volsync_volume_out_of_sync samples for 30 minutes -- the volsync controller or its ServiceMonitor may be down, which would also silence every other VolSync alert."


### PR DESCRIPTION
Closes the alerting gap that let `vollmint-db` go **24 days with zero backups** and no recoverable point in time, unnoticed.

## Why nothing caught it

`cnpg-cluster-alerts` watched **liveness only** — `CNPGInstanceDown`, `CNPGClusterNoMetrics`, `CNPGHighReplicationLag`. A cluster whose backups had never once worked still looked completely healthy, because CNPG keeps archiving failure in `.status.conditions` and leaves `phase` at `Cluster in healthy state`.

The same blind spot existed in the other two backup systems.

## What's added

**CNPG — 5 rules**

| alert | expression | severity |
|---|---|---|
| `CNPGWALArchiveBacklog` | ready-to-archive WAL > 20 for 30m | critical |
| `CNPGNoRecoverabilityPoint` | `first_recoverability_point == 0` for 24h | critical |
| `CNPGBackupStale` | last available backup > 26h | critical |
| `CNPGBackupFailing` | last failure newer than last success | warning |

`CNPGWALArchiveBacklog` is the one that matters — unarchived WAL piles up in `pg_wal` from the *first* failure, so it fires in 30 minutes instead of waiting for a missed schedule. vollmint sat at **142 segments**.

Two subtleties handled:
- **Replicas publish `0` for every backup timestamp**; only the primary publishes real values. Each expression aggregates `max by (job, namespace)` — comparing raw series would fire permanently on every standby.
- **The 24h window on `NoRecoverabilityPoint` is deliberate.** A freshly bootstrapped cluster legitimately has none until its ScheduledBackup first fires, which can be most of a day away.

**VolSync — 3 rules (new file)**

Before this, the only occurrence of "volsync" in any PrometheusRule was an *exclusion* (`pod!~"volsync-src-.*"` inside `PodNotReady`). 13 PVCs replicate to B2 — the only offsite-first backup path on the cluster — and a source that stopped syncing would surface solely as a stale `status.lastSyncTime` that nothing reads.

Uses the controller's own `volsync_volume_out_of_sync` verdict rather than reimplementing staleness, since it already knows each source's schedule.

**Velero — 3 rules**

Four existing rules pin `schedule="velero-daily-full"`, one pins `velero-daily-b2`. `velero-grafana-b2` and `velero-monthly-b2` had **none**. grafana-b2 is the worse miss: `grafana.db` holds dashboards, users and API keys that exist nowhere else.

`VeleroAnyBackupFailed` is deliberately **not** pinned to a schedule name, so a schedule created later is covered from day one instead of needing yet another rule.

## Verification

Checked against live Prometheus, not assumed. All 10 expressions parse and all 10 currently evaluate to 0 series — but **that alone proves nothing**, since it's indistinguishable from an expression that matches nothing ever (the failure mode that left three Kyverno policies inert). So each rule's underlying series was confirmed present with real values by relaxing its threshold until it had to match:

```
wal ready              5 series    recoverability      5 series
last_available         5 series    last_failed         5 series
volsync out_of_sync   13 series    volsync missed     13 series
velero last_status     5 series    grafana-b2 ts       1 series
                                   monthly-b2 ts       1 series
```