### PR TITLE
fix(ci): install helm for the HelmRelease values check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -266,6 +266,16 @@ jobs:
             echo "No HelmRelease or values ConfigMap changed — nothing to validate"
             exit 0
           fi
+
+          # check-helm-values.py shells out to `helm pull` and `helm lint`, and this job
+          # never installed helm -- it only has kubectl and yq. Installed here rather than
+          # as its own step so it costs nothing on the PRs that reach the early exit above.
+          if ! command -v helm >/dev/null 2>&1; then
+            echo "📦 Installing Helm..."
+            curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          fi
+          helm version --short
+
           echo "$CHANGED_HR" | xargs ./scripts/check-helm-values.py
 
       - name: Validate YAML syntax


### PR DESCRIPTION
The check crashed the first time it ever ran on a real PR (#1148):

```
FileNotFoundError: [Errno 2] No such file or directory: 'helm'
##[error]Process completed with exit code 123
```

`check-helm-values.py` shells out to `helm pull` and `helm lint`, and `validate-changes` installs only **kubectl** and **yq** — it has never had helm.

This is the third defect in the same check, each only visible once the previous one was fixed:

1. **#1140** added the step — but placed it above the step that sets `LINT_FILES`, so it was skipped on every PR
2. **#1144** fixed the ordering and the pyyaml bootstrap, so it could finally execute
3. **this** — first actual execution, and helm isn't installed

Locally it passes because devsbx01 has helm on PATH, which is exactly why none of this surfaced until CI ran it for real.

## The fix

Installed **inside** the step rather than as its own step, and **after** the early exit for "no HelmRelease or values ConfigMap changed" — so it costs nothing on PRs that don't need it. Guarded with `command -v` so a runner that already has helm skips the download.

## Proof

Not from this PR — it touches only `ci.yaml`, so it takes the early exit itself. **#1148 changes a `configmap.yaml`** and reaches the helm call, so updating its branch after this merges is what actually demonstrates the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReBNuj9oheJm4PihWXh23N