### PR TITLE
docs: correct four claims that are false about this cluster

### DIFF
--- a/.claude/rules/flux.md
+++ b/.claude/rules/flux.md
@@ -21,9 +21,15 @@ clusters/vollminlab-cluster/
 ## App file structure (every app)
 
 ```
-helmrelease.yaml       # Required — HelmRelease CR
-configmap.yaml         # Required — Helm values via valuesFrom ConfigMap
+helmrelease.yaml       # Required *for Helm apps* — HelmRelease CR
+configmap.yaml         # Required *for Helm apps* — Helm values via valuesFrom ConfigMap
 kustomization.yaml     # Required — lists all resources in this dir
+
+There are two archetypes, and only the first uses the two files above.
+Measured 2026-08-19: **53 of 89 `app/` dirs are Helm-based; 36 are raw-manifest**
+(Deployment/CronJob/CNPG `Cluster`/Terraform CR + `kustomization.yaml`) — e.g. every
+`tofu/*-config/app/`, every CNPG `*-db/app/`, `kube-system/etcd-defrag/app/`. A raw-manifest
+app dir having no `helmrelease.yaml` is correct, not drift.
 ingress.yaml           # Optional
 pvc-*.yaml             # Optional
 *-externalsecret.yaml  # Optional (ESO + 1Password — never plain Secret)
@@ -48,7 +54,10 @@ This is what causes Flux to sync the chart source. Without it the HelmRelease ca
 
 ## Source repository conventions
 
-- File always named `[app-name]-helmrepository.yaml` regardless of kind
+- `HelmRepository`/`GitRepository` → `[app-name]-helmrepository.yaml` / `-gitrepository.yaml`
+- `OCIRepository` → `[app-name]-ocirepository.yaml`. (This rule previously said
+  `-helmrepository.yaml` *regardless of kind*; **0 of the 14 OCIRepository files follow that** and
+  all 14 use `-ocirepository.yaml`. The rule was wrong, the files are consistent.)
 - `metadata.name: [app-name]-repo` — always suffix with `-repo`, no exceptions
 - Named after the **app being deployed**, not the chart author
 - HTTP registry → `kind: HelmRepository` (`source.toolkit.fluxcd.io/v1`)
@@ -84,7 +93,14 @@ Every resource kind follows a predictable pattern. Use this table when creating 
 | ConfigMap (Helm values) | `{app-name}-values` | `configmap.yaml` |
 | Ingress | `{app-name}-ingress` (add qualifier for split ingresses: `{app-name}-{qualifier}-ingress`) | `ingress.yaml` or `ingress-{qualifier}.yaml` |
 | ExternalSecret | `{app-name}-{purpose}` — never use `-secret` as suffix (redundant) | `{metadata.name}-externalsecret.yaml` |
-| Flux Kustomization CR | `{namespace}-{app}` | `{app}-kustomization.yaml` |
+| Flux Kustomization CR | `{app}` (see note) | `{app}-kustomization.yaml` |
+
+**Flux Kustomization CR naming**: this table previously specified `{namespace}-{app}`. Measured
+2026-08-19: **1 of 41 follows that** (`monitoring-vmware-exporter`); the other 40 use the bare app
+or namespace name, and `docs/runbooks/flux-templates.md` has always shown `name: [app-name]`. The
+table now matches the codebase and the template. Two genuine filename↔name mismatches remain and
+are worth fixing on contact: `kyverno-webhooks-patch-kustomization.yaml` → `kyverno-patches`, and
+`volsync-kustomization.yaml` → `volsync-system`.
 
 **ExternalSecret filename rule**: the filename base **must exactly equal** `metadata.name`. Stripping `-externalsecret.yaml` from the filename must give you the object name. See `secrets.md` for the full ESO + 1Password workflow.
 

--- a/.claude/rules/velero.md
+++ b/.claude/rules/velero.md
@@ -203,11 +203,18 @@ success throughout. After any CronJob PR lands, check the job pods' exit codes.
 
 Before diagnosing any backup issue or taking any corrective action, run the storage breakdown first:
 
-```bash
-# Bucket breakdown — answers "what is actually consuming space" in one command
-kubectl exec -n minio $(kubectl get pods -n minio -l app=minio -o jsonpath='{.items[0].metadata.name}') \
-  -- mc du --depth 2 velero-access/velero/
+**The `velero-access` mc alias no longer exists** (verified 2026-08-19). `mc du` against it
+returns `0B  0 objects` — which reads as "the bucket is empty" rather than "wrong alias", so it
+will give you a confident wrong answer. The live aliases are `local` and `r`. `mc du` over this
+bucket also takes >2 min and times out, and `kubectl exec -- du -sh /export/*` does not glob
+because there is no shell; use `sh -c`. Prefer the Prometheus metric for attribution:
 
+```bash
+# Per-bucket usage, instant — this is the reliable one
+minio_bucket_usage_total_bytes
+```
+
+```bash
 # PVC free space
 kubectl exec -n minio $(kubectl get pods -n minio -l app=minio -o jsonpath='{.items[0].metadata.name}') \
   -- df -h /export

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ GitOps-managed Kubernetes cluster using Flux CD. All workloads are Helm-based Fl
 - Never use `:latest` image or chart version tags. Kyverno blocks them.
 - All pods require `app`, `env`, and `category` labels. Kyverno enforces in enforce mode.
 - Never set `policy: sync` in external-dns — shared Pi-hole backend, `upsert-only` only. `policy: sync` wiped all infrastructure DNS records on 2026-04-05.
-- Every new Ingress must include `shlink.vollminlab.com/slug: <service-name>` — the shlink-ingress-controller uses this to auto-create a `vollm.in/<slug>` short URL. Use the service name from the hostname (e.g. `radarr.vollminlab.com` → slug `radarr`). See `clusters/vollminlab-cluster/homepage/homepage/app/ingress.yaml` as the canonical example.
+- Every new **host-level** Ingress must include `shlink.vollminlab.com/slug: <service-name>` — the shlink-ingress-controller uses this to auto-create a `vollm.in/<slug>` short URL. Use the service name from the hostname (e.g. `radarr.vollminlab.com` → slug `radarr`). See `clusters/vollminlab-cluster/homepage/homepage/app/ingress.yaml` as the canonical example. **Path-split secondary Ingresses are exempt** — the `-signalr`, `-tus` and `-s3` objects that carve one path out of an existing host (usually to bypass Authentik) must NOT carry a slug; their host already has one on the primary Ingress. Measured 2026-08-19: 28 of 34 Ingresses carry a slug and all 6 without are path-split secondaries whose primary sibling has one.
 
 ## Bootstrap / DR
 

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -19,8 +19,8 @@ Overall posture is **solid for a homelab**: ESO + 1Password with gitleaks CI (Se
 
 The material gaps are **architectural, not "anyone can walk in"**:
 
-1. **No intra-cluster network segmentation** outside the DMZ — 28 of 35 namespaces have zero NetworkPolicy (default-allow lateral movement). *Biggest gap.* → **RESOLVED**
-2. **No Pod Security Standards enforcement on app namespaces** — no Kyverno or PSA enforcement of non-root, dropped capabilities, seccomp, or read-only rootfs for application workloads; ~83% of containers ship no explicit securityContext. → **RESOLVED**
+1. **No intra-cluster network segmentation** outside the DMZ — 28 of 35 namespaces had zero NetworkPolicy (default-allow lateral movement). *Biggest gap.* → **PARTIAL — re-verified 2026-08-19: 23 of 38 namespaces still have zero NetworkPolicy, and only 9 have a default-deny.** See the H1 correction below.
+2. **No Pod Security Standards enforcement on app namespaces** — no Kyverno or PSA enforcement of non-root, dropped capabilities, seccomp, or read-only rootfs for application workloads; ~83% of containers ship no explicit securityContext. → **PARTIAL — re-verified 2026-08-19: 20 namespaces carry no `pod-security.kubernetes.io/enforce` label at all.** 17 of those have `warn`/`audit` set but no `enforce`, which logs violations and admits them. See the H2 correction below.
 3. **Image supply chain is unpinned** — no registry allowlist and only ~17% of images are digest-pinned. → **RESOLVED**
 
 > **Major correction (2026-05-29) — the authentication findings were withdrawn.** The parallel agents (and my first synthesis) flagged Grafana/Headlamp/Portainer/MinIO/Audiobookshelf/Jellyfin as missing authentication, rated up to CRITICAL. **This was wrong.** All of these have dedicated Authentik OIDC providers (verified live via `ak shell` and Grafana's SSO API), and every other app ingress carries forward-auth. The blind spot: **app-level OIDC is provisioned out-of-band via Terraform through each app's API and stored in the app's database**, so it's invisible to manifest/config inspection. As a result **H3, M1, and M2 were all withdrawn as false positives.** The remaining real findings (H1, H2, M3–M7) are infrastructure-level facts verified directly against the cluster. A "DMZ broken labels" agent finding was also a false positive. Full corrections are documented inline and at the end.
@@ -29,11 +29,35 @@ The material gaps are **architectural, not "anyone can walk in"**:
 
 ## HIGH
 
-### ~~H1~~ — RESOLVED 2026-06-04 (PR #878) · GitHub #795 closed
+### H1 — PARTIAL (was marked RESOLVED 2026-06-04, PR #878) · GitHub #795
 
-NetworkPolicy default-deny + explicit-allow rolled out to all crown-jewel and remaining namespaces (authentik, cnpg-system, harbor, monitoring, minio, portainer, tofu, flux-system, mediastack, shlink, and others). Key lesson learned: ipBlock rules must **not** be used for webhook ingress on this cluster — Calico IPIP encapsulation with `rp_filter=2` on `tunl0` causes the kernel to silently drop host→pod packets before nftables/Calico policy chains run. Open `from: []` with port restriction is used instead; TLS authentication on the webhook provides equivalent security. Container ports (not service ports) must always be used in NetworkPolicy — this class of bug hit twice (PRs #875/876/878).
+> **Correction, 2026-08-19.** This finding was marked RESOLVED and the paragraph below claimed the
+> rollout reached `flux-system`, `mediastack` and `shlink`. Verified against the live cluster, none
+> of those three has a default-deny: `mediastack` and `shlink` have **zero** NetworkPolicy objects,
+> and `flux-system` has policies but no default-deny (`gotk-components.yaml` ships `egress: - {}`,
+> i.e. allow-all).
+>
+> Live coverage on 2026-08-19: **9 of 38 namespaces have a default-deny** (authentik, cnpg-system,
+> dmz, harbor, minio, monitoring, portainer, tofu, vollmint), 15 have any NetworkPolicy at all, and
+> **23 have none** — including `kyverno`, `velero`, `cert-manager`, `renovate` and `homepage`.
+>
+> The rollout is real and the pattern is sound; it simply covers fewer namespaces than this section
+> claimed. Marking it RESOLVED is the more damaging error, because it stops anyone re-checking.
+> Treat the remaining namespaces as open work.
 
-### ~~H2~~ — RESOLVED 2026-06-03 (PRs #858, #864, #866) · GitHub #796 closed
+NetworkPolicy default-deny + explicit-allow was rolled out to the crown-jewel namespaces (authentik, cnpg-system, harbor, monitoring, minio, portainer, tofu — later also vollmint). Key lesson learned: ipBlock rules must **not** be used for webhook ingress on this cluster — Calico IPIP encapsulation with `rp_filter=2` on `tunl0` causes the kernel to silently drop host→pod packets before nftables/Calico policy chains run. Open `from: []` with port restriction is used instead; TLS authentication on the webhook provides equivalent security. Container ports (not service ports) must always be used in NetworkPolicy — this class of bug hit twice (PRs #875/876/878).
+
+### H2 — PARTIAL (was marked RESOLVED 2026-06-03, PRs #858, #864, #866) · GitHub #796
+
+> **Correction, 2026-08-19.** Kyverno's enforce baseline is real, but PSA enforcement is not
+> complete. **20 namespaces carry no `pod-security.kubernetes.io/enforce` label.** 17 of them set
+> `warn` and/or `audit` without `enforce` — which logs a violation and then admits the pod — including
+> `authentik`, `harbor`, `mediastack`, `minio`, `monitoring`, `shlink`, `vollmint` and `velero`.
+> Enforce is set on 18: `restricted` on 10, `privileged` on 7, `baseline` on dmz only.
+>
+> `vollmint` shows the mechanism: it was created later with a complete default-deny NetworkPolicy
+> suite and still shipped `warn`/`audit` with no `enforce`. The NetworkPolicy template gets copied to
+> new namespaces; the PSA one does not.
 
 - **Category:** policy_gap / missing_coverage
 - **Evidence:** Kyverno enforces `restrict-privileged`, `restrict-hostpath`, `require-resources`, `restrict-latest-tag`, `restrict-default-namespace`, `restrict-loadbalancer-services`, `dmz-restrict-external-access`. It does **not** enforce (or even audit) `runAsNonRoot`, `capabilities.drop: [ALL]`, `seccompProfile: RuntimeDefault`, `readOnlyRootFilesystem`, or `allowPrivilegeEscalation: false`. Pod Security Admission labels exist only for infra exceptions (`calico-system`, `metallb-system`, `tigera-operator` = `privileged`) and **DMZ = `enforce: baseline`** (baseline does *not* require non-root/seccomp/caps). **No application namespace enforces `restricted`.** ~383 of 464 containers (~83%) carry no explicit securityContext; ~28 explicitly set `runAsNonRoot: false`.


### PR DESCRIPTION
Four documentation claims that don't match the cluster. Each verified live before rewriting.

## 1. `security-audit.md` marks two findings RESOLVED that aren't

**H1 — network segmentation.** The doc says the default-deny rollout reached `flux-system`, `mediastack` and `shlink`. None of the three has one:

```
mediastack: default-deny=False  any-netpol=False
shlink:     default-deny=False  any-netpol=False
flux-system: default-deny=False any-netpol=True   (gotk-components ships egress: - {})
```

Live coverage: **9 of 38 namespaces have a default-deny**, 15 have any NetworkPolicy, **23 have none** — including `kyverno`, `velero`, `cert-manager`, `renovate`, `homepage`.

**H2 — Pod Security Standards.** **20 namespaces carry no `enforce` label.** 17 set `warn`/`audit` without `enforce` — which logs the violation and then admits the pod — including `authentik`, `harbor`, `mediastack`, `minio`, `monitoring`, `shlink`, `vollmint`, `velero`.

Both are now **PARTIAL** with measured numbers inline. The rollouts are real and the patterns sound; they just cover less than claimed. **`RESOLVED` is the more damaging error**, because it stops anyone re-checking — which is precisely what happened.

## 2. `flux.md` contradicts the codebase in three places

| rule as written | reality |
|---|---|
| Kustomization CR named `{namespace}-{app}` | **1 of 41** follows it |
| OCIRepository file named `-helmrepository.yaml` "regardless of kind" | **0 of 14** follow it |
| "every app dir has helmrelease + configmap" | **36 of 89** are raw-manifest |

In all three the codebase is self-consistent and **the rule is the outlier** — and `flux-templates.md` already documented the real convention for the first two, so the two docs contradicted each other. Linting against the old text would emit ~55 false positives.

Also flagged the two genuine filename↔name mismatches worth fixing on contact: `kyverno-webhooks-patch-kustomization.yaml` → `kyverno-patches`, `volsync-kustomization.yaml` → `volsync-system`.

## 3. `CLAUDE.md` shlink slug rule is an absolute that's correctly broken 6 times

28 of 34 Ingresses carry a slug. All 6 without are path-split secondaries (`-signalr`, `-tus`, `-s3`), and **every one has a primary sibling that carries it**. Now scoped to host-level Ingresses, with path-split secondaries explicitly exempt — as written it invited someone to create a short URL for `radarr.vollminlab.com/signalr`.

## 4. `velero.md`'s storage recipe uses a dead `mc` alias

`mc du velero-access/velero/` returns `0B  0 objects` — which reads as *"the bucket is empty"* rather than *"wrong alias"*. **It handed me exactly that wrong answer during this session.** Replaced with `minio_bucket_usage_total_bytes`, and noted that `mc du` times out on this bucket and `kubectl exec -- du /export/*` can't glob without a shell.