### PR TITLE
chore(tofu): approve the authentik provider 2026.5.1 plan

### DIFF
--- a/clusters/vollminlab-cluster/tofu/authentik-config/app/terraform-cr.yaml
+++ b/clusters/vollminlab-cluster/tofu/authentik-config/app/terraform-cr.yaml
@@ -24,7 +24,26 @@ spec:
   # pending plan id from .status.plan.pending, review the plan, then approve by setting
   # this to that id. Restore "auto" afterwards only if that is the considered choice --
   # the same argument applies to every future provider bump.
-  approvePlan: ""
+  # Approving the plan generated at main@998e4779 (#1136, authentik provider
+  # 2026.2.1 -> 2026.5.1). Read before approving: 0 to add, 8 to change, 0 to
+  # destroy -- all authentik_provider_oauth2, all in-place.
+  #
+  # The entire diff is the removal of the `redirect_uri_type` key from each of
+  # the 12 entries in allowed_redirect_uris. Every url is byte-identical and
+  # every matching_mode stays "strict"; verified by diffing the removed and
+  # added url sets out of `tofu show`.
+  #
+  # It is safe because the key was never ours. Our config sets only
+  # matching_mode + url; 2026.2.1 read redirect_uri_type back from the API into
+  # state, and 2026.5.1 types the attribute as list(map(string)), so the extra
+  # state-only key now compares as a diff. Authentik defaults the field to
+  # AUTHORIZATION when omitted, and all 14 live redirect URIs are already
+  # `authorization` (0 `logout`) -- so the apply writes back what is there.
+  #
+  # This id is bound to the revision. If another commit lands on main before
+  # this merges, the controller generates a new plan id and this value stops
+  # matching -- which holds the apply rather than misapplying it.
+  approvePlan: "plan-main-998e47794b"
   path: ./terraform/authentik
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
Step 4 of the sequence set out in #1142. The plan the bumped provider generated has been read in full before approving it.

```
Plan: 0 to add, 8 to change, 0 to destroy
```

All 8 are `authentik_provider_oauth2` — audiobookshelf, grafana, harbor, headlamp, jellyfin, minio, portainer, seerr — every one updated **in-place**. Nothing created, nothing destroyed.

## What the diff actually is

The removal of the `redirect_uri_type` key from each of the 12 `allowed_redirect_uris` entries. That's the whole change:

```diff
-   {
-     "matching_mode"     = "strict"
-     "redirect_uri_type" = "authorization"
-     "url"               = "https://grafana.vollminlab.com/login/generic_oauth"
-   },
+   {
+     "matching_mode" = "strict"
+     "url"           = "https://grafana.vollminlab.com/login/generic_oauth"
+   },
```

Verified mechanically rather than by eye — the removed and added `url` sets diff clean (12 vs 12, identical), and all 24 `matching_mode` values are `strict`. **No redirect target moves.**

## Why it's safe

The key was never ours. Our config sets only `matching_mode` + `url`; provider 2026.2.1 read `redirect_uri_type` back from the API into state, and 2026.5.1 types the attribute as `list(map(string))`, so that state-only key now compares as a diff.

The one thing that could bite: `redirect_uri_type` **is** a real server-side field, and Authentik defaults it to `AUTHORIZATION` when omitted. If any live URI were `logout`, this apply would silently flip it. So I audited every one:

```
TOTALS: uris=14 non_authorization=0
```

14 of 14 already `authorization`, zero `logout`. The apply writes back the value that is already there.

## Note on the plan id

`plan-main-998e47794b` is bound to the revision. If another commit lands on `main` before this merges, the controller generates a new plan id, this value stops matching, and the apply is **held** rather than misapplied — so a stale approval fails closed. If that happens I'll re-read the new plan and update the id.

Reading the plan requires extracting the `tfplan-default-authentik-config` Secret and rendering it with a *matching* tofu — the runner writes 1.12.1 and plan files aren't portable across versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReBNuj9oheJm4PihWXh23N