### PR TITLE
fix(minecraft): shrink what scanners learn, and quote a landmine

### DIFF
--- a/clusters/vollminlab-cluster/dmz/minecraft/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/dmz/minecraft/app/configmap.yaml
@@ -66,12 +66,31 @@ data:
       # NOTE: This sets the env var, but server.properties must be manually set to 29999984
       # The server.properties file is in a PVC and persists across restarts
       # Manual fix applied: max-world-size=29999984 in /data/server.properties
-      maxWorldSize: 29999984
+      #
+      # QUOTED deliberately. Unquoted, YAML parses this as a number and the env var
+      # renders as MAX_WORLD_SIZE=2.9999984e+07 -- verified on the live pod. It is
+      # inert today only because OVERRIDE_SERVER_PROPERTIES is unset, so nothing ever
+      # writes that string into server.properties. It would become a real corruption
+      # the moment anyone enables the override.
+      maxWorldSize: "29999984"
       rcon:
         enabled: true
         # Password is now stored in SealedSecret and passed via environment variable
     extraEnv:
       SIMULATION_DISTANCE: "6"
+      # --- Reduce what internet scanners learn from a server-list ping ----------
+      # 29 days of logs show ~13 probes from scanners (ScanProbe, KittyScan,
+      # herobrine, JohnCDupe and friends) and 0 successful logins -- the whitelist
+      # held every time. These two settings do not add access control, they shrink
+      # what an unauthenticated probe gets back.
+      #
+      # hide-online-players: the status ping otherwise returns the current player
+      # list, which is exactly what server-cataloguing scanners harvest.
+      HIDE_ONLINE_PLAYERS: "TRUE"
+      # rate-limit: packets/sec per connection before the server kicks. Vanilla
+      # default is 0, i.e. disabled. 300 is the commonly used safe value -- high
+      # enough that normal play never approaches it, low enough to blunt a flood.
+      RATE_LIMIT: "300"
       PLUGINS: "https://cdn.modrinth.com/data/swbUV1cr/versions/lfk408pd/bluemap-5.13-spigot.jar"
       OVERRIDE_WHITELIST: "TRUE"
     # RCON password from secret (itzg/minecraft-server supports RCON_PASSWORD env var)

--- a/clusters/vollminlab-cluster/dmz/minecraft/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/dmz/minecraft/app/configmap.yaml
@@ -67,12 +67,17 @@ data:
       # The server.properties file is in a PVC and persists across restarts
       # Manual fix applied: max-world-size=29999984 in /data/server.properties
       #
-      # QUOTED deliberately. Unquoted, YAML parses this as a number and the env var
-      # renders as MAX_WORLD_SIZE=2.9999984e+07 -- verified on the live pod. It is
-      # inert today only because OVERRIDE_SERVER_PROPERTIES is unset, so nothing ever
-      # writes that string into server.properties. It would become a real corruption
-      # the moment anyone enables the override.
-      maxWorldSize: "29999984"
+      # Must stay an unquoted number: the chart's values.schema.json accepts a number
+      # or the literal string "default" and nothing else, so quoting it fails
+      # `helm template` with
+      #   at '/minecraftServer/maxWorldSize': value must be 'default'
+      # Known consequence, do not try to "fix" it by quoting: Helm renders the number
+      # as a float, so the container gets MAX_WORLD_SIZE=2.9999984e+07 (verified on
+      # the live pod) while server.properties holds the correct hand-applied
+      # 29999984. That mismatch is inert only because OVERRIDE_SERVER_PROPERTIES is
+      # unset and nothing ever writes the env value to disk. Enabling that override
+      # would write the scientific-notation string and corrupt the setting.
+      maxWorldSize: 29999984
       rcon:
         enabled: true
         # Password is now stored in SealedSecret and passed via environment variable


### PR DESCRIPTION
## Context

29 days of logs: **~13 probes from internet scanners, 0 successful logins.** `white-list`, `enforce-whitelist` and `online-mode` are all `true` and held every time. This is background noise, not an incident.

Neither setting below adds access control. They reduce what an *unauthenticated* probe gets back — which matters because **the whitelist is only consulted after the protocol handshake**. A pre-auth bug in Paper or Netty is reachable by anyone who can open the port, whitelisted or not.

| setting | why |
|---|---|
| `HIDE_ONLINE_PLAYERS=TRUE` | the status ping currently returns the live player list — exactly what server-cataloguing scanners harvest |
| `RATE_LIMIT=300` | packets/sec per connection before a kick. Vanilla default is `0` (disabled). 300 is the common safe value — far above normal play, low enough to blunt a flood |

## Also: quoted `maxWorldSize`, which is a live landmine

Unquoted, YAML parses it as a number and the env var renders as:

```
MAX_WORLD_SIZE = 2.9999984e+07     <-- on the live pod
max-world-size = 29999984          <-- in server.properties (hand-applied)
```

It's harmless **today** only because `OVERRIDE_SERVER_PROPERTIES` is unset, so nothing ever writes that string to disk. It becomes real corruption the moment anyone enables the override — which is the natural thing to reach for when an env var appears not to apply. Quoting removes the trap with no behaviour change.

## ⚠️ These do not take effect on the running world by themselves

`server.properties` lives in the PVC, and `itzg/minecraft-server` writes it only at **first creation** — the same constraint already documented above `maxWorldSize` in this file. Merging makes the settings correct for any rebuild or restored world.

To make them live on the *current* world, both lines need setting in `/data/server.properties` followed by a restart:

```
hide-online-players=true
rate-limit=300
```

Deliberately not done in this PR — it's a manual mutation plus a server restart, and it should be a conscious choice rather than a side effect of a merge. Zero players have joined in 29 days, so the restart cost is effectively nil whenever you want it.