### PR TITLE
chore(renovate): manage the dependencies of build/b2-exporter

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,7 +14,22 @@
   // approvePlan: auto on a 10m interval, a new provider release auto-applied itself to
   // production within minutes of publication. Lockfiles (committed in the same change)
   // stop the silent upgrade; this makes the upgrade visible and reviewable.
-  "enabledManagers": ["flux", "github-actions", "custom.regex", "terraform"],
+  // "dockerfile" and "pip_requirements" added 2026-08-20. build/b2-exporter is the source
+  // for the b2-exporter:1.0.2 image running in `monitoring`, and no manager had ever read it:
+  // its only commit is the one that created it in May, so b2sdk, prometheus_client and the
+  // python:3.12-slim base have never been updated. The flux and custom.regex managers only
+  // look under clusters/, so the gap was invisible rather than accepted.
+  //
+  // Scoped by managerFilePatterns to build/ below. The container images this repo actually
+  // deploys are pinned in HelmReleases and values ConfigMaps, already covered by flux and
+  // custom.regex -- letting the dockerfile manager loose repo-wide would duplicate them.
+  "enabledManagers": ["flux", "github-actions", "custom.regex", "terraform", "dockerfile", "pip_requirements"],
+  "dockerfile": {
+    "managerFilePatterns": ["/^build/.+/Dockerfile$/"]
+  },
+  "pip_requirements": {
+    "managerFilePatterns": ["/^build/.+/requirements\.txt$/"]
+  },
   "ignorePaths": [
     "clusters/vollminlab-cluster/flux-system/gotk-components.yaml"
   ],


### PR DESCRIPTION
`build/b2-exporter` is the source for the `b2-exporter:1.0.2` image running in `monitoring`, and **no Renovate manager had ever read it**.

The `flux` and `custom.regex` managers only look under `clusters/`, and `dockerfile` / `pip_requirements` weren't in `enabledManagers`. So these have never been offered an update:

```
b2sdk==2.12.0
prometheus_client==0.25.0
FROM python:3.12-slim
```

The proof is the git history — its only commit is the one that created it in May. Not a single dependency PR in three months.

## Scope

Bound to `build/` via `managerFilePatterns`. The container images this repo *deploys* are pinned in HelmReleases and values ConfigMaps and are already covered by `flux` + `custom.regex`; letting the `dockerfile` manager loose repo-wide would duplicate them.

Validated with renovate's own validator:

```
 INFO: Config validated successfully against 1 file(s)
```

## What this does *not* close

This covers the one in-house image built from this repo. The other four are outside Renovate's reach entirely — `autodiscover: false` with a `repositories` list naming only `vollminlab/k8s-vollminlab-cluster`, and **none of the four carries a renovate or dependabot config of its own**:

| repo | dep config | manifests |
|---|---|---|
| masters-league | NONE | Dockerfile |
| vollmint | NONE | Dockerfile, go.mod |
| shlink-ingress-controller | NONE | Dockerfile, go.mod |
| longhorn-rebalancing-controller | NONE | Dockerfile, go.mod |

All four ship images that run in this cluster. Tracked separately — that's a 4-repo change and a tooling decision, not a one-line config edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReBNuj9oheJm4PihWXh23N