### PR TITLE
feat(ci): build every image under build/ and run its tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1364,14 +1364,28 @@ jobs:
 
             docker build -t "ci-build-$name:${{ github.sha }}" "$dir"
 
-            # Unit tests run INSIDE a container built from the same base and the same
+            # Unit tests run INSIDE an image built from the same base and the same
             # requirements.txt, so a dependency bump that breaks the code fails here
             # rather than in production. Skipped cleanly when an image has no tests.
+            #
+            # Built as an image rather than `docker run -v $PWD/...`: the runner talks
+            # to a separate dockerd (dind), so a bind mount of the workspace resolves
+            # against THAT daemon's filesystem and silently yields an empty directory.
+            # A build context is uploaded over the API and therefore works.
             if compgen -G "$dir/*_test.py" > /dev/null; then
               base=$(grep -m1 '^FROM' "$df" | awk '{print $2}')
               echo "running $name tests against $base"
-              docker run --rm -v "$PWD/$dir:/src:ro" -w /src "$base" \
-                sh -c 'pip install --quiet --no-cache-dir -r requirements.txt pytest && pytest -q'
+              tf=$(mktemp)
+              {
+                echo "FROM $base"
+                echo "WORKDIR /src"
+                echo "COPY requirements.txt ."
+                echo "RUN pip install --quiet --no-cache-dir -r requirements.txt pytest"
+                echo "COPY . ."
+                echo "RUN pytest -q"
+              } > "$tf"
+              docker build --no-cache -f "$tf" -t "ci-test-$name:${{ github.sha }}" "$dir"
+              rm -f "$tf"
             else
               echo "no *_test.py in $dir — build-only"
             fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1312,7 +1312,7 @@ jobs:
   notify-success:
     name: Notify Success
     runs-on: ${{ vars.CI_RUNNER || 'vollminlab' }}
-    needs: [validate-changes, integration-test, security-scan, policy-validation, validate-terraform]
+    needs: [validate-changes, integration-test, security-scan, policy-validation, validate-terraform, build-images]
     if: success()
     steps:
       - name: Success notification
@@ -1324,7 +1324,7 @@ jobs:
   notify-failure:
     name: Notify Failure
     runs-on: ${{ vars.CI_RUNNER || 'vollminlab' }}
-    needs: [validate-changes, integration-test, security-scan, policy-validation, validate-terraform]
+    needs: [validate-changes, integration-test, security-scan, policy-validation, validate-terraform, build-images]
     if: failure()
     steps:
       - name: Failure notification
@@ -1332,3 +1332,56 @@ jobs:
           set -euo pipefail
           echo "❌ CI checks failed!"
           echo "🔧 Please review the failed steps above"
+
+  # Images this repo builds itself live under build/. Nothing validated them: the
+  # flux/kustomize jobs only look at clusters/, and build/b2-exporter's image is
+  # published by a b2-exporter/v* tag workflow, so a Dockerfile or requirements
+  # change was first exercised at release time rather than review time. #1147 has
+  # just pointed Renovate at those files, so bumps now arrive as PRs -- #1171
+  # (python 3.12 -> 3.14) and #1168 (prometheus_client) are open right now, and
+  # neither would have been built by anything before this job.
+  #
+  # Deliberately generic over build/*: a second image needs no CI change, which
+  # removes the "added an image, forgot to wire CI" failure mode entirely.
+  build-images:
+    name: Build In-House Images
+    runs-on: ${{ vars.CI_RUNNER || 'vollminlab' }}
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Build every image under build/ and run its tests
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          found=0
+          for df in build/*/Dockerfile; do
+            dir=$(dirname "$df")
+            name=$(basename "$dir")
+            found=$((found + 1))
+            echo "::group::$name"
+
+            docker build -t "ci-build-$name:${{ github.sha }}" "$dir"
+
+            # Unit tests run INSIDE a container built from the same base and the same
+            # requirements.txt, so a dependency bump that breaks the code fails here
+            # rather than in production. Skipped cleanly when an image has no tests.
+            if compgen -G "$dir/*_test.py" > /dev/null; then
+              base=$(grep -m1 '^FROM' "$df" | awk '{print $2}')
+              echo "running $name tests against $base"
+              docker run --rm -v "$PWD/$dir:/src:ro" -w /src "$base" \
+                sh -c 'pip install --quiet --no-cache-dir -r requirements.txt pytest && pytest -q'
+            else
+              echo "no *_test.py in $dir — build-only"
+            fi
+            echo "::endgroup::"
+          done
+
+          # A loop that matches nothing exits 0 and reads as success. Fail instead:
+          # if build/ ever moves or is renamed, this job must not quietly become inert.
+          if [ "$found" -eq 0 ]; then
+            echo "::error::no build/*/Dockerfile found — this job would pass without building anything"
+            exit 1
+          fi
+          echo "built $found image(s)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,12 @@ on:
       - 'clusters/**'
       - 'bootstrap/**'
       - 'terraform/**'
+      # Images this repo builds itself. Without this, a PR touching only build/**
+      # triggers NO workflow at all -- so every required check stays "expected",
+      # never reports, and the PR is permanently unmergeable. That is the live
+      # state of #1171 and #1168, and it is the same bug the .kubernetes-version
+      # note below records.
+      - 'build/**'
       - '.github/workflows/**'
       - '.vscode/**'
       - 'scripts/**'
@@ -25,6 +31,12 @@ on:
       - 'clusters/**'
       - 'bootstrap/**'
       - 'terraform/**'
+      # Images this repo builds itself. Without this, a PR touching only build/**
+      # triggers NO workflow at all -- so every required check stays "expected",
+      # never reports, and the PR is permanently unmergeable. That is the live
+      # state of #1171 and #1168, and it is the same bug the .kubernetes-version
+      # note below records.
+      - 'build/**'
       - '.github/workflows/**'
       - '.vscode/**'
       - 'scripts/**'


### PR DESCRIPTION
Nothing validated the images this repo builds itself. The flux and kustomize jobs only look at `clusters/`, and `build/b2-exporter`'s image is published by a `b2-exporter/v*` tag workflow — so a Dockerfile or `requirements.txt` change was first exercised **at release time rather than review time**.

## That gap just went live

#1147 pointed Renovate at those files, so bumps now arrive as PRs. **#1171** (`python` 3.12 → 3.14) and **#1168** (`prometheus_client` 0.25 → 0.26) are open right now, and before this job nothing would have built either one.

## What runs per image

- **`docker build`** — validates the Dockerfile and that `requirements.txt` is installable against the declared base
- **the unit tests, inside a container from that same base and those same requirements** — so a dependency bump that breaks the code fails in review

`build/b2-exporter/exporter_test.py` has existed since May and **has never run anywhere**. It's 3 tests and they pass.

## Generic over `build/`, on purpose

A second in-house image here is plausible, and this way it needs no CI change — which removes the "added an image, forgot to wire CI" failure mode rather than relying on remembering. An image with no `*_test.py` is built and skipped cleanly.

## The loop fails when it matches nothing

```bash
if [ "$found" -eq 0 ]; then
  echo "::error::no build/*/Dockerfile found — this job would pass without building anything"
  exit 1
fi
```

A `for` loop over a glob that stops matching exits 0 and reads as success — exactly how the helm-values check sat inert across two PRs. If `build/` is ever moved or renamed, this job says so.

Also added to both notify jobs' `needs`, or the notification would report on a run that hadn't waited for it.

Verified locally by executing the same loop: image builds, 3 tests pass against `python:3.12-slim`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReBNuj9oheJm4PihWXh23N