### PR TITLE
chore(tofu): manual plan approval for b2 and grafana, and fix the approval procedure

### DIFF
--- a/clusters/vollminlab-cluster/tofu/authentik-config/app/terraform-cr.yaml
+++ b/clusters/vollminlab-cluster/tofu/authentik-config/app/terraform-cr.yaml
@@ -24,26 +24,41 @@ spec:
   # pending plan id from .status.plan.pending, review the plan, then approve by setting
   # this to that id. Restore "auto" afterwards only if that is the considered choice --
   # the same argument applies to every future provider bump.
-  # Approving the plan generated at main@998e4779 (#1136, authentik provider
-  # 2026.2.1 -> 2026.5.1). Read before approving: 0 to add, 8 to change, 0 to
-  # destroy -- all authentik_provider_oauth2, all in-place.
+  # HOW APPROVAL ACTUALLY WORKS -- do not put a plan id in this file.
   #
-  # The entire diff is the removal of the `redirect_uri_type` key from each of
-  # the 12 entries in allowed_redirect_uris. Every url is byte-identical and
-  # every matching_mode stays "strict"; verified by diffing the removed and
-  # added url sets out of `tofu show`.
+  # The pending plan is named plan-<branch>-<source sha>, so it is regenerated on
+  # EVERY commit to this repo, not just commits touching this module. An approval
+  # delivered through git therefore names a plan that the merge commit itself has
+  # already invalidated -- it can never match. #1145 proved this: it merged
+  # approvePlan: "plan-main-998e47794b", the merge moved main to 60b4f111, the
+  # controller re-planned as plan-main-60b4f1118b, and the apply was held.
   #
-  # It is safe because the key was never ours. Our config sets only
-  # matching_mode + url; 2026.2.1 read redirect_uri_type back from the API into
-  # state, and 2026.5.1 types the attribute as list(map(string)), so the extra
-  # state-only key now compares as a diff. Authentik defaults the field to
-  # AUTHORIZATION when omitted, and all 14 live redirect URIs are already
-  # `authorization` (0 `logout`) -- so the apply writes back what is there.
+  # So git carries the POSTURE ("" = hold every plan) and approval is a transient
+  # out-of-band step:
   #
-  # This id is bound to the revision. If another commit lands on main before
-  # this merges, the controller generates a new plan id and this value stops
-  # matching -- which holds the apply rather than misapplying it.
-  approvePlan: "plan-main-998e47794b"
+  #   P=$(kubectl get terraform -n tofu <name> -o jsonpath='{.status.plan.pending}')
+  #   # read the plan first -- extract the tfplan Secret and render it with a
+  #   # version-matched tofu; plan files are not portable across tofu versions:
+  #   kubectl get secret -n tofu tfplan-default-<name> -o jsonpath='{.data.tfplan}' \
+  #     | base64 -d | gunzip -c > tfplan && tofu show tfplan
+  #   kubectl patch terraform -n tofu <name> --type=merge \
+  #     -p "{\"spec\":{\"approvePlan\":\"$P\"}}"
+  #
+  # The controller applies within seconds; Flux then restores "" from this file,
+  # which re-arms the hold. That revert is the point, not a race to worry about.
+  # The 2026.5.1 plan was applied 2026-08-20: 0 add, 8 change, 0 destroy -- the
+  # redirect_uri_type key dropped from 12 allowed_redirect_uris, every url and
+  # matching_mode unchanged. Verified live afterwards: 14 redirect URIs, all still
+  # `authorization`, no provider left with zero URIs.
+  #
+  # It went in via the out-of-band step described above, NOT via this field. #1145
+  # tried to approve through git and could not: the merge commit changed the source
+  # sha, the controller re-planned under a new id, and the apply was held.
+  #
+  # Back to "" so this file states the posture and nothing more. The stale id #1145
+  # left here did keep holding plans, but it read as an approval that had taken
+  # effect when it had not.
+  approvePlan: ""
   path: ./terraform/authentik
   sourceRef:
     kind: GitRepository

--- a/clusters/vollminlab-cluster/tofu/b2-config/app/terraform-cr.yaml
+++ b/clusters/vollminlab-cluster/tofu/b2-config/app/terraform-cr.yaml
@@ -10,7 +10,44 @@ metadata:
     category: core
 spec:
   interval: 10m
-  approvePlan: auto
+  # Manual plan approval, set 2026-08-20 ahead of the provider bump in #1137
+  # (Backblaze/b2 ~> 0.8 -> ~> 0.13). The provider is pre-1.0, so a minor bump is
+  # a breaking-change slot by semver convention, not a patch.
+  #
+  # `approvePlan` names a plan to approve; "auto" approves every plan, so with it
+  # set the controller applies within the 10m interval and there is never anything
+  # to review. This module owns the B2 buckets and application keys that every
+  # offsite backup writes to -- velero's b2 BSL and the victoria-metrics cold tier.
+  # A provider that renames or recreates a key or bucket takes out the offsite copy,
+  # and that is the copy that exists for the case where the cluster is gone.
+  # CI cannot cover this: it runs `tofu validate` but never `tofu plan`, so a green
+  # PR says the config parses, not what it will do.
+  #
+  # Empty string means no plan is approved, so the controller plans and waits.
+  #
+  # HOW APPROVAL ACTUALLY WORKS -- do not put a plan id in this file.
+  #
+  # The pending plan is named plan-<branch>-<source sha>, so it is regenerated on
+  # EVERY commit to this repo, not just commits touching this module. An approval
+  # delivered through git therefore names a plan that the merge commit itself has
+  # already invalidated -- it can never match. #1145 proved this: it merged
+  # approvePlan: "plan-main-998e47794b", the merge moved main to 60b4f111, the
+  # controller re-planned as plan-main-60b4f1118b, and the apply was held.
+  #
+  # So git carries the POSTURE ("" = hold every plan) and approval is a transient
+  # out-of-band step:
+  #
+  #   P=$(kubectl get terraform -n tofu <name> -o jsonpath='{.status.plan.pending}')
+  #   # read the plan first -- extract the tfplan Secret and render it with a
+  #   # version-matched tofu; plan files are not portable across tofu versions:
+  #   kubectl get secret -n tofu tfplan-default-<name> -o jsonpath='{.data.tfplan}' \
+  #     | base64 -d | gunzip -c > tfplan && tofu show tfplan
+  #   kubectl patch terraform -n tofu <name> --type=merge \
+  #     -p "{\"spec\":{\"approvePlan\":\"$P\"}}"
+  #
+  # The controller applies within seconds; Flux then restores "" from this file,
+  # which re-arms the hold. That revert is the point, not a race to worry about.
+  approvePlan: ""
   path: ./terraform/b2
   sourceRef:
     kind: GitRepository

--- a/clusters/vollminlab-cluster/tofu/grafana-config/app/terraform-cr.yaml
+++ b/clusters/vollminlab-cluster/tofu/grafana-config/app/terraform-cr.yaml
@@ -10,7 +10,44 @@ metadata:
     category: core
 spec:
   interval: 10m
-  approvePlan: auto
+  # Manual plan approval, set 2026-08-20 ahead of the provider bump in #1138
+  # (grafana/grafana 3.25.9 -> 4.45.1) -- a MAJOR version, the only one in this
+  # batch, so breaking changes are announced rather than merely possible.
+  #
+  # `approvePlan` names a plan to approve; "auto" approves every plan, so with it
+  # set the controller applies within the 10m interval and there is never anything
+  # to review. This module manages the Grafana org, folders, dashboards and
+  # datasources. grafana.db is the one artifact in `monitoring` that is not
+  # reproducible from git -- it is why velero-grafana-b2 exists as its own schedule
+  # -- so a plan that recreates rather than updates is a real data-loss path.
+  # CI cannot cover this: it runs `tofu validate` but never `tofu plan`, so a green
+  # PR says the config parses, not what it will do.
+  #
+  # Empty string means no plan is approved, so the controller plans and waits.
+  #
+  # HOW APPROVAL ACTUALLY WORKS -- do not put a plan id in this file.
+  #
+  # The pending plan is named plan-<branch>-<source sha>, so it is regenerated on
+  # EVERY commit to this repo, not just commits touching this module. An approval
+  # delivered through git therefore names a plan that the merge commit itself has
+  # already invalidated -- it can never match. #1145 proved this: it merged
+  # approvePlan: "plan-main-998e47794b", the merge moved main to 60b4f111, the
+  # controller re-planned as plan-main-60b4f1118b, and the apply was held.
+  #
+  # So git carries the POSTURE ("" = hold every plan) and approval is a transient
+  # out-of-band step:
+  #
+  #   P=$(kubectl get terraform -n tofu <name> -o jsonpath='{.status.plan.pending}')
+  #   # read the plan first -- extract the tfplan Secret and render it with a
+  #   # version-matched tofu; plan files are not portable across tofu versions:
+  #   kubectl get secret -n tofu tfplan-default-<name> -o jsonpath='{.data.tfplan}' \
+  #     | base64 -d | gunzip -c > tfplan && tofu show tfplan
+  #   kubectl patch terraform -n tofu <name> --type=merge \
+  #     -p "{\"spec\":{\"approvePlan\":\"$P\"}}"
+  #
+  # The controller applies within seconds; Flux then restores "" from this file,
+  # which re-arms the hold. That revert is the point, not a race to worry about.
+  approvePlan: ""
   path: ./terraform/grafana
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
chore(tofu): manual plan approval for b2 and grafana, and fix the approval procedure

Prep for #1137 (Backblaze/b2 ~> 0.8 -> ~> 0.13) and #1138 (grafana/grafana
3.25.9 -> 4.45.1, a major). Both run approvePlan: auto on a 10m interval, so
merging either bump applies it to production with no plan, no review and no CI
signal -- CI runs `tofu validate`, never `tofu plan`. The #1143 guard blocks both
for that reason; this is the unblock.

Also corrects the procedure #1142 documented and #1145 tried to follow, which
does not work. The pending plan is named plan-<branch>-<source sha> and is
regenerated on EVERY commit to this repo, not only commits touching the module.
An approval delivered through git therefore names a plan its own merge commit has
already invalidated. #1145 merged approvePlan: "plan-main-998e47794b", the merge
moved main to 60b4f111, the controller re-planned as plan-main-60b4f1118b, and
the apply was held -- correctly, but it meant the bump never applied.

So git carries the posture ("" = hold every plan) and approval is a transient
`kubectl patch` of the pending id, after reading the plan. The controller applies
within seconds and Flux then restores "" from the file, re-arming the hold. Each
of the three CRs now carries that procedure, including how to render the plan
(extract the tfplan Secret, use a version-matched tofu -- plan files are not
portable across versions, which is not obvious until it fails).

authentik goes back to "" as part of this. Its 2026.5.1 plan was applied
2026-08-20 by the out-of-band step: 0 add, 8 change, 0 destroy, verified live
afterwards as 14 redirect URIs all still `authorization` with no provider left
empty. The stale id #1145 left behind kept holding plans, but read as an approval
that had taken effect when it had not.

Neither new module is incidental. b2 owns the buckets and application keys every
offsite backup writes to -- velero's b2 BSL and the victoria-metrics cold tier --
the copy that exists for the case where the cluster is gone. grafana owns the org,
folders, dashboards and datasources, and grafana.db is the one artifact in
`monitoring` not reproducible from git.

---

**Full detail:** the pending plan is named `plan-<branch>-<source sha>`, regenerated on every commit to this repo. #1145 merged `approvePlan: "plan-main-998e47794b"`, the merge moved main to `60b4f111`, the controller re-planned as `plan-main-60b4f1118b`, and the apply was held — failed closed, but failed.

Approval is now an out-of-band step after reading the plan:

```bash
P=$(kubectl get terraform -n tofu <name> -o jsonpath='{.status.plan.pending}')
kubectl get secret -n tofu tfplan-default-<name> -o jsonpath='{.data.tfplan}' \
  | base64 -d | gunzip -c > tfplan && tofu show tfplan
kubectl patch terraform -n tofu <name> --type=merge \
  -p "{\"spec\":{\"approvePlan\":\"$P\"}}"
```

Flux then restores `""`, re-arming the hold. Plan files aren't portable across tofu versions — the runner writes 1.12.1.

authentik's 2026.5.1 plan **was applied** 2026-08-20 this way: 0 add, 8 change, 0 destroy; verified live as 14 redirect URIs all still `authorization`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReBNuj9oheJm4PihWXh23N