### PR TITLE
fix(shlink): move to chart 0.3.7, the 0.3.6 artifact is unpullable

### DIFF
--- a/clusters/vollminlab-cluster/flux-system/repositories/vollminlab-ocirepository.yaml
+++ b/clusters/vollminlab-cluster/flux-system/repositories/vollminlab-ocirepository.yaml
@@ -11,6 +11,6 @@ spec:
   interval: 1h
   url: oci://harbor.vollminlab.com/vollminlab/charts/shlink-ingress-controller
   ref:
-    tag: "0.3.6"
+    tag: "0.3.7"
   secretRef:
     name: harbor-vollminlab-pull


### PR DESCRIPTION
## The 0.3.6 chart is damaged in Harbor

Its manifest references a config blob that returns **404** — confirmed with admin credentials, so not an auth problem:

```
config: application/vnd.cncf.helm.config.v1+json       sha256:3cc876…  HTTP 404  MISSING
layer:  application/vnd.cncf.helm.chart.content.v1…    sha256:5f9e77…  HTTP 200  OK
```

**Flux has been fine** because source-controller stored the artifact on 2026-05-22 and doesn't need that blob — the HelmRelease reports Ready and a forced reconcile still succeeds.

**The exposure is a rebuild.** On a fresh cluster, or if source-controller lost its cache, this chart couldn't be fetched and the controller wouldn't deploy — that's the component turning the `shlink.vollminlab.com/slug` ingress annotation into a `vollm.in` short URL.

## How it was found

`scripts/check-helm-values.py` on its first full run (#1140): **51 of 52 HelmReleases validated, this was the 52nd.** Nothing else was checking chart pullability.

Not systemic — `charts/vollmint:0.4.0` and `charts/longhorn-rebalancing-controller:0.4.0` both have intact config blobs.

## The fix

`v0.3.7` tagged from `main` in the shlink-ingress-controller repo. **The chart directory is byte-identical to v0.3.6** — the three commits between them are documentation only — so this republishes the same chart content with a complete set of blobs.

Verified after the build:

```
config sha256:690a95…  HTTP 200 OK
layer  sha256:4ab754…  HTTP 200 OK
helm pull --version 0.3.7  ->  Pulled, 1488 bytes
```

And the values validator that flagged 0.3.6 now passes:
```
ok  shlink-ingress-controller  oci://…/charts/shlink-ingress-controller:0.3.7
check-helm-values: 1 chart(s) validated against real values, 0 problems
```

## Why a new version rather than re-pushing v0.3.6

Re-running that tag would rebuild and **overwrite the container image under a tag that is currently running**, silently swapping in months-newer base layers. A new version overwrites nothing — 0.3.6 in Harbor still shows its original 2026-05-22 push — and the cluster opts in through this commit.

## Note: this also moves the image

The deployment renders `{{ .Values.image.tag | default .Chart.AppVersion }}` and this cluster doesn't override `image.tag`, so the chart bump moves the controller onto the 0.3.7 image built today. **That's intended** — the running image is from May.

Expect a brief controller restart. Short-URL creation is annotation-driven and reconciles on startup, so existing `vollm.in` links are unaffected.