### PR TITLE
fix(velero): stop backing up the harbor-trivy vulnerability cache

### DIFF
--- a/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor/app/configmap.yaml
@@ -143,6 +143,21 @@ data:
     # rather than the real requirement. Limit now matches the chart default (1Gi).
     # container_oom_events_total read 0 throughout — the kubelet lastState is the truth.
     trivy:
+      # Skip the trivy cache in Velero file-system backups. The `data` volume is
+      # 2.6 GiB of /home/scanner/.cache, of which trivy.db is a 1.3 GB vulnerability
+      # database downloaded from upstream and rewritten whole on each refresh. It is
+      # fully reproducible -- a restored pod re-downloads it -- and because the file is
+      # replaced rather than appended it dedupes to nearly nothing in kopia, so each
+      # nightly full lands ~2.6 GiB of new blocks in a repo with 96h retention.
+      #
+      # Same reasoning .claude/rules/velero.md applies to loki: do not back up a
+      # rebuildable cache. This is NOT the emptyDir whack-a-mole that rule warns
+      # against -- `data` is a real PVC, and velero-skip-smb-policy cannot target one
+      # by name (resource policies match capacity, storageClass, csi driver, nfs and
+      # volumeType, not PVC identity), so the pod annotation is the only mechanism.
+      # The PVC object is still backed up; only its contents are skipped.
+      podAnnotations:
+        backup.velero.io/backup-volumes-excludes: data
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
## Why now

MinIO's PVC is **82% full and the fill rate tripled in the last three days**:

| window | rate |
|---|---|
| 14d → 7d ago | 0.56 GiB/day |
| 7d → 3d ago | 0.29 GiB/day |
| last 3 days | **~1.9 GiB/day** |

At that rate the 18 GiB free is **~9 days**. MinIO holds velero's 96h tier, every Loki chunk and all CNPG base backups, so filling it takes out three backup systems at once.

## The largest avoidable contributor

`harbor-trivy`'s `data` volume is 2.6 GiB of `/home/scanner/.cache`, and 1.3 GB of that is `trivy.db`:

```
-rw-r--r-- 1 scanner scanner 1312845824 2026-08-20 07:08 trivy.db
```

Two properties make it the worst possible FSB candidate:

- **fully reproducible** — a restored pod re-downloads it from upstream
- **replaced, not appended** — so it dedupes to nearly nothing in kopia, and every nightly full writes ~2.6 GiB of *fresh* blocks into a repo with 96h retention

Measured from the 2026-08-20 `daily-full`: 25 PodVolumeBackups totalling 24.5 GiB, of which this is **2.64 GiB — 11% of every nightly run**, for data that is a download away.

## Why an annotation and not the resource policy

This is the reasoning `.claude/rules/velero.md` already applies to loki — don't back up a rebuildable cache.

It's deliberately **not** the emptyDir whack-a-mole that same rule warns against. `data` is a real PVC, and `velero-skip-smb-policy` can't target one by name: resource policies match on capacity, storageClass, csi driver, nfs and volumeType, not PVC identity. The pod annotation is the only mechanism available here.

The PVC object itself is still backed up — only its contents are skipped, so a restore recreates the volume and trivy repopulates it.

Verified `trivy.podAnnotations` is supported by goharbor chart 1.19.2, and `check-helm-values` passes against the real resolved values.

Does not by itself solve the capacity trend — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReBNuj9oheJm4PihWXh23N