### PR TITLE
fix(ci): strip nodePort before the dry-run so minecraft PRs can pass

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -617,6 +617,25 @@ jobs:
             fi
             echo "  ✅ $RELEASE_NAME renders and strict-parses cleanly"
 
+            # Drop nodePort before the dry-run. nodePort is allocated cluster-wide,
+            # not per namespace, and this repo pins it deliberately (minecraft on
+            # 32565). So the value in the rendered manifest is by definition already
+            # held by the live Service, and the dry-run below reports
+            #   The Service "minecraft" is invalid: spec.ports[0].nodePort:
+            #   Invalid value: 32565: provided port is already allocated
+            # on every PR that touches such an app, whatever the change was — a
+            # NetworkPolicy edit that never goes near the Service still fails.
+            # Integration Test is a required check, so that blocked the merge.
+            #
+            # This does not relax validation: schema, Kyverno admission and every
+            # other field are still dry-run exactly as before. It removes the one
+            # field that cannot be meaningfully checked against a cluster already
+            # running the real object. It also does not touch the manifest — the
+            # pinned port stays pinned, which is deliberate for a port players
+            # connect to.
+            yq eval -i '(select(.kind == "Service") | .spec.ports[]?) |= del(.nodePort)' \
+              "$RENDER_DIR/rendered.yaml"
+
             # ── Server-side dry-run: real admission chain, zero side effects ────
             if kubectl apply --dry-run=server -n "$TEST_NAMESPACE" \
                  -f "$RENDER_DIR/rendered.yaml" > "$RENDER_DIR/dryrun.out" 2>&1; then


### PR DESCRIPTION
## The recurring blocker

`Integration Test` renders every changed app's HelmRelease and applies it with `--dry-run=server` into a `ci-test-*` namespace **on the live cluster**. `nodePort` is allocated **cluster-wide**, not per namespace — and this repo pins minecraft's to `32565` deliberately. So the value in the rendered manifest is *by definition* already held by the running Service:

```
The Service "minecraft" is invalid: spec.ports[0].nodePort:
Invalid value: 32565: provided port is already allocated
```

This fires on **every PR touching minecraft, whatever the change is**:

- **#1127** — a NetworkPolicy edit that never goes near the Service. Had to split minecraft out.
- **#1128** — a six-line dead-rule deletion. Currently red on exactly this.

`Integration Test` is a required check, so each time the only options were to split the change out or merge past a red check.

## The fix

Rendered Services get `nodePort` removed immediately before the dry-run:

```bash
yq eval -i '(select(.kind == "Service") | .spec.ports[]?) |= del(.nodePort)' \
  "$RENDER_DIR/rendered.yaml"
```

**This does not relax validation.** Schema checking, Kyverno admission and every other field still go through the real admission chain exactly as before. The one field dropped is the one that cannot be meaningfully validated against a cluster already running the real object.

**It does not touch any manifest.** The pinned port stays pinned — correct for a port players connect to, and the documented guidance is explicitly *not* to "fix" this by unpinning it. This fixes the CI assumption instead.

## Verification

Tested the expression against a fixture with a two-port NodePort Service, a ClusterIP Service, and a Deployment:

| object | result |
|---|---|
| NodePort Service (2 ports) | both `nodePort` removed, `port`/`name` intact |
| ClusterIP Service | untouched |
| Deployment | untouched |
| multi-doc structure | preserved |

CI installs `yq v4.44.3`; that's the version tested against.

Once this merges, #1128 should pass on a re-run.