### PR TITLE
fix(kyverno): size longhorn-manager to measured usage and cover its second container

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/inject-resource-requirements.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/inject-resource-requirements.yaml
@@ -41,7 +41,8 @@ spec:
       #   csi-resizer       67.9Mi / 68.6Mi   -> request  80Mi, limit 160Mi
       #   csi-snapshotter   61.7Mi / 63.6Mi   -> request  80Mi, limit 160Mi
       #   longhorn-ui        4.8Mi /  6.0Mi   -> request  16Mi, limit  32Mi
-      #   longhorn-manager 564.1Mi / 607.1Mi  -> request 384Mi (SEE BELOW), limit 1Gi
+      #   longhorn-manager 564.9Mi / 607.1Mi  -> request 640Mi, limit 1Gi
+      #   pre-pull-share-…   0.5Mi /   4.2Mi  -> request  16Mi, limit 32Mi
       #
       # resizer and snapshotter were previously requesting 64Mi, below their own p95 --
       # a request under real usage under-declares the workload to the scheduler, which
@@ -153,6 +154,31 @@ spec:
                           limits:
                             cpu: "20m"
                             memory: "32Mi"
+          # The longhorn-manager DaemonSet has a SECOND container that had no block
+          # here at all. require-resources demands every container declare requests
+          # and a memory limit, so without this the DaemonSet could not satisfy the
+          # policy even with the mutate firing -- it passes today only because
+          # ignore-longhorn-dynamic-pods exempts it. Measured 30d: p95 0.5Mi, max
+          # 4.2Mi; it pulls an image and idles.
+          - list: "request.object.spec.template.spec.containers || `[]`"
+            preconditions:
+              all:
+                - key: "{{element.name}}"
+                  operator: Equals
+                  value: pre-pull-share-manager-image
+            patchStrategicMerge:
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - (name): pre-pull-share-manager-image
+                        resources:
+                          requests:
+                            cpu: "10m"
+                            memory: "16Mi"
+                          limits:
+                            cpu: "50m"
+                            memory: "32Mi"
           - list: "request.object.spec.template.spec.containers || `[]`"
             preconditions:
               all:
@@ -168,7 +194,7 @@ spec:
                         resources:
                           requests:
                             cpu: "100m"
-                            memory: "384Mi"
+                            memory: "640Mi"
                           limits:
                             cpu: "1"
                             memory: "1Gi"


### PR DESCRIPTION
Two gaps from #1155's follow-up, both deferred at the time pending a capacity decision. Closes #1157.

## longhorn-manager's request was below its own p95

| | measured 30d | was | now |
|---|---|---|---|
| longhorn-manager | p95 **564.9Mi**, max 607.1Mi | request 384Mi | request **640Mi** |
| pre-pull-share-manager-image | p95 0.5Mi, max 4.2Mi | *no block at all* | request 16Mi / limit 32Mi |

The 1Gi limit is unchanged and remains ~1.7× measured max.

## The tradeoff, stated

This reserves **~5.8Gi across the 9-node DaemonSet**, taking k8sworker02 from 2.2Gi of request headroom to roughly 1.6Gi.

Accepted, because the alternative is worse: the whole `longhorn-system` namespace is currently BestEffort, which makes **longhorn-manager — the Longhorn control plane on every node — first in line for eviction** under node memory pressure. Tight headroom beats that.

## The second container was invisible

`pre-pull-share-manager-image` had no `foreach` block, so `require-resources` could never be satisfied for that DaemonSet even with the mutate firing. It passes today only because `ignore-longhorn-dynamic-pods` exempts it — an exception covering for a policy that couldn't succeed.

## This applies nothing on its own

Mutate policies act at admission, so the DaemonSet must be **rolled** for the values to land. That's the follow-up step, done one node at a time — the same method that worked for the CSI Deployments in #1155, where the rollout itself was the safe probe (a failed mutate means the update is rejected and nothing changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReBNuj9oheJm4PihWXh23N