### PR TITLE
chore(renovate): manage the four in-house repos that build cluster images

### DIFF
--- a/clusters/vollminlab-cluster/renovate/renovate/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/renovate/renovate/app/configmap.yaml
@@ -53,7 +53,13 @@ data:
       config: |
         {
           "platform": "github",
-          "repositories": ["vollminlab/k8s-vollminlab-cluster"],
+          "repositories": [
+            "vollminlab/k8s-vollminlab-cluster",
+            "vollminlab/masters-league",
+            "vollminlab/vollmint",
+            "vollminlab/shlink-ingress-controller",
+            "vollminlab/longhorn-rebalancing-controller"
+          ],
           "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
           "onboarding": false,
           "requireConfig": "optional",


### PR DESCRIPTION
Renovate has only ever looked at this repo — `autodiscover: false` with a `repositories` list of one. The other four repos whose images run in this cluster carried no renovate or dependabot config either, so **every Go module, npm package, Python requirement, base image and pinned Action in all four has gone unmanaged for the life of those repos**.

| repo | dep config before | manifests |
|---|---|---|
| masters-league | NONE | Dockerfile, backend/requirements.txt, frontend/package.json, workflows |
| vollmint | NONE | Dockerfile, go.mod, web/package.json, workflows |
| shlink-ingress-controller | NONE | Dockerfile, go.mod, workflows |
| longhorn-rebalancing-controller | NONE | Dockerfile, go.mod, workflows |

## ⚠️ Merge order matters

Each repo's own `renovate.json5` lands **first**:

- vollminlab/longhorn-rebalancing-controller#12
- vollminlab/shlink-ingress-controller#19
- vollminlab/vollmint#15
- vollminlab/masters-league#8

With `onboarding: false` + `requireConfig: optional`, a repo added here *before* it has a config is still processed — just with bare defaults: no labels, no schedule, no npm grouping. Configs first means the first run is already conventional.

## Expect a burst

These repos have never had a dependency PR. The first pass after this merges will open a batch. The per-repo configs group non-major npm updates and `prConcurrentLimit: 10` bounds it.

**Worth verifying after merge** that the `renovate-token` actually has access to all four repos — if it's fine-grained and scoped to this repo only, the added entries will fail rather than silently do nothing. Check the renovate CronJob logs for each repo name on the next run.

Together with #1147 (which covers `build/b2-exporter` here), this closes the gap for all five in-house images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReBNuj9oheJm4PihWXh23N