### PR TITLE
fix(cloudflare): disable Bot Fight Mode, which the WAF skip rule cannot reach

### DIFF
--- a/terraform/cloudflare/bot-management.tf
+++ b/terraform/cloudflare/bot-management.tf
@@ -1,0 +1,53 @@
+# ---------------------------------------------------------------------------
+# Cloudflare Bot Management — zone-wide bot posture
+#
+# Bot Fight Mode is disabled deliberately. Do not turn it back on.
+#
+# It cannot be scoped or bypassed. Bot Fight Mode issues its managed challenge
+# from its own phase — no WAF custom-rule `skip`, IP Access Rule, or hostname
+# exemption reaches it, and Cloudflare exposes no `products` token for it. The
+# skip rule in security.tf runs in http_request_firewall_custom and never sees
+# it, so authentik was challenged for months despite that rule firing correctly.
+#
+# Measured 2026-08-21 — same URL, two paths:
+#
+#   /api/v3/flows/executor/default-authentication-flow/
+#     via Cloudflare : 403  text/html         (cf-mitigated: challenge)
+#     via LAN        : 200  application/json
+#
+# firewallEventsAdaptive attributed it to `source: botFight`, action
+# `managed_challenge`.
+#
+# A browser solves a managed challenge; a native app cannot. Swiftfin, the
+# Jellyfin mobile clients and every other non-browser client took a hard 403 the
+# moment they left the LAN. LAN clients masked it completely, because Pi-hole
+# points them at the ingress VIP instead of through the tunnel — the same
+# masking that hid the tunnel-origin 502 for 68 days (#1058).
+#
+# What still guards this zone:
+#   - Every exposed service authenticates for itself (Authentik forward-auth,
+#     native OIDC, or the app's own login).
+#   - The Cloudflare Managed Free Ruleset stays on, and is landing blocks.
+#   - ai_bots_protection stays on "block".
+#
+# NOTE: the Cloudflare Terraform API token needs the **Bot Management Write**
+# permission group (zone scope) for this resource. Without it every plan and
+# apply fails with `10000 Authentication error`, because the token cannot even
+# read the current bot config.
+#
+# Free plan — the sbfm_* attributes are Pro and above, and must stay unset.
+# Attributes not listed here (content_bots_protection, crawler_protection,
+# is_robots_txt_managed, cf_robots_variant) are already at their defaults and
+# are deliberately left unmanaged.
+# ---------------------------------------------------------------------------
+
+resource "cloudflare_bot_management" "vollminlab" {
+  zone_id = var.cloudflare_zone_id
+
+  fight_mode = false
+
+  # Pinned to the values measured live on 2026-08-21 so this resource cannot
+  # silently reset them.
+  enable_js          = true
+  ai_bots_protection = "block"
+}

--- a/terraform/cloudflare/security.tf
+++ b/terraform/cloudflare/security.tf
@@ -1,12 +1,19 @@
 # ---------------------------------------------------------------------------
 # Cloudflare WAF Custom Rules — Security overrides
 #
-# Authentik handles all authentication itself, so Cloudflare's bot challenges
-# must be bypassed for authentik.vollminlab.com. Without this, a fresh browser
-# session (incognito, first visit) gets a managed challenge on the
-# /api/v3/flows/executor/ fetch, which returns HTML instead of JSON and
-# breaks the login flow with "Request failed and the interceptors did not
-# return an alternative response".
+# Authentik handles all authentication itself, so Cloudflare's managed WAF,
+# security level, browser integrity check and rate limiting are skipped for
+# authentik.vollminlab.com. Those products do honour this rule — firewall
+# events show it matching as `action: skip, source: firewallCustom`.
+#
+# This rule does NOT stop Bot Fight Mode, which was its original stated purpose
+# (#648). Bot Fight Mode runs in its own phase, outside
+# http_request_firewall_custom, and has no `products` token, so it is
+# unreachable from here. The managed challenge on the /api/v3/flows/executor/
+# fetch — HTML instead of JSON, surfacing in the browser as "Request failed and
+# the interceptors did not return an alternative response" — kept firing with
+# this rule active and enabled. It is fixed in bot-management.tf by turning Bot
+# Fight Mode off outright.
 # ---------------------------------------------------------------------------
 
 resource "cloudflare_ruleset" "authentik_skip_challenges" {


### PR DESCRIPTION
> [!WARNING]
> **Do not merge until the Cloudflare Terraform API token is granted `Bot Management Write` (zone scope).**
> `cloudflare-config` is `approvePlan: auto` on a 10m interval, so merging applies almost immediately — and the token currently cannot even *read* the bot config. Verified against the live token:
> ```
> GET  /zones/<id>/bot_management -> 10000 Authentication error
> PUT  /zones/<id>/bot_management -> 10000 Authentication error
> ```
> Add the permission group **Bot Management Write** (id `3b94c49258ec4573b06d51d99b6416c0`) to the token behind the `Cloudflare Terraform` 1Password item, then merge. Otherwise the apply fails and leaves the Terraform CR in error.

## What's wrong

Cloudflare **Bot Fight Mode is on zone-wide** (`fight_mode: true`) and has been challenging every non-browser client on `vollminlab.com`.

The `skip` rule in `security.tf` was added in #648 to stop exactly this, and **it never worked**. Bot Fight Mode runs in its own phase — outside `http_request_firewall_custom` — and Cloudflare exposes no `products` token for it, so a WAF custom-rule `skip` cannot reach it. The rule fires correctly for the products it *does* cover (`action: skip, source: firewallCustom` in the firewall log); it simply has no bearing on Bot Fight.

Measured 2026-08-21, same URL, two paths:

```
/api/v3/flows/executor/default-authentication-flow/
  via Cloudflare : 403  text/html         (cf-mitigated: challenge)
  via LAN        : 200  application/json
```

`firewallEventsAdaptive` attributes it to `source: botFight`, `action: managed_challenge`. That 403-HTML-instead-of-JSON is verbatim the failure `security.tf`'s own comment says the rule exists to prevent.

## Why it went unnoticed

A browser solves a managed challenge, so interactive logins survived. **Native apps cannot** — a `Swiftfin tvOS/…` user-agent takes a hard 403 through the edge. And LAN clients never see it at all, because Pi-hole points them at the ingress VIP instead of through the tunnel. Same masking that hid the tunnel-origin 502 for 68 days (#1058).

Not a recent regression: the Cloudflare account audit log shows no `bot_management` change in 60 days.

## The change

- New `terraform/cloudflare/bot-management.tf` — `cloudflare_bot_management` with `fight_mode = false`. `enable_js` and `ai_bots_protection` are pinned to their measured live values so the resource can't silently reset them. `sbfm_*` stay unset (Pro+ only; this zone is Free).
- `security.tf` header comment corrected — it claimed a fix the rule was never capable of delivering.

## Security posture after this

Bot Fight Mode is the only thing removed. Still in place:

- Every exposed service authenticates for itself (Authentik forward-auth, native OIDC, or the app's own login).
- The Cloudflare Managed Free Ruleset stays on, and is landing blocks (one `block firewallManaged` on jellyfin in the sampled window).
- `ai_bots_protection` stays `"block"`.

Worth a conscious call rather than a rubber stamp: on the Free plan this is all-or-nothing, so there is no way to keep Bot Fight for the rest of the zone while exempting the hosts that native clients use.

## Verification done

- `cloudflare_bot_management` and all four attributes confirmed present in the **exact locked provider version, 5.23.0** (not just `~> 5.8`) via `tofu providers schema`.
- `tofu fmt` clean, `tofu validate` passes.
- `tofu plan` could **not** be run — it needs read access the token doesn't yet have. That is the same blocker called out at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHLgifp8WoVtyEfwvMpdGb