### PR TITLE
fix(tofu): stop the authentik oauth2 providers re-planning forever

### DIFF
--- a/terraform/authentik/providers_oauth2.tf
+++ b/terraform/authentik/providers_oauth2.tf
@@ -18,8 +18,9 @@ resource "authentik_provider_oauth2" "grafana" {
 
   allowed_redirect_uris = [
     {
-      matching_mode = "strict"
-      url           = "https://grafana.vollminlab.com/login/generic_oauth"
+      matching_mode     = "strict"
+      redirect_uri_type = "authorization"
+      url               = "https://grafana.vollminlab.com/login/generic_oauth"
     }
   ]
 
@@ -48,8 +49,9 @@ resource "authentik_provider_oauth2" "headlamp" {
 
   allowed_redirect_uris = [
     {
-      matching_mode = "strict"
-      url           = "https://headlamp.vollminlab.com/oidc-callback"
+      matching_mode     = "strict"
+      redirect_uri_type = "authorization"
+      url               = "https://headlamp.vollminlab.com/oidc-callback"
     }
   ]
 
@@ -71,8 +73,9 @@ resource "authentik_provider_oauth2" "minio" {
 
   allowed_redirect_uris = [
     {
-      matching_mode = "strict"
-      url           = "https://minio.vollminlab.com/oauth_callback"
+      matching_mode     = "strict"
+      redirect_uri_type = "authorization"
+      url               = "https://minio.vollminlab.com/oauth_callback"
     }
   ]
 
@@ -93,8 +96,9 @@ resource "authentik_provider_oauth2" "jellyfin" {
 
   allowed_redirect_uris = [
     {
-      matching_mode = "strict"
-      url           = "https://jellyfin.vollminlab.com/sso/OID/redirect/authentik"
+      matching_mode     = "strict"
+      redirect_uri_type = "authorization"
+      url               = "https://jellyfin.vollminlab.com/sso/OID/redirect/authentik"
     }
   ]
 
@@ -115,8 +119,9 @@ resource "authentik_provider_oauth2" "harbor" {
 
   allowed_redirect_uris = [
     {
-      matching_mode = "strict"
-      url           = "https://harbor.vollminlab.com/c/oidc/callback"
+      matching_mode     = "strict"
+      redirect_uri_type = "authorization"
+      url               = "https://harbor.vollminlab.com/c/oidc/callback"
     }
   ]
 
@@ -137,8 +142,9 @@ resource "authentik_provider_oauth2" "portainer" {
 
   allowed_redirect_uris = [
     {
-      matching_mode = "strict"
-      url           = "https://portainer.vollminlab.com"
+      matching_mode     = "strict"
+      redirect_uri_type = "authorization"
+      url               = "https://portainer.vollminlab.com"
     }
   ]
 
@@ -158,12 +164,14 @@ resource "authentik_provider_oauth2" "seerr" {
 
   allowed_redirect_uris = [
     {
-      matching_mode = "strict"
-      url           = "https://seerr.vollminlab.com/login"
+      matching_mode     = "strict"
+      redirect_uri_type = "authorization"
+      url               = "https://seerr.vollminlab.com/login"
     },
     {
-      matching_mode = "strict"
-      url           = "https://seerr.vollminlab.com/profile/settings/linked-accounts"
+      matching_mode     = "strict"
+      redirect_uri_type = "authorization"
+      url               = "https://seerr.vollminlab.com/profile/settings/linked-accounts"
     },
   ]
 
@@ -182,20 +190,24 @@ resource "authentik_provider_oauth2" "audiobookshelf" {
 
   allowed_redirect_uris = [
     {
-      matching_mode = "strict"
-      url           = "https://audiobookshelf.vollminlab.com/auth/openid/callback"
+      matching_mode     = "strict"
+      redirect_uri_type = "authorization"
+      url               = "https://audiobookshelf.vollminlab.com/auth/openid/callback"
     },
     {
-      matching_mode = "strict"
-      url           = "https://audiobookshelf.vollminlab.com/auth/openid/mobile-redirect"
+      matching_mode     = "strict"
+      redirect_uri_type = "authorization"
+      url               = "https://audiobookshelf.vollminlab.com/auth/openid/mobile-redirect"
     },
     {
-      matching_mode = "strict"
-      url           = "https://audiobookshelf.vollminlab.com/audiobookshelf/auth/openid/callback"
+      matching_mode     = "strict"
+      redirect_uri_type = "authorization"
+      url               = "https://audiobookshelf.vollminlab.com/audiobookshelf/auth/openid/callback"
     },
     {
-      matching_mode = "strict"
-      url           = "https://audiobookshelf.vollminlab.com/audiobookshelf/auth/openid/mobile-redirect"
+      matching_mode     = "strict"
+      redirect_uri_type = "authorization"
+      url               = "https://audiobookshelf.vollminlab.com/audiobookshelf/auth/openid/mobile-redirect"
     },
   ]
 


### PR DESCRIPTION
**The 2026.5.1 apply did not stick.** The controller re-plans the identical diff every cycle:

```
Plan: 0 to add, 8 to change, 0 to destroy.
  ~ allowed_redirect_uris   (x8, always the same 8 providers)
```

This is a **perpetual diff**, not a pending change.

## Cause

Our config declared only `matching_mode` + `url`. Authentik's API returns a third field, `redirect_uri_type`, and the provider stores the API response in state:

- apply writes 2 keys →
- read-back puts 3 keys in state →
- next plan diffs 3 against 2 → repeat forever

Provider 2026.5.1 types the attribute as `list(map(string))` — free-form keys, literal comparison — so nothing suppresses it.

## Fix

The attribute being a plain map is also the fix: **the key is ours to declare.** Setting `redirect_uri_type = "authorization"` on all 12 entries makes config match what the API returns, so the plan converges.

```hcl
allowed_redirect_uris = [
  {
    matching_mode     = "strict"
    redirect_uri_type = "authorization"
    url               = "https://grafana.vollminlab.com/login/generic_oauth"
  }
]
```

**`"authorization"` is not a new value.** It's what all 14 live redirect URIs already carry (0 are `logout`), and it's the dataclass default Authentik applies when the field is omitted. Nothing about the OAuth2 flows changes.

## Why this matters beyond tidiness

Under `approvePlan: auto` this module rewrote 8 Authentik objects **every 10 minutes, forever** — the shape of the known authentik WAL bloat. Under manual approval it holds a plan that can never clear, so a real future change would be indistinguishable from the standing noise.

Verified: `tofu validate` → `Success! The configuration is valid.` against provider 2026.5.1, and `tofu fmt` clean.

After merge this needs one approval via the out-of-band step (see the CR comment) to apply — and the plan **after** that one should finally come back `No drift`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReBNuj9oheJm4PihWXh23N