### PR TITLE
fix(1password): let Prometheus reach the Connect metrics endpoint

### DIFF
--- a/.claude/rules/networkpolicy.md
+++ b/.claude/rules/networkpolicy.md
@@ -77,6 +77,7 @@ Keep this table current whenever a new NetworkPolicy namespace is added.
 | `monitoring` | `grafana` | 3000 | Grafana HTTP (homepage widget) | allow-homepage-grafana ingress (from homepage) |
 | `monitoring` | `prometheus` | 9090 | Prometheus HTTP (homepage widget) | allow-homepage-prometheus ingress (from homepage) |
 | `monitoring` | `karma` | 8080 | karma Alertmanager dashboard UI (svc 80→8080) | allow-ingress-nginx ingress (from ingress-nginx) |
+| `1password` | `connect-api` | 8080 | 1Password Connect API + `/metrics`; svc targetPort is numeric 8080 and the container declares **no** ports, so 8080 is the container port | onepassword-connect ingress (from monitoring; also from external-secrets) |
 | `authentik` | `server` | 9000 | authentik-server HTTP (homepage widget) | allow-homepage ingress (from homepage) |
 | `authentik` | n/a (ingress target) | 8000 | CNPG instance status API | allow-cnpg-operator ingress |
 | `authentik` | n/a (egress target) | 7844 | Cloudflare tunnel edge (QUIC UDP + http2 TCP) | allow-external-egress egress |

--- a/clusters/vollminlab-cluster/1password/1password-connect/app/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/1password/1password-connect/app/networkpolicy.yaml
@@ -22,6 +22,26 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
+    # The chart ships serviceMonitor.enabled: true, so a ServiceMonitor has declared
+    # this pod a scrape target since 2026-05-31 -- but no ingress rule admitted
+    # `monitoring`, so Prometheus has never reached it. 82 days of a target that
+    # could not report, and nothing alerts on that: a target which never came up is
+    # easy to miss among healthy ones.
+    #
+    # 8080 is the CONTAINER port, not merely the service port. The Service uses a
+    # numeric targetPort 8080 on `connect-api` and the containers declare no ports
+    # at all, so the numeric targetPort is what the process listens on. /metrics is
+    # served on the API port, per the ServiceMonitor's own endpoint definition.
+    #
+    # 1Password Connect is the root of the entire secret chain -- ESO cannot
+    # materialise a single Secret without it -- so it is worth having metrics for.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - protocol: TCP
+          port: 8080
   egress:
     - ports:
         - protocol: TCP


### PR DESCRIPTION
The connect chart ships `serviceMonitor.enabled: true`, so a ServiceMonitor has declared this pod a scrape target since **2026-05-31**. No ingress rule ever admitted the `monitoring` namespace, so Prometheus has never reached it.

**82 days of a declared target that could not report.**

Nothing alerts on this shape. A target that never came up is indistinguishable from one that was never wanted, and it sits quietly among healthy ones — the same class as the Velero backup that reported `Completed` while matching zero volumes, and the CI check that reported green while never executing.

Worth having: **1Password Connect is the root of the entire secret chain** — ESO cannot materialise a single Secret without it.

## The port was verified, not assumed

```
svc/onepassword-connect
    connect-api: 8080 -> targetPort 8080      (numeric)
pod containers
    connect-api: []                            (declares NO ports)
```

`.claude/rules/networkpolicy.md` is explicit that the rule needs the **container** port. Here the Service uses a numeric `targetPort: 8080` and the containers declare no ports at all, so 8080 *is* what the process listens on. `/metrics` is on the API port, per the ServiceMonitor's own endpoint definition.

A row was added to that file's namespace port table, which it designates as the source of truth.

## Verification after merge

The honest test isn't "the rule exists" — it's whether the target actually comes up:

```bash
# should go from absent/down to up
count(up{namespace="1password"} == 1)
```

If it stays down after Flux reconciles, then `/metrics` isn't served where the ServiceMonitor claims, and the right fix is to delete the ServiceMonitor rather than keep a rule for nothing.

Closes half of #1165. The `minio/users.tf` `ignore_changes` comments are a separate concern and follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReBNuj9oheJm4PihWXh23N