### PR TITLE
fix(ci): make the two Python-based checks actually run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,27 +82,6 @@ jobs:
       - name: Check README structure block
         run: ./scripts/check-readme-structure.sh
 
-      # Validates each changed app's REAL values (resolved through valuesFrom) against
-      # its chart's values.schema.json. Lives inside validate-changes rather than as its
-      # own job for the same reason as the README check above: it blocks merges through
-      # an existing required check instead of needing a new one added to branch
-      # protection.
-      #
-      # This is the enforcement half of the pre-commit hook. The hook it replaces ran
-      # nowhere in CI -- only for someone who had run `pre-commit install` -- so a values
-      # error reached the merge path unless integration-test happened to catch it later.
-      - name: Validate HelmRelease values against chart schemas
-        if: env.LINT_FILES != ''
-        run: |
-          set -euo pipefail
-          python3 -m pip install --quiet --disable-pip-version-check pyyaml
-          CHANGED_HR=$(printf '%s\n' "$LINT_FILES" \
-            | grep -E '^clusters/vollminlab-cluster/.*/(helmrelease|configmap)\.yaml$' || true)
-          if [[ -z "$CHANGED_HR" ]]; then
-            echo "No HelmRelease or values ConfigMap changed — nothing to validate"
-            exit 0
-          fi
-          echo "$CHANGED_HR" | xargs ./scripts/check-helm-values.py
 
       # Single source of truth. .kubernetes-version is the file Renovate bumps, so
       # reading it here means CI's kubectl follows the version the upgrade PR proposes
@@ -262,6 +241,32 @@ jobs:
               echo "EOF"
             } >> $GITHUB_ENV
           fi
+
+      # MUST stay after get-changed-files: LINT_FILES is exported to $GITHUB_ENV by
+      # that step, so an `if: env.LINT_FILES != ''` step placed above it evaluates
+      # against an empty value and is silently skipped on every PR. That is exactly
+      # what happened to this step between #1140 and this commit -- it never ran once.
+      # Validates each changed app's REAL values (resolved through valuesFrom) against
+      # its chart's values.schema.json. Lives inside validate-changes rather than as its
+      # own job for the same reason as the README check above: it blocks merges through
+      # an existing required check instead of needing a new one added to branch
+      # protection.
+      #
+      # This is the enforcement half of the pre-commit hook. The hook it replaces ran
+      # nowhere in CI -- only for someone who had run `pre-commit install` -- so a values
+      # error reached the merge path unless integration-test happened to catch it later.
+      - name: Validate HelmRelease values against chart schemas
+        if: env.LINT_FILES != ''
+        run: |
+          set -euo pipefail
+          ./scripts/ci-ensure-pyyaml.sh
+          CHANGED_HR=$(printf '%s\n' "$LINT_FILES" \
+            | grep -E '^clusters/vollminlab-cluster/.*/(helmrelease|configmap)\.yaml$' || true)
+          if [[ -z "$CHANGED_HR" ]]; then
+            echo "No HelmRelease or values ConfigMap changed — nothing to validate"
+            exit 0
+          fi
+          echo "$CHANGED_HR" | xargs ./scripts/check-helm-values.py
 
       - name: Validate YAML syntax
         if: env.LINT_FILES != ''
@@ -1242,7 +1247,7 @@ jobs:
         if: steps.tf-changes.outputs.changed == 'true'
         run: |
           set -euo pipefail
-          python3 -m pip install --quiet --disable-pip-version-check pyyaml
+          ./scripts/ci-ensure-pyyaml.sh
           printf '%s\n' "${{ steps.tf-changes.outputs.files }}" \
             | grep -v '^$' \
             | xargs -r ./scripts/check-tofu-provider-approval.py

--- a/scripts/ci-ensure-pyyaml.sh
+++ b/scripts/ci-ensure-pyyaml.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Make `import yaml` work for the Python helpers CI runs.
+#
+# The self-hosted runner image ships python3 with NO pip and NO ensurepip, so a
+# bare `python3 -m pip install pyyaml` dies with "No module named pip". The
+# yamllint step in ci.yaml has bootstrapped get-pip.py for this reason since it
+# was written; two later steps (check-helm-values.py, check-tofu-provider-approval.py)
+# did not, and both were broken -- one visibly, one silently, because its paths
+# filter had never matched a PR. This script is the shared, correct form.
+#
+# Bootstrap only if the import is genuinely missing, so a runner image that
+# gains python3-yaml costs nothing.
+set -euo pipefail
+
+# PY is overridable ONLY so the no-pip bootstrap branch can be tested against a
+# venv built --without-pip, which reproduces the runner image exactly. CI never sets it.
+PY="${PY:-python3}"
+
+if "$PY" -c 'import yaml' 2>/dev/null; then
+  echo "✅ pyyaml already available"
+  exit 0
+fi
+
+echo "📦 pyyaml missing — bootstrapping pip"
+
+# --user is correct on the runner (no venv, PEP 668 marks the system env external)
+# but is an error inside a venv, where user site-packages are not visible. Detect
+# rather than assume, so this behaves the same in CI and under test.
+if "$PY" -c 'import sys; sys.exit(0 if sys.prefix != sys.base_prefix else 1)'; then
+  INSTALL_FLAGS=""
+else
+  INSTALL_FLAGS="--user --break-system-packages"
+fi
+# timeouts so a hung download fails fast instead of stalling the job to its
+# own timeout-minutes.
+timeout 90 curl -sSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
+timeout 90 "$PY" /tmp/get-pip.py $INSTALL_FLAGS --quiet
+timeout 90 "$PY" -m pip install $INSTALL_FLAGS --quiet pyyaml
+
+# Verify the artifact, not the exit code: a --quiet install that resolved to
+# nothing still exits 0. The import is the only proof that matters, and failing
+# here is strictly better than letting a dependent check pass vacuously.
+"$PY" -c 'import yaml; print(f"✅ pyyaml {yaml.__version__} ready")'


### PR DESCRIPTION
Both checks added in this session were inert — neither had executed once, and both let the job report green while doing nothing.

## `check-helm-values` (#1140) — never ran, not once

The step sits above `Get changed files`, but its guard reads `env.LINT_FILES`, which *that* step exports to `$GITHUB_ENV`. Evaluated before the producer runs, the value is always empty, so the step was skipped on every PR.

Confirmed empirically — the step name appears **0 times across the last 12 workflow runs**. Moved below the producer, with a comment recording why the ordering is load-bearing.

## `check-tofu-provider-approval` (#1143) — failed on its own dependency

Caught on #1136:

```
/usr/bin/python3: No module named pip
##[error]Process completed with exit code 1
```

The runner image ships `python3` with no pip and no ensurepip. `ci.yaml:281` (yamllint) has bootstrapped `get-pip.py` for this exact reason since it was written; both new steps copied the bare `python3 -m pip install` form instead.

## The fix

`scripts/ci-ensure-pyyaml.sh`, used by both steps:

- import-check first, so a runner image that already has pyyaml costs nothing
- `get-pip.py` bootstrap otherwise, with `timeout` guards so a hung download fails fast
- a closing `import yaml` assertion — a `--quiet` install that resolved to nothing still exits 0, and a vacuous pass here would silently disarm the check it feeds

Verified against a `python3 -m venv --without-pip` interpreter, which reproduces the runner's condition exactly:

| | result |
|---|---|
| old form, pip-less interpreter | `No module named pip` — reproduces the CI failure |
| new helper, pip-less interpreter | `📦 bootstrapping pip` → `✅ pyyaml 6.0.3 ready` |
| new helper, second invocation | `✅ pyyaml already available` (short-circuits) |

## Note

Neither fixed step runs on *this* PR — one needs a changed HelmRelease, the other a changed `.tf` file, and this PR has neither. Real proof comes from re-running #1136, whose `Validate Terraform Modules` is currently red on this exact error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReBNuj9oheJm4PihWXh23N