### PR TITLE
chore(tofu): commit provider lockfiles and let Renovate see terraform

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,7 +9,12 @@
   "prConcurrentLimit": 10,
   "labels": ["renovate", "dependencies"],
   "commitMessagePrefix": "chore(deps):",
-  "enabledManagers": ["flux", "github-actions", "custom.regex"],
+  // "terraform" added 2026-08-19. Until then no manager saw terraform/, so provider
+  // upgrades never appeared as a PR -- and with no lockfiles, `~>` constraints and
+  // approvePlan: auto on a 10m interval, a new provider release auto-applied itself to
+  // production within minutes of publication. Lockfiles (committed in the same change)
+  // stop the silent upgrade; this makes the upgrade visible and reviewable.
+  "enabledManagers": ["flux", "github-actions", "custom.regex", "terraform"],
   "ignorePaths": [
     "clusters/vollminlab-cluster/flux-system/gotk-components.yaml"
   ],
@@ -63,7 +68,18 @@
     "tautulli-repo": "https://k8s-at-home.com/charts/",
     "velero-repo": "https://vmware-tanzu.github.io/helm-charts"
   },
+  "terraform": {
+    "managerFilePatterns": ["/^terraform/.+/versions\.tf$/"],
+  },
   "packageRules": [
+    {
+      // These apply to live infrastructure the moment they merge (approvePlan: auto,
+      // interval 10m), so they must not be grouped with chart bumps or auto-anything.
+      "matchManagers": ["terraform"],
+      "commitMessagePrefix": "chore(tofu):",
+      "labels": ["renovate", "dependencies", "terraform", "review-carefully"],
+      "automerge": false,
+    },
     {
       "description": "Require manual review for all Flux HelmRelease updates",
       "matchManagers": ["flux"],

--- a/terraform/authentik/.terraform.lock.hcl
+++ b/terraform/authentik/.terraform.lock.hcl
@@ -1,0 +1,66 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/goauthentik/authentik" {
+  version     = "2026.2.1"
+  constraints = "~> 2026.2.0"
+  hashes = [
+    "h1:/NL9ijMTtdvS0ru/sr2JqxwKZIExLM8hXru3wV0sskc=",
+    "h1:B/syh6YYriGCANfY0bc0O8f6uZDRJ7xREHtuCh6OZOg=",
+    "h1:E6D8z9fZLKD1YjvGriRrKYyp6HfcCnUPOlq4vpEblOo=",
+    "h1:FQIxBT55TA6/EJiRa2IF/TBUPruN9c6a5zHB7nTUngA=",
+    "h1:Nn0D+Mm5miyYx1ScxhaIgI7gcmfRRzW5/8SZcwrW71w=",
+    "h1:RupC1JKNXXWQGll5aCmmTx19hpB99cUO1FeV8dah4D0=",
+    "h1:U0YyeuYE5/udBeFGzDv8jUmESfSrPnN2f3uL0mk97s4=",
+    "h1:URiGm+XyEVYY5Y/K56xIgmSJ2D/Iq9qiRkNQFib3rc8=",
+    "h1:btVtZGeimkweEg+o8sDjAZ/IOCE3u0gfIPqQMze0WoE=",
+    "h1:lDpjvszFAgHlfbyeCtF7e+74m87tFl9/w2DDDBFg2d8=",
+    "h1:n8GOPcIcLRXpvYpAhDBaD1Dbbsq4p47dddKEU2MoKq0=",
+    "h1:vLa6wSp/aaYFcZVtORM/+eKgZL8gsc4KPCI+NViTs+k=",
+    "h1:yfFe0oim+iEPc2HD+KY9GTt0vcfFJREE7B56AuqA81w=",
+    "zh:08cafee5161404b80e686e109bb94e3810cb7a8c67504a4087b622e1ae29eeb8",
+    "zh:2d5e48585e3df2ed49ea35f249f7ada0277faae206ba836e6894139996d58d6d",
+    "zh:44f30a905e56de25d0da26c6b120ab9f2d512e07c530dcdcc9993d1f47298fa2",
+    "zh:489548925116df36fca91859e866b69a6c6d4fc79513e6fc54e6b2d87d16c2df",
+    "zh:4c0acd9c0ce25d5d39700abd552bffaf0e97a42a228822b76e025bca34a8b8fe",
+    "zh:6da874a37f84cf385511adf1a800930358db39af775a07e1fa268948301e8341",
+    "zh:7108c67eb23f5c074d4c821e47ae20624244c113bc47bbe08d3629981988d07d",
+    "zh:8e24cd22a7295995bc32bbd55c9cff474dfed19a543af11202fba6d24236dd12",
+    "zh:9ef7e4be69c7deefd4235da192edacfea90fabc551694d3fcc62942b5c4b756d",
+    "zh:ba3bdba82e17a126ef0ff15626b764664e051bf773d893fd7f53716275dc33a2",
+    "zh:d523ab7fd64a54bb3b73273254d2ac7361fc1ccf5789adbf0e75b7824200fdef",
+    "zh:ddffd5257ff0e738ffe2c6e4324ee92664345c0cbb9e1c3e084463885a0847e3",
+    "zh:e44c785b16f16a69abd6d71d516e27b654969f7a683a25229a5ea97ad6ed1de9",
+  ]
+}
+
+provider "registry.opentofu.org/portainer/portainer" {
+  version     = "1.34.3"
+  constraints = "~> 1.29"
+  hashes = [
+    "h1:4sI2IDhBtewxFH68Kz1piurZQ79krCrP+WuF9IAqFoQ=",
+    "h1:AyI8iY4h5z8T9s4xhrnR6ia96S3EzklRp24m7ySdM4w=",
+    "h1:Eekxhz0oJXYdj9NyXFeujqnOa20ODpfP65H4q6MeAbg=",
+    "h1:TbJD6nUp3X/tXyEwkBGJzkY+TUm8kAB8Y0JqZko811o=",
+    "h1:Y6EG9F70BWjDJvHzZNKk+mw1gCrZT1Zfnf4XPPmtWGQ=",
+    "h1:fRwlbd7C2w3gER/HHnL5AcS29qIzA6zfPqRHD8DcKho=",
+    "h1:gWSXgTiW9+xMAyJUs/PyUcQvRNKjzmmNBWvVzOGKSV4=",
+    "h1:mmMTilhgkZDtICkE2ZNMqdejAIvZkPoLpXIj59ljXm4=",
+    "h1:nWKCP68I76t7/Yq2eF857yBUcgA9+iw9j/7RTiNZGgo=",
+    "h1:oW4isOhL9JCXtvYIHPDjdjoNUBgxGaMyFWRYte0Ljko=",
+    "h1:yzjl4T8pNTM/nFsFoMY5BWnxTMg6LZSFYvTGv7JWSws=",
+    "h1:zsKb/5H5V9UAC7ew9cUlHD6U0Tgq6BKhiMq34DzH5X0=",
+    "zh:0f59c9ed711bbb4189ad1dd3078158cd19b5006deb09169f915878af95209953",
+    "zh:40dcdfbf7ebec07ccf8ddebc93a64f477a7c2393fc265223a662addbecfb565e",
+    "zh:4d2c263fa02f11c3ae56f1a0d1a3fac27c8ec6ff439c5f2110d0c7b94a40ba5e",
+    "zh:6932b0aa3fa279d4b4b8eeb5f4b44cd20b2b7d524e0b7f22c48d02e6ba9b4f2d",
+    "zh:771674beba2a52865ba0657319074c93776aeee7b544c24cab61e6aaeaf1f304",
+    "zh:7a511203b45728f91638767e2125266e499cee534c40bb6d3a5d047df35f5a84",
+    "zh:810abf4d2b265847309d8c48a0082206d7e2b0d0c15f9acf5d051f1414d2f1cc",
+    "zh:8252b9e9973b6e2ed5e556ab1d4b4f94136e88c1ede2343e2a6743de4aa42d4d",
+    "zh:8478c1fa77f0ec0b0c17e236b4ea070900ce4891027f332609b649ee0384078a",
+    "zh:8575f3e672548be518ea2ad837603fb4a35da5d5484c86dbd08d7fc6f14b9190",
+    "zh:b345aa3ec7136124c61d6fcd7dbdb00c0567108eb8106173d2fd842418e77ca5",
+    "zh:cfe04bd5ce95829db2ad5927b9e48cab4fb0659ed6471d834a532a2250c8dcdd",
+  ]
+}

--- a/terraform/b2/.terraform.lock.hcl
+++ b/terraform/b2/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/backblaze/b2" {
+  version     = "0.13.2"
+  constraints = "~> 0.8"
+  hashes = [
+    "h1:CvSGLZjfK6nBmUwWAttzVd/Yl43efMBP6k8MTYcfKSo=",
+    "h1:JrsBRoUeXwYXU0MUIyYfzatFzTG46nxn07gid7lMsK8=",
+    "h1:SLAIwqv4rdVsM2PaAZbUzAU0GLv+4VqYnjE8/MadR9w=",
+    "h1:ZLs3VUlLAnQGQFZPMKZiIcsuNCcyS4hnQqjuH31pqvY=",
+    "h1:dD31XsGhaqYadSqGeVjTrfB2La8SZmzrVjV1d7CTZEY=",
+    "zh:18200e500f82b6a017f65e59675be44c95c37fe75f95366a5e1f2cd5bed83d43",
+    "zh:702b2f81c76d36113be91aba7f99703e5993ccdb655b81b707379655f4aee7c9",
+    "zh:a77ca7f9b7e4f2559be2153f4c3d50916e460d4e940842f7a261b05e82bed79f",
+    "zh:bc94e85036235ab61d8743a1e5012be2da4bbb75b34f00ee48648bae67ce1386",
+    "zh:ce235c956b02f10748cd764cbf52caecc0e229fe8393d99a8c93c0a0317d0d1b",
+  ]
+}

--- a/terraform/cloudflare/.terraform.lock.hcl
+++ b/terraform/cloudflare/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/cloudflare/cloudflare" {
+  version     = "5.23.0"
+  constraints = "~> 5.8"
+  hashes = [
+    "h1:AHGT3iXr4NMNymUXeRXu3WcKIVUbvHKpYRUbdgiQv/4=",
+    "h1:C6JU7d5XoRQnksREiFD3hTgGRQ18ciV7ynKvpvGIteA=",
+    "h1:LeM+28HS6S95Ab9xxG7GoLTrE9k9Q0GoJ3mjG2rVbMI=",
+    "h1:Sixlatj4vbZGhJ9r7I5c0l4gWp5Bej0aNR3akDt7wig=",
+    "h1:UfdcqA0fWnAbuDsV4hx8/xeAfyVKmjJYyXGFawHLldc=",
+    "h1:cvzir6P1UJ+IBTLlXNg57K6ojEB2+dQDa6ZK1f6eKuQ=",
+    "h1:imUBweQvKLcFlE+TjpiwjNg6OlSoyLlAe5LuP5x13kk=",
+    "h1:s3+LfSvj6fOzcXKjsOQEHg6MmHMuZDBXNNQ+7z4JAF4=",
+    "zh:3492a18e8753c2734bb253b70b46c8ec66151198b5221dc7772dab76778a2c06",
+    "zh:698ca2b12417c7477744e5410796f4fa0311f7882e1a6c790581795182b3905c",
+    "zh:b21e7da03e7529469f042eb5b11d08b084d255ab794bfeec80f6d8a9e8a91df6",
+    "zh:bbd837ccb1e08335aa7473e6c806da4c2ff04c93bfb63f6606bd09efceb82cff",
+    "zh:bdcaa21fe92031f5f043a6774821247a26047db92e5a2abfc4bfbd9262358e0c",
+    "zh:cb2c86565c94822733760015f892c71d3ed886d7db4549c561d62ec7bc20a175",
+    "zh:ccc101c27eec4ffdcbf43eaedc85a5ba5850c29d38dca7b1d7e20d668edb7a96",
+    "zh:e029d245d2470b350e12b4747a9a6c6d637010628bfe4f46644ff79f676f56e5",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/terraform/grafana/.terraform.lock.hcl
+++ b/terraform/grafana/.terraform.lock.hcl
@@ -1,0 +1,43 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/grafana/grafana" {
+  version     = "3.25.9"
+  constraints = "~> 3.7"
+  hashes = [
+    "h1:5fXaauPL+gsUJAtGiPebhvPors/QNB1NYKK5wiLDGjM=",
+    "h1:AvTZROjSfOmkx2s7HODHTV42vYHT+CqDzkrQYFjXnE8=",
+    "h1:Km1ENNsGy1QmLBIpxI3q2QaADWT94xQ7CheJuDXtEio=",
+    "h1:Mr94xUwSKxLJxWxd/zed2K2xb57zE/+18uhIuo5/k44=",
+    "h1:S4B9LJ3cFruekMLvoX/GGNX2NbgXrKojACkVBfhL/Ms=",
+    "h1:Uca8BsavyPTPGaH3OlhkMhYSEzyICUQGMwLuEOz6lPc=",
+    "h1:XYBJv5TPq1cAR0IQ300EbCzOumQs33FAbyx/d0jACUY=",
+    "h1:YWrEGcws1JufVyHpYXwxI2UGyJUemhQKukq6nHKJPpU=",
+    "h1:aPMyxdQYLjdgLrWnR3ueNjPmUVqym5WsbfhlrzLzw8c=",
+    "h1:ddQjGuxcMvrxB2bHBgC5SHI+ueo7KvnZhNRW/5+Nnh4=",
+    "h1:m19AUS7s6DUOawfYD4OSEXVqxjp7OG/i8ArjcxCDIW0=",
+    "h1:m7YN3Q3Trdkpo2IzvNBZsYzltKbTgBCBtRNOyWcTJ2A=",
+    "h1:nNGW1JcrxYZeWO0uKDC6EGvIeKFUb6MZQpIViEtwnD4=",
+    "h1:uwRkqjMUwP9SP8AexJJHwCG5u8DLMTXmWQt4fEK+MJk=",
+    "zh:052dd83cbf794d6a0c41ef6262286063d64c7b2107f3a6b1b81e679303072759",
+    "zh:117092dfc73619621eb48046934ef14c09e4419fc6d5bab35bff7549eac905fb",
+    "zh:153952d2f01812cada014905852c8a03fb68a204b98a533b81830e923bf69848",
+    "zh:16e9ada001398329ebe0c28be26cb3b71d8a30bd4cc41aa94ec182d671a06b58",
+    "zh:1eab3a56da8bb9478b0b32e87c3210b82d937d6a9586bd64046840f48486f7a1",
+    "zh:2e92818816fbac9e52a00d7c2c94b529b2fccdcfcd712c0fef8f4b340658c6ad",
+    "zh:3518f1973b3942ef380574a6765835204970f39c635b7e1dacde5e2c6a9abf16",
+    "zh:3ec8c054b91d44cb103ec82484e0974360ad9d4167e035cbfba0c858613f46f1",
+    "zh:418418c9d9e3e30e6e065d00956c56f78873546ad2c7d52a5fddb3ead207f4f7",
+    "zh:50009c4adbfe2174984f9c80627eb37c629b2b756acfd79f09b6dde7c6e58c60",
+    "zh:5482ea23403676f691d765d644519cbb632b1b5c1cfa6f3115705a0512d7d2db",
+    "zh:55b45e72ff7f186f91e3134eb925718b1e7b3e32aa5c810888f6be1db7242cf4",
+    "zh:577cc62c2e5e2b6c9eda49c316931318f106b7cbf2f59727d20a16c8a1902637",
+    "zh:63d43991044566879304f153ef3a1ae50cc4301508888a230462259aac97c7a2",
+    "zh:76074d9d200c59c707f570603b7b447b48d38ce57b53b54ee921c45b6521d816",
+    "zh:81141dd99b77fd091f1bd86fff15e6a25abfd92c825e77439457a6eba027f27c",
+    "zh:a3db02539d1417e326cee4e70ed77bce37bc4586f98b7067a0653e7b608d0cc9",
+    "zh:a53a7c400f3d8cef527897a95bd4e559e306703706d1dae509963d42423ef006",
+    "zh:d6b4f270ea3a27542fea8af45323428452563191929e13d3d92a64365dca1694",
+    "zh:fffaf801f26a13d5a600d6f39f508e7c07ed09e7dd35fc3541d8066236348b6f",
+  ]
+}

--- a/terraform/harbor/.terraform.lock.hcl
+++ b/terraform/harbor/.terraform.lock.hcl
@@ -1,0 +1,36 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/goharbor/harbor" {
+  version     = "3.12.4"
+  constraints = "~> 3.10"
+  hashes = [
+    "h1:/X+cRkAWY5Juhc93F98wMM4jlf1S2GypNCsDk8gEQcQ=",
+    "h1:2GtEFymXmXPdyFf++A1ghfgK7ATbBWiGCtR0DPycGng=",
+    "h1:4+JyjckrCDBRc4C1xzS32SK44zYYTEbRzR7FnPOLZxg=",
+    "h1:7zZqxOnxoCsvKNTTS9zOmMozmrAVE5J9dHOWZCLBPcY=",
+    "h1:DpubitY1zucliMr/ZUAfWc02fx9L3SC47qVa0co+vtI=",
+    "h1:HYQInbRVApP1GvfuJT7rHXOGgTq/FwWtYOIZuywifa0=",
+    "h1:Hs5icYOm32MIR1mmzmQbnGI+Vef+e1/swJWei/At4sU=",
+    "h1:KtfV+M0wUTnUlY/hFS6T205bBK63j+cv5ZLlIVlbmJM=",
+    "h1:W0vTrwGogj495t4+cX0/KbZ7/HaoBX2CnueZ4pRll2w=",
+    "h1:hlg6zMPvzLhhspgywPhweMa42PSgPXOZdGlhxZEmm2M=",
+    "h1:nZWRDiZP3vSnPcodYgZ75c5sEsihSdKidUL/TXGNe2g=",
+    "h1:u5APj+uJ+xNLa9w1l2nALVwq1xovayoxiMxqjiK9vHQ=",
+    "h1:yZOI1UdxnmNZsP5xz1evNZX1cbf5Sl/MYfxEx0geUWg=",
+    "zh:0e6ded3ea566292f6b31d5b7f5fc1da7731a1f19be7767d66bc4dc69e598b5d8",
+    "zh:1da28f35308cfbd2515b527c9350a28175c6abffe00a619bfbc2b7cb163283ab",
+    "zh:29fcc5bee07bfceada99a28eda70fea0f34095a361ff29eb70fa771ebcb9f7a5",
+    "zh:3a0cb06484a8c4ffc66433432031cba1374471fbb3eb0e2dc077d561cde44895",
+    "zh:3fd5155e6a687fdeabd53170489fac324c9bd6dd105582ef7fca38677beee58d",
+    "zh:4567d921cb150257fd951fcfc2c9d1cbd73ccb25f8c60b0947d0983fb1eda1a1",
+    "zh:747d5f96b62b84cb80a3af731c9375165f501c482f52621e7ee2ff7e3f7fc87b",
+    "zh:919f979f79918cc4ef6e3dca288081495a96f4b37dc82c75bdf3cda1ad149530",
+    "zh:d929632cec2cd30098d4cf5f5a04fb3b3cc252165a4e43a40ec391e5374818a8",
+    "zh:e38ec76683786c1e78ab311ba8cf1be50d82b39dfb9f98d0c744a9c95abe6856",
+    "zh:e52d89c6dc3fcd08420aa15dbb1191c755299d5b5d514c347f38a0038a2e3a44",
+    "zh:e95e04131b490ff9fbd136cac688f85a58419f0b34be9b8575de92bc8c36b35c",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f912594ee307306ec780d5b10902ddb839bcd0cda13493ff50b9dc7eff764af1",
+  ]
+}

--- a/terraform/minio/.terraform.lock.hcl
+++ b/terraform/minio/.terraform.lock.hcl
@@ -1,0 +1,35 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/aminueza/minio" {
+  version     = "3.40.1"
+  constraints = "~> 3.1"
+  hashes = [
+    "h1:/r2iMp7eAHXQXxerk3fc1BiSwX25HuPe46i6JVbMJp4=",
+    "h1:4EhdkhErr5xQnD3V2SE4R59Vr6htL1usPVH16Ij7HLk=",
+    "h1:6fJK4KPLEbR8kESCveYzw5L+BKxMVjIYaWaxZVpntTY=",
+    "h1:EijL214brx518Mk0DXwJM4cWr33XEYGoTjm6X12VCnI=",
+    "h1:IK8Ly7cWiFpDwgITtnCc5TbDXqG+KpMnXWXBJLQ+p1o=",
+    "h1:JY6ik5jgSD1xNN3MZ2bfc2sv+m27hmToaro7wN+uxM0=",
+    "h1:OnH0hQ8BbH22L4hdnfZazJKt0SNvicM5lBhcU6sk2lo=",
+    "h1:TBMX8nZgEAbIguGMH+NIoaO32bRmbviF35oCXcOn8LE=",
+    "h1:dEkk1DWlstf1/4zb0ZXBApo69SlLEE7XLnKRqDYnbZI=",
+    "h1:gAYXlTTj2MpNZYPIKP5iSsH0zDLzcIwRFANKgHu16/4=",
+    "h1:mNepAd0TfaCE/46MjSa/hw/0+Vyl5B9HyMrmsnhYg9M=",
+    "h1:wu1A2PEMEkCmA9a9kJkn8lIXFMZw4cdQSUPcd7CmYs8=",
+    "h1:xIVVpnSETectIMghvPzq+iJlHeFZ18rCh+MAwY4zYoI=",
+    "zh:03d25258c03e2317ae727fd9dd1a68797863a08d6856ef3236e6358c09b4d972",
+    "zh:2324bf868eaaa93de57e2132a611a744d308db0aa697cb9ffa8986beec87e91d",
+    "zh:29be0f5b58a6823a47c9a2fbbe0c3cee37c7aecd2288e0f40c0ab00fac5c655a",
+    "zh:43f63518100468b23bdbdada699afa5b61e466e828dcf58306acf10326c7f95a",
+    "zh:61e2d2d0ce819be121df634166a897f3cfd806d138631c129e374460f40fd797",
+    "zh:8aefe97ac5ce097fe75c1309cadea746d74fb6720e4c2efdd39db00d0e7054ea",
+    "zh:8ba6796cc59acc198dd237c7f2566779b59a4aa443777d9a6de696f6b234c276",
+    "zh:a07bdf38eddc0e71744b7f2043c43b9dfbe709be79c6c27457e74ee575cb7573",
+    "zh:bede2f970529baa1419dc3324f0efba488fb219369121fe7fe017f2f5f54ccfe",
+    "zh:c67df110dd9099871fe8b2771edf932520d2a277522c2dcdf6de97b0d7e752f4",
+    "zh:d1cf6e55e2b97ccbbcd2d56b4690915373636bb3c05a20d3d4d6d1d685ad3cd0",
+    "zh:e102ac50de2b1a06f558a8dd04adc71e017a3d53a072e92acc91d295d5d05919",
+    "zh:ffc3d2e225744f378d00dd260059548e493e9091fd78c5674d711ba801d1b663",
+  ]
+}

--- a/terraform/prowlarr/.terraform.lock.hcl
+++ b/terraform/prowlarr/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/devopsarr/prowlarr" {
+  version     = "3.2.1"
+  constraints = "~> 3.2"
+  hashes = [
+    "h1:/TLpIFdZadtRk0sAnc+jDklH7sOulCAyV7WhTD39gwU=",
+    "h1:6/6WQ9xqMdiLYQKApxPiVjdJ5WJEu/gjuQgD2XfGwso=",
+    "h1:8Inn1daQIYp/OYgrw8wmXwwREdcDuyHnTooECf7fK0E=",
+    "h1:C+l2EcI4YPo6SovgMQt7Ghyq5EHkGnr4TaSqb7CxBeg=",
+    "h1:MbCVMcmB3g1qPTGqA583cQlbM5ko9kCt6chkZTstWtM=",
+    "h1:T6KCTZrSORS3E1Fm4uXxziJJRakus5uJJiG1+o8JYI0=",
+    "h1:XTW3cgubLkW0IyrXdZATqqeBdNdZlcR8z8ZqMkS7O9g=",
+    "h1:YnXv54Kb9aPnbdo+jgO3PSuGWLG5SaNvYQ6L0MtLTyA=",
+    "h1:ZmLa3u0adVuGx2SrddGCyVnKFxUWwgiNO+OQcny+DKk=",
+    "h1:a8gqcBrud6CWBvOjE/5yHlSLy1FwD7mFNDTjUOnJvas=",
+    "h1:kAH9Z3trr75vE+gd+oPhHxwGdzPWD/3i2IwU+dRGbpk=",
+    "h1:miRNNcIfO5C5ZrVabCYy/BTPi5cx5C5htNavESTE9jQ=",
+    "h1:tM7MtXkm2tPiG7mWV6wcVkQaqdo0Yeu/8BCpL2MCqek=",
+    "h1:xKtSZTClqW4dvxnRk5KmwmvwG88tuIpWkY6wB4Z24W4=",
+    "zh:0d37e70e3104e69ed38f22675ef893df445fc1988da99a928bd576e181db5fb6",
+    "zh:0d776682ef78ef01b5542e69138e55d3b53b67fa3faaa3db5a4319799944d39a",
+    "zh:1ff54720bb754c5b24e577eb22d8756edee779e7c764188e6f53f5a6432931c6",
+    "zh:30d13d0246db3962d159f0a6c71cb1fb5215eb205905e3b3d507c28a55b0e929",
+    "zh:619f7051634693a482741cfe9c6f2bce138662cad9b305c7dbeea8742eea0ab8",
+    "zh:6c57ac508eb4418229f45e28f04706b2b72fdb835ea060443a8000b5b12ce3c9",
+    "zh:6e8d10c7048fe72e58c37bf8fb7b1f9e5980f67ae46bae77d34ae381f4aed241",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:8c00ba84caf8714e9e03bd148a9423d4d2e22570c8bf00c3c50fb3735fa57c08",
+    "zh:95d52ba75e28c785a7a19393540d4e1b9b1d3480f31a376f875038c1078ef7fa",
+    "zh:96df6af86047fe43dd6496034d1025be70e2fd953f3389b7219db459b91379b6",
+    "zh:a552da4a984865e59cf9127c372cd46435ad2c6eaa3128d493119330047b2323",
+    "zh:b0b5b9dc4f70b5e2df814c78d4996a5376ac9f48e5968461a0dbefb7966ea1d5",
+    "zh:bf6bdfd73308609e3ffc93a426635d505a8e99bb33b7f51e6197b5f74c31c3c9",
+    "zh:dd369ae9029cb57538ca99b3d86e9d679a731c2c8ab1e3b20cee380ab1a95b56",
+  ]
+}

--- a/terraform/radarr/.terraform.lock.hcl
+++ b/terraform/radarr/.terraform.lock.hcl
@@ -1,0 +1,36 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/devopsarr/radarr" {
+  version     = "2.4.0"
+  constraints = "~> 2.2"
+  hashes = [
+    "h1:BqfK8BmzZkdTGWdfOLkyMjVT/N1DjwWZHqTCW4iJjBs=",
+    "h1:KWdK8v0diFn1ejgY8nHIPiIiBcUFCxZGYF92HYuPxH8=",
+    "h1:KvX+lLP4o3OqONj9q3fu4hgGXpz2pmYJL1ca1Js1H2g=",
+    "h1:My2Jmt4X2YQT1CTGDKdiaIMJSi5RXnwFQHRGCo7S6fg=",
+    "h1:PATWuQ2cTC99IVq5GiGhHy14vQZpXD3PUuQtEiqy1Tg=",
+    "h1:YxV2MauLNefbuuRVn4eWTyNqzyy+5vvjhXGInELpLg8=",
+    "h1:aKVFv/L+PbpSSLilmbcvHkbth2e8MRbLtLFs0YU2GsY=",
+    "h1:bCWtq31jkPRJUemlAHhhiJksDrbdsFTxk7ETVLoqgLk=",
+    "h1:eUuUAiWFGEZ9cN4ZdHOvDBmuEXb+SYtFjIHVXvk4dSk=",
+    "h1:eV2D1Q/w42w2Vr6i7JV5KiMvNoEfLHpekjWUypWdYvk=",
+    "h1:hF2CxzNl6WMt5L9wuxmOCULCmX2X5mk1rSyeB5yPo5c=",
+    "h1:oc/XBbHaYLouDUiqFxWvfE7lYRxqKCTSGWyD+qlxUNw=",
+    "h1:xOdf39dypJTD/bK6Xwd9yKww7F5r0KbPVfJiJFSYiho=",
+    "zh:0c82d7c007560d1912cc0873c5757680de49d1ad1c0c2324e34d3672e4cccb6c",
+    "zh:0e336892152ba3c1a63fb4af033d4cfd3a21d6b5a298c8feeccc7c1ce6f9fadc",
+    "zh:1c2d7abbbc676565e057adb874eea3a92f0d25aa532be3c83dba09a0e4a7235f",
+    "zh:3c89157d78c49499092f1206a2d33d22c48f0805ec5566245c0906ca2ab7ea82",
+    "zh:4726d4fdec7488a1b3784a8d2ebcf0fcb465d66c1cffe76145b57237a6dacf19",
+    "zh:5c6bdf2cc1518ec08f8f8d4771df1ca7f6fc4ffe289047a2c418e3237d0997c8",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:a090720696ac96c0b3489787b7e85288e88411e5ae824beaae7d593b2490a693",
+    "zh:b4442b025aec2a2d5a3462933d0c964c004210d6eaaf27b8b5eddcdfc58bc41e",
+    "zh:b5ef7ccd630497e3996bdc3c0ec8680cf34dd87a0e1659be61751f164b5e0327",
+    "zh:b6d206fea10ad91fd6deea6146d1fd082d2c2931056ad75cfe74cf8882f25532",
+    "zh:d312c362b106ed01e6fd96923ec4089a3eb1345be95d803b7827e8659debc731",
+    "zh:d53934a99a52659871bfbe05d1bd06382e0ceea1750df9c015183a25dff27118",
+    "zh:f755698d694d1b7db5584d89a9871db856ad15552a3cd777113325c72cf33dab",
+  ]
+}

--- a/terraform/readarr/.terraform.lock.hcl
+++ b/terraform/readarr/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/devopsarr/readarr" {
+  version     = "2.1.0"
+  constraints = "~> 2.1"
+  hashes = [
+    "h1:++fwPzPUmlrQNm+uLSwhMSBEGe5t4xV7X6LovAnhwec=",
+    "h1:2IJXS503QZt1qIg8kF0vL2I59X2nIws64IW606F6r7k=",
+    "h1:7FgjDQ0JfQW8ADX+EuXWpCqd5z/GFADw2jr/xF/QYr8=",
+    "h1:C1QOUfxNBfmOYNX0T9u3jtMyxXT9u1O8xeU4hZEc7jQ=",
+    "h1:K5gZjqeDpq09KDfrPV/0rXi6QzC1e1ZtEgYSi+98dVE=",
+    "h1:MXV364y15RECLJmqPPokzqdew+xPrfJYa7qvkv4h3Wc=",
+    "h1:R6qjlvBC2/gi0JWBM8zme/bicKREPGeD+GeD9aPTSKw=",
+    "h1:U9jeDVOiBOXhwL+qCzEdrApkqc3uqM+tfkHTcMDOIAg=",
+    "h1:WIMmK2TnhJJzHrLj6GhMb+hxtz7HCAcky7PBu7ret8Y=",
+    "h1:cZrH2M0HFbl8pClnlf4vdCCUAMrI1hg+WKd7iZNouhs=",
+    "h1:g4QqKh+2mh2AM+EJjElkTNtPVIES1CqXHnfmYICa768=",
+    "h1:izeTjAxpKaokH1VA19byXHBBup9p8g9VH4/axmXW8Kc=",
+    "h1:jM03HvLAID1IA1CHyH76ce2BYt+fT+pdVJq1pquVnSM=",
+    "h1:shc/VI6JTkAwO9R7SygJx2Z+fM9nBqu4c5hzjQSP4Uo=",
+    "zh:05580fd743c03231079bb123fa0d7f31c95ea297a7b1645f537919affd0aa75b",
+    "zh:2373590be800cc2ad0c8b69ad62b9d4cdeff2a2e1748291c597320c27a25d9ca",
+    "zh:338fd052151515172fb2f4434a9f7b40daf965fce087c6314e13bf7dc3e897f6",
+    "zh:38776792fe5cb832012732f885c6c5a8295c74850b1a92aba4bda75823be8c40",
+    "zh:3e97553377e593712ee34961e5cb1714ecad85951ca5423b32fa1b47c96c8ec8",
+    "zh:40a0e2b724e904fd5d937a173b6ace96fc031b5870d239616e448b32fa6ebbd0",
+    "zh:469d96390f482a2c5032a23a3da8bc4bcc9f598845db9d2f9919ea3b9203193d",
+    "zh:4845895a793d28f382c1a25ac0a61a0be1743c6deef26a47ae7dbcb0b7d7e738",
+    "zh:6157c5cd2550a17494c02057b6e21caf87c353c30a43602dc5cf49ede11eb277",
+    "zh:7879cc8541942a20d4d10e88f7f1ef3dcff64d7341c184d8c1c257acf87abaa3",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:99bfed39e2faf9ded16065d60c7f9eea14e71a743bc04242d53a8c88261cb0ad",
+    "zh:b9b227f5759a5bd5668a215fb51c12ae5f6e16db87358c18f65b58a6ba8f0b5c",
+    "zh:ce076e3ec5622d732d8c683a1f3d3fe948d0ad1fb6b4bba11db09a583c271a16",
+    "zh:feba071c8cb39e52c098b1c08ad053ad722c6b69c84e21a288f6f435f6f32460",
+  ]
+}

--- a/terraform/sonarr/.terraform.lock.hcl
+++ b/terraform/sonarr/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/devopsarr/sonarr" {
+  version     = "3.4.2"
+  constraints = "~> 3.3"
+  hashes = [
+    "h1:2XcXWqATWjGrdkC4lngY4LvqUgwxfy5pjpLWRlNVYcY=",
+    "h1:2eXqiynDO4Tojbg4q/rrJdCIEQUtcQS7wypHUQUO1mY=",
+    "h1:4FkDDw2DX4vnUcmwTxnrrAq40th7HD6oSKOjdR5FEmc=",
+    "h1:EPnSXZ7ee1/DNcNwhfhoOuxJKawOZi+XpOcs/xfqQwo=",
+    "h1:JUf458Xf1d27s0VNnprV6dbW27V9KArilSRMpeGWF1Y=",
+    "h1:NViWdxf3eWLgUmGpJ9djZOmpJdreDykwTSFsODO3o4A=",
+    "h1:OtPlrdLOOt9FZcs224fMw3q5T6IYMaC2oDfkkRsYWhg=",
+    "h1:OtXAYOHzmEjgDYm7aiaJOiLRazr8lPeq9qUmwFRP7Wg=",
+    "h1:RCI1fuccrZXNgu04VzxjD2e2A1hsMO8UP/BLDagThqw=",
+    "h1:S0PlWOCiA7rTo7dQC1S3/n6SNdHruQpSyshEnTRQ/Hg=",
+    "h1:WFDyYkinXBPFQfgDWSKttAP15kT7RkbtLdoDdHO7GUs=",
+    "h1:Y+5xDTD66B3jnbIdz6961P2NLC46mzOXeg9xFYzg+3I=",
+    "h1:Y0hfMSXSn0EavnbgG6NPEPhsG0ko0USrrl68PKXgt+U=",
+    "h1:m+yujmlcnuRf/fSAc1DUs8ghyOt+T3PMfxfk6I7pXzk=",
+    "zh:01d675253aef5586b165bc4749d006f91cda6ce65b24842c7911cc178fe7e09d",
+    "zh:2da242ee58c1726cff9ce9260bc94756bc8a775a717da5aec8e9a8bf60578ac6",
+    "zh:30acc52a3a31ac75387728c27b3193f0419dcb72ee7488e8dbcd407884921205",
+    "zh:47adaba9c7915c832a9d8dfb5d0a18dd08b60fd7c531a810b2642ab75d200ee1",
+    "zh:551b580729cd82cc7a303d836985286e79a26062f02629bf51081ba2e4edf471",
+    "zh:5e5c5b1614cf0c61aa154543da1d5bda295a405fda52746d9193b0b8db922ddb",
+    "zh:65ebe76847129677f747364ee20591f01f5df4a67b06c5dff1bf53b813ec613a",
+    "zh:67db823f6016e345f2cbceb5300d0cce595bdeb0da32b15a1743724f0a4f978f",
+    "zh:75f119f674b3b0988133d38c1645e97cf6f0aee62a4131dfd62c8462636c2a94",
+    "zh:7ca3d6cfd4ccc2a9fb008ca93362c97a98f2ae98b55a56a7902fd33030d64179",
+    "zh:82033841c5a3fceecc1e3b84ef7328f027e2bb4bf63dfc24886510fed9d8a843",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:9aee54de9fcce6ef4f6b4f4f394a5628690d7d4849b03cd996ff991f8b29433a",
+    "zh:cda3fd66138de23856f869549aa06c82ce1f899474bc133d29d8463bfa032b16",
+    "zh:e4f8a67b8d08702056073a5ac8928dbb991767a52d3f36c3726399df0b5f2b96",
+  ]
+}

--- a/terraform/tailscale/.terraform.lock.hcl
+++ b/terraform/tailscale/.terraform.lock.hcl
@@ -1,0 +1,35 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/tailscale/tailscale" {
+  version     = "0.29.2"
+  constraints = "~> 0.29"
+  hashes = [
+    "h1:7D3VzQoUKr4NYJ7ZMMRdV9iQUK8d6yJBrnBhi0DtBfA=",
+    "h1:910l+uQ0y8nSWPo/CsGI0Ni+lM6oc/h6yckucLmivAY=",
+    "h1:IPFMdH5vsXeNRj8H/Y6Z6iq3Fko8zkmgcROSXeRJ7MM=",
+    "h1:KG/OMAOors/W0AZlHkcUD9aeGBIWDCloKa652+JlATM=",
+    "h1:SSZ93MdSAaJ1Xi/VIvZDz5z1sve3BIS+WqDKACvJut0=",
+    "h1:Vzj5bDkG9nOQbRMKHPhsol0+BrvzZ22lwkbLSIs4ycs=",
+    "h1:Xjuo1Cwe065i1qJfhKm3dti4eeEwIT9rNNqU3R6id0A=",
+    "h1:eADNOR3ZnirZXCP+3k0hy9CKQK8sgeVC0lpo08UntZY=",
+    "h1:gzBWWbJc4JOwQEIINtnYkbwErRkA2oLvhtRW4lAQ7UU=",
+    "h1:ipdqf/NJpSaP7em0/+n3hu0KVzwai3cIn2VgP4Rxdhs=",
+    "h1:lNitoP/DTekzHnRjZ3RBLthPRZ3aHy6lR7jo2rtoH+0=",
+    "h1:laqGsqlHY2/R1JQnhniKwcT0U8gb+tF0K9vr+Tovskc=",
+    "h1:wUSb/6AFeFi905uIodIMA11SyyboCTtDqqNhJYdHweM=",
+    "zh:32b453302a684584198a03c2e09d99ef1f6deac2fe26f8dc134d973b07fd0c23",
+    "zh:3920bb891a476f30e29248533f667a507c97e93e0a2af010b242e980d6411ca6",
+    "zh:630cceb40d8806945ad36e04517f313520ea5cee17bd36e26a8e999567835e1a",
+    "zh:6816de7f6bd3cfe341451af3be95b0af17c5539733b165f7505e88de6b730fc5",
+    "zh:729d75ab50efb675716ffa609358f6d9e80c66f7f64e01e11c8926c5293385be",
+    "zh:7d1024f621fe02b3731dc65ab20105150762b29df46e398da2c73d007bb62fb2",
+    "zh:81cf9cd23a70e5196b9d774482259c17e08471556932c348d3e9df0f7a482af1",
+    "zh:8de75b9c4b89ed1affcdb3ce32e00afaf213cfd76e93181ea4758ffd10b6eedc",
+    "zh:8f0b9b175ceb124c1cf01e6bbb660bf1bce0ff77416e026dc0679ed7156bc737",
+    "zh:8fb4cde10eb346ef9e2233591d75c39bcc2cafee578b669196192e8acdb39f12",
+    "zh:96798e58b8fcddc2add2da0fe8f1df9f913153d4cbccd68a7557b64633f5ea00",
+    "zh:a598bd615f4465b828f3b6ed2db694d8148c9469d5497922c7bc17c08b655cf4",
+    "zh:b2604d5067f3f259ff9be9bb0c4f9ec801d27c905cbf6ceafee50fc2a23f8331",
+  ]
+}


### PR DESCRIPTION
## The gap

Nothing watches which provider versions this cluster applies to production:

- `~>` constraints on all 12 provider blocks
- **no `.terraform.lock.hcl` anywhere** (and not gitignored — just never created)
- `approvePlan: auto` on all 11 Terraform CRs, `interval: 10m`
- CI runs `tofu validate`, **never `tofu plan`**
- `terraform` absent from Renovate's `enabledManagers`

Net effect: **a provider publishing a new minor or patch is applied to live Authentik, Cloudflare DNS, MinIO and Harbor within ten minutes of publication** — no plan, no review, no PR, no CI signal. And the upgrade is recorded nowhere: `git blame` shows nothing, because nothing in the repo changed.

Lockfiles close the silent half. Renovate closes the invisible half — bumps now arrive as PRs prefixed `chore(tofu):` with a `review-carefully` label, explicitly **not** automerged.

## These versions are what's already running

The versions locked are the newest satisfying each existing constraint — exactly what the controller resolves to today with no lockfile. **This freezes current behaviour, it does not stage an upgrade.**

| module | provider | locked | constraint |
|---|---|---|---|
| authentik | goauthentik/authentik | 2026.2.1 | `~> 2026.2.0` |
| authentik | portainer/portainer | 1.34.3 | `~> 1.29` |
| b2 | backblaze/b2 | 0.13.2 | `~> 0.8` |
| cloudflare | cloudflare/cloudflare | 5.23.0 | `~> 5.8` |
| grafana | grafana/grafana | 3.25.9 | `~> 3.7` |
| harbor | goharbor/harbor | 3.12.4 | `~> 3.10` |
| minio | aminueza/minio | 3.40.1 | `~> 3.1` |
| prowlarr | devopsarr/prowlarr | 3.2.1 | `~> 3.2` |
| radarr | devopsarr/radarr | 2.4.0 | `~> 2.2` |
| readarr | devopsarr/readarr | 2.1.0 | `~> 2.1` |
| sonarr | devopsarr/sonarr | 3.4.2 | `~> 3.3` |
| tailscale | tailscale/tailscale | 0.29.2 | `~> 0.29` |

## The failure mode I guarded against

A lockfile missing the hash for the runner's platform makes `tofu init` **fail closed on every workspace at once**. All nine nodes are `amd64/linux` and the tofu pod runs on k8sworker01, so every lockfile was additionally run through `tofu providers lock -platform=linux_amd64`, and each provider block verified to carry `h1:` hashes — not just the registry-signed `zh:` ones.

## Verification

All 11 modules `tofu validate` cleanly, checked **by exit code** rather than by tailing the log — my first pass tailed the last line and mis-read harbor as failing, when it actually prints *"Success! The configuration is valid, but there were some validation warnings"*. That one warning (`oidc_client_secret` has a write-only alternative) exits 0 and predates this change.

`tofu fmt -check -recursive` clean. Provider binaries under `.terraform/` removed, not committed.

## Deliberately not included

`use_lockfile` on the eleven S3 backends, and retiring `approvePlan: auto`. Both are worth doing; both change apply-time behaviour, so they belong in their own change rather than riding along with pure dependency pinning.