### PR TITLE
chore(tofu): require manual plan approval for authentik before the provider bump

### DIFF
--- a/clusters/vollminlab-cluster/tofu/authentik-config/app/terraform-cr.yaml
+++ b/clusters/vollminlab-cluster/tofu/authentik-config/app/terraform-cr.yaml
@@ -10,7 +10,21 @@ metadata:
     category: core
 spec:
   interval: 10m
-  approvePlan: auto
+  # Manual plan approval, set 2026-08-20 ahead of the provider bump in #1136
+  # (goauthentik/authentik 2026.2.1 -> 2026.5.1, three minor releases).
+  #
+  # `approvePlan` names a plan to approve; "auto" approves every plan, so with it set
+  # the controller applies within the 10m interval and there is never anything to
+  # review. This module manages 83 resources and is the SSO for the whole cluster --
+  # if a provider upgrade rewrites or destroys any of them, the failure takes out the
+  # means of logging in to diagnose it. CI cannot cover this: it runs `tofu validate`
+  # but never `tofu plan`, so a green PR says the config parses, not what it will do.
+  #
+  # Empty string means no plan is approved, so the controller plans and waits. Read the
+  # pending plan id from .status.plan.pending, review the plan, then approve by setting
+  # this to that id. Restore "auto" afterwards only if that is the considered choice --
+  # the same argument applies to every future provider bump.
+  approvePlan: ""
   path: ./terraform/authentik
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
**Merge this before #1136.**

## Why

#1136 raises `goauthentik/authentik` **2026.2.1 → 2026.5.1** — three minor releases. With `approvePlan: auto` the controller applies within its 10m interval, so **merging that PR *is* the apply**, and there's never a plan to look at.

This module manages **83 resources** and is the SSO for the entire cluster. If the upgrade rewrites or destroys any of them, the failure removes the means of logging in to diagnose it.

**The green checks on #1136 don't cover this.** CI runs `tofu validate`, never `tofu plan` — they confirm the config parses, not what applying it would do.

## What changes

```diff
-  approvePlan: auto
+  approvePlan: ""
```

Per the CRD: *"ApprovePlan specifies name of a plan wanted to approve. If its value is `auto`, the controller will automatically approve every plan."* An empty string approves nothing, so the controller plans and waits.

## Sequence

1. **Merge this.** Confirm the controller plans cleanly against the *current* provider — expect no changes, since state matches.
2. **Merge #1136.**
3. Read `.status.plan.pending` and review the plan produced by the *new* provider.
4. Approve by setting `approvePlan` to that plan id.

Step 1 matters: it proves the manual-approval path works while the provider is still the known-good one. If something's wrong with the mechanism, you find out with a no-op plan rather than mid-upgrade.

## Scope

`authentik-config` only. `b2-config` and `grafana-config` still auto-apply — whether that stays true is a separate decision, though **#1138 is a major version bump (grafana 3.25.9 → 4.45.1)** and deserves the same treatment before it merges.