### PR TITLE
fix(kyverno): correct the Longhorn CSI resource values before arming the mutate

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/inject-resource-requirements.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/inject-resource-requirements.yaml
@@ -35,6 +35,27 @@ spec:
                       - csi-resizer
                       - csi-snapshotter
                       - longhorn-manager
+      # Memory values measured over 30d (2026-08-21), working-set p95 / max:
+      #   csi-attacher      55.0Mi / 55.1Mi   -> request  64Mi, limit 128Mi
+      #   csi-provisioner   52.7Mi / 53.9Mi   -> request  64Mi, limit 128Mi
+      #   csi-resizer       67.9Mi / 68.6Mi   -> request  80Mi, limit 160Mi
+      #   csi-snapshotter   61.7Mi / 63.6Mi   -> request  80Mi, limit 160Mi
+      #   longhorn-ui        4.8Mi /  6.0Mi   -> request  16Mi, limit  32Mi
+      #   longhorn-manager 564.1Mi / 607.1Mi  -> request 384Mi (SEE BELOW), limit 1Gi
+      #
+      # resizer and snapshotter were previously requesting 64Mi, below their own p95 --
+      # a request under real usage under-declares the workload to the scheduler, which
+      # is what put the CNPG pods in BestEffort until #1120. Limits are ~2.3x measured
+      # max in every case.
+      #
+      # longhorn-manager's 384Mi request is ALSO below its 564Mi p95, but it is a
+      # DaemonSet on 9 nodes, so correcting it reserves ~5.8Gi cluster-wide and
+      # k8sworker02 has only 2.2Gi of request headroom. Deliberately left for a
+      # separate capacity decision -- it is exempted from require-resources by
+      # ignore-longhorn-dynamic-pods, so it is not a blocking risk. Tracked in #1155.
+      #
+      # CPU is unchanged: measured p95 is under 1.5m and max under 3m for all four
+      # sidecars, so the 20m request and 100m limit are far from binding.
       mutate:
         foreach:
           - list: "request.object.spec.template.spec.containers || `[]`"
@@ -90,10 +111,10 @@ spec:
                         resources:
                           requests:
                             cpu: "20m"
-                            memory: "64Mi"
+                            memory: "80Mi"
                           limits:
                             cpu: "100m"
-                            memory: "128Mi"
+                            memory: "160Mi"
           - list: "request.object.spec.template.spec.containers || `[]`"
             preconditions:
               all:
@@ -109,10 +130,10 @@ spec:
                         resources:
                           requests:
                             cpu: "20m"
-                            memory: "64Mi"
+                            memory: "80Mi"
                           limits:
                             cpu: "100m"
-                            memory: "128Mi"
+                            memory: "160Mi"
           - list: "request.object.spec.template.spec.containers || `[]`"
             preconditions:
               all:


### PR DESCRIPTION
Groundwork for #1155.

## The situation

The four Longhorn CSI Deployments fail `require-resources`, which is **Enforce**, and `longhorn-system` isn't in its exclusion. They survive only because a mutate runs at admission and these haven't been through admission since 2026-06-03. longhorn-manager creates them programmatically — no `ownerReferences`, not Helm-managed — so there's no GitOps spec to fix them in.

`inject-resource-requirements` exists for exactly this and its selector lists all four. But **nothing it targets has ever been mutated**:

```
DaemonSet/longhorn-manager   longhorn-manager   NONE
Deployment/longhorn-ui       longhorn-ui        NONE
Deployment/csi-*             csi-*              NONE
```

The whole namespace is BestEffort.

## Checking the numbers first

`.claude/rules/kyverno.md` warns that a dormant mutate's values have never been exercised — fixing one there would have OOMKilled longhorn-manager. So I measured before arming anything. 30d working set, p95 / max:

| container | p95 | max | request | verdict |
|---|---|---|---|---|
| csi-attacher | 55.0Mi | 55.1Mi | 64Mi | ok |
| csi-provisioner | 52.7Mi | 53.9Mi | 64Mi | ok |
| csi-resizer | 67.9Mi | 68.6Mi | 64Mi | **below p95** |
| csi-snapshotter | 61.7Mi | 63.6Mi | 64Mi | **below p95** |
| longhorn-ui | 4.8Mi | 6.0Mi | 16Mi | ok |
| longhorn-manager | 564.1Mi | 607.1Mi | 384Mi | **below p95** |

resizer and snapshotter go to **80Mi request / 160Mi limit**. A request below real usage under-declares the workload to the scheduler — the same defect #1120 fixed for the CNPG pods. Limits land at ~2.3x measured max throughout.

CPU is untouched: p95 under 1.5m and max under 3m for all four, so the 20m request and 100m limit are nowhere near binding.

## What's deliberately not in scope

**longhorn-manager's request is also short**, but it's a DaemonSet on 9 nodes — correcting it reserves ~5.8Gi cluster-wide, and k8sworker02 has 2.2Gi of request headroom. That's a capacity decision, not a policy fix. It's exempted from `require-resources` by `ignore-longhorn-dynamic-pods`, so unlike the CSI Deployments it is **not** a blocking risk. Tracked in #1155.

## This applies nothing on its own

The Deployments must be rolled for the mutate to fire at admission. That's the follow-up step, and it's also what settles the open question in #1155 — whether a recreate is admitted or rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReBNuj9oheJm4PihWXh23N