### PR TITLE
fix(cnpg): give all five databases resource requests, off BestEffort QoS

### DIFF
--- a/clusters/vollminlab-cluster/authentik/cnpg/app/cluster.yaml
+++ b/clusters/vollminlab-cluster/authentik/cnpg/app/cluster.yaml
@@ -9,6 +9,19 @@ metadata:
     category: security
 spec:
   instances: 1
+  # Sized from 14d measured usage (p95 601Mi, peak 932Mi, cpu p95 106m).
+  # Without this block the instance pods are BestEffort -- the first QoS class the
+  # kubelet evicts under node memory pressure, and the highest oom_score_adj for the
+  # node OOM killer. Kyverno's require-resources never flagged it because that policy
+  # matches Deployment/StatefulSet/DaemonSet and CNPG creates bare Pods.
+  # Request sits above p95 so the scheduler reserves what is actually used; the limit
+  # carries the headroom. No CPU limit, per this cluster's policy.
+  resources:
+    requests:
+      cpu: 150m
+      memory: 768Mi
+    limits:
+      memory: 1536Mi
   inheritedMetadata:
     labels:
       app: authentik-db

--- a/clusters/vollminlab-cluster/harbor/harbor-db/app/cluster.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor-db/app/cluster.yaml
@@ -9,6 +9,19 @@ metadata:
     category: storage
 spec:
   instances: 2
+  # Sized from 14d measured usage (p95 152Mi, peak 239Mi, cpu p95 12m).
+  # Without this block the instance pods are BestEffort -- the first QoS class the
+  # kubelet evicts under node memory pressure, and the highest oom_score_adj for the
+  # node OOM killer. Kyverno's require-resources never flagged it because that policy
+  # matches Deployment/StatefulSet/DaemonSet and CNPG creates bare Pods.
+  # Request sits above p95 so the scheduler reserves what is actually used; the limit
+  # carries the headroom. No CPU limit, per this cluster's policy.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
   inheritedMetadata:
     labels:
       app: harbor-db

--- a/clusters/vollminlab-cluster/mediastack/jellystat-db/app/cluster.yaml
+++ b/clusters/vollminlab-cluster/mediastack/jellystat-db/app/cluster.yaml
@@ -9,6 +9,19 @@ metadata:
     category: media
 spec:
   instances: 1
+  # Sized from 14d measured usage (p95 229Mi, peak 353Mi, cpu p95 13m).
+  # Without this block the instance pods are BestEffort -- the first QoS class the
+  # kubelet evicts under node memory pressure, and the highest oom_score_adj for the
+  # node OOM killer. Kyverno's require-resources never flagged it because that policy
+  # matches Deployment/StatefulSet/DaemonSet and CNPG creates bare Pods.
+  # Request sits above p95 so the scheduler reserves what is actually used; the limit
+  # carries the headroom. No CPU limit, per this cluster's policy.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 320Mi
+    limits:
+      memory: 768Mi
   inheritedMetadata:
     labels:
       app: jellystat-db

--- a/clusters/vollminlab-cluster/shlink/shlink-db/app/cluster.yaml
+++ b/clusters/vollminlab-cluster/shlink/shlink-db/app/cluster.yaml
@@ -9,6 +9,19 @@ metadata:
     category: apps
 spec:
   instances: 1
+  # Sized from 14d measured usage (p95 117Mi, peak 286Mi, cpu p95 10m).
+  # Without this block the instance pods are BestEffort -- the first QoS class the
+  # kubelet evicts under node memory pressure, and the highest oom_score_adj for the
+  # node OOM killer. Kyverno's require-resources never flagged it because that policy
+  # matches Deployment/StatefulSet/DaemonSet and CNPG creates bare Pods.
+  # Request sits above p95 so the scheduler reserves what is actually used; the limit
+  # carries the headroom. No CPU limit, per this cluster's policy.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
   inheritedMetadata:
     labels:
       app: shlink-db

--- a/clusters/vollminlab-cluster/vollmint/vollmint-db/app/cluster.yaml
+++ b/clusters/vollminlab-cluster/vollmint/vollmint-db/app/cluster.yaml
@@ -9,6 +9,19 @@ metadata:
     category: apps
 spec:
   instances: 2
+  # Sized from 14d measured usage (p95 173Mi, peak 259Mi, cpu p95 11m).
+  # Without this block the instance pods are BestEffort -- the first QoS class the
+  # kubelet evicts under node memory pressure, and the highest oom_score_adj for the
+  # node OOM killer. Kyverno's require-resources never flagged it because that policy
+  # matches Deployment/StatefulSet/DaemonSet and CNPG creates bare Pods.
+  # Request sits above p95 so the scheduler reserves what is actually used; the limit
+  # carries the headroom. No CPU limit, per this cluster's policy.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
   inheritedMetadata:
     labels:
       app: vollmint-db


### PR DESCRIPTION
## Every database in the cluster is currently the first thing evicted

All 7 CNPG instance pods run with **no memory request and no memory limit** — `resources: {}`:

```
authentik/authentik-db-1    BestEffort   k8sworker01
harbor/harbor-db-2          BestEffort   k8sworker04
harbor/harbor-db-3          BestEffort   k8sworker01
mediastack/jellystat-db-1   BestEffort   k8sworker04
shlink/shlink-db-1          BestEffort   k8sworker01
vollmint/vollmint-db-1      BestEffort   k8sworker04
vollmint/vollmint-db-2      BestEffort   k8sworker02
```

BestEffort is the **first QoS class the kubelet evicts** under node memory pressure, and carries the highest `oom_score_adj` for the node OOM killer.

The placement concentrates it: **worker04 holds three of them**, and worker04 is already the most committed node in the cluster — 85% of requests, **162% of limits**.

## Why no policy caught this

Kyverno's `require-resources` matches `Deployment`, `StatefulSet`, `DaemonSet`. **CNPG creates bare Pods**, so these were never evaluated at all — not exempted, just invisible. They appear in no PolicyReport as a violation.

## Sizing — measured per cluster, 14d

| cluster | p50 | p95 | peak | → request | limit |
|---|---|---|---|---|---|
| `authentik-db` | 368 | 601 | 932 | **768Mi** | **1536Mi** |
| `jellystat-db` | 186 | 229 | 353 | 320Mi | 768Mi |
| `vollmint-db` | 160 | 173 | 259 | 256Mi | 512Mi |
| `harbor-db` | 146 | 152 | 239 | 256Mi | 512Mi |
| `shlink-db` | 79 | 117 | 286 | 256Mi | 512Mi |

Per-cluster rather than one number for all five — authentik's working set is 4× shlink's.

The **request sits above p95** so the scheduler reserves what's actually in use; roughly **1.27 GiB of real database working set was invisible to it**. The **limit carries headroom** at ~2× measured peak. CPU requests from measured p95 (authentik 106m, rest 10–13m). No CPU limits, per cluster policy.

## One interaction worth noting

No cluster sets `postgresql.parameters`, so all five use CNPG's default `shared_buffers` of 128MB rather than a fraction of the memory limit. Adding a limit therefore doesn't change Postgres's own allocation behaviour — which is the usual way a memory limit on Postgres goes wrong.

## ⚠️ This rolls the database pods

- **Two-instance clusters** (`harbor-db`, `vollmint-db`) — fail over replica-first, no meaningful downtime.
- **Single-instance clusters** (`authentik-db`, `shlink-db`, `jellystat-db`) — restart in place. **Authentik SSO is briefly unavailable**, which affects forward-auth for every protected service.

Worth merging when you can watch it, not unattended.