### PR TITLE
fix(velero): stop double-backing-up the volumes VolSync already protects

### DIFF
--- a/clusters/vollminlab-cluster/mediastack/audiobookshelf/app/pvc-audiobookshelf-config.yaml
+++ b/clusters/vollminlab-cluster/mediastack/audiobookshelf/app/pvc-audiobookshelf-config.yaml
@@ -4,6 +4,11 @@ metadata:
   name: pvc-audiobookshelf-config
   namespace: mediastack
   labels:
+    # Protected by VolSync (offsite-first, restic to B2). Velero FSB skips it via
+    # the pvcLabels rule in velero-skip-smb-policy, so it is copied once a night
+    # rather than three or four times. Remove this label if VolSync stops
+    # covering the volume, or it becomes backed up by nothing.
+    backup.vollminlab.com/volsync: "true"
     app: audiobookshelf
     env: production
     category: media

--- a/clusters/vollminlab-cluster/mediastack/audiobookshelf/app/pvc-audiobookshelf-metadata.yaml
+++ b/clusters/vollminlab-cluster/mediastack/audiobookshelf/app/pvc-audiobookshelf-metadata.yaml
@@ -4,6 +4,11 @@ metadata:
   name: pvc-audiobookshelf-metadata
   namespace: mediastack
   labels:
+    # Protected by VolSync (offsite-first, restic to B2). Velero FSB skips it via
+    # the pvcLabels rule in velero-skip-smb-policy, so it is copied once a night
+    # rather than three or four times. Remove this label if VolSync stops
+    # covering the volume, or it becomes backed up by nothing.
+    backup.vollminlab.com/volsync: "true"
     app: audiobookshelf
     env: production
     category: media

--- a/clusters/vollminlab-cluster/mediastack/bazarr/app/pvc-bazarr-config.yaml
+++ b/clusters/vollminlab-cluster/mediastack/bazarr/app/pvc-bazarr-config.yaml
@@ -4,6 +4,11 @@ metadata:
   name: pvc-bazarr-config
   namespace: mediastack
   labels:
+    # Protected by VolSync (offsite-first, restic to B2). Velero FSB skips it via
+    # the pvcLabels rule in velero-skip-smb-policy, so it is copied once a night
+    # rather than three or four times. Remove this label if VolSync stops
+    # covering the volume, or it becomes backed up by nothing.
+    backup.vollminlab.com/volsync: "true"
     app: bazarr
     env: production
     category: media

--- a/clusters/vollminlab-cluster/mediastack/filebrowser/app/pvc-filebrowser-config.yaml
+++ b/clusters/vollminlab-cluster/mediastack/filebrowser/app/pvc-filebrowser-config.yaml
@@ -4,6 +4,11 @@ metadata:
   name: pvc-filebrowser-config
   namespace: mediastack
   labels:
+    # Protected by VolSync (offsite-first, restic to B2). Velero FSB skips it via
+    # the pvcLabels rule in velero-skip-smb-policy, so it is copied once a night
+    # rather than three or four times. Remove this label if VolSync stops
+    # covering the volume, or it becomes backed up by nothing.
+    backup.vollminlab.com/volsync: "true"
     app: filebrowser
     env: production
     category: apps

--- a/clusters/vollminlab-cluster/mediastack/jellyfin/app/pvc-jellyfin-config.yaml
+++ b/clusters/vollminlab-cluster/mediastack/jellyfin/app/pvc-jellyfin-config.yaml
@@ -4,6 +4,11 @@ metadata:
   name: pvc-jellyfin-config
   namespace: mediastack
   labels:
+    # Protected by VolSync (offsite-first, restic to B2). Velero FSB skips it via
+    # the pvcLabels rule in velero-skip-smb-policy, so it is copied once a night
+    # rather than three or four times. Remove this label if VolSync stops
+    # covering the volume, or it becomes backed up by nothing.
+    backup.vollminlab.com/volsync: "true"
     app: jellyfin
     env: production
     category: media

--- a/clusters/vollminlab-cluster/mediastack/prowlarr/app/pvc-prowlarr-config.yaml
+++ b/clusters/vollminlab-cluster/mediastack/prowlarr/app/pvc-prowlarr-config.yaml
@@ -4,6 +4,11 @@ metadata:
   name: pvc-prowlarr-config
   namespace: mediastack
   labels:
+    # Protected by VolSync (offsite-first, restic to B2). Velero FSB skips it via
+    # the pvcLabels rule in velero-skip-smb-policy, so it is copied once a night
+    # rather than three or four times. Remove this label if VolSync stops
+    # covering the volume, or it becomes backed up by nothing.
+    backup.vollminlab.com/volsync: "true"
     app: prowlarr
     env: production
     category: media

--- a/clusters/vollminlab-cluster/mediastack/qbittorrent/app/pvc-qbittorrent-config.yaml
+++ b/clusters/vollminlab-cluster/mediastack/qbittorrent/app/pvc-qbittorrent-config.yaml
@@ -4,6 +4,11 @@ metadata:
   name: pvc-qbittorrent-config
   namespace: mediastack
   labels:
+    # Protected by VolSync (offsite-first, restic to B2). Velero FSB skips it via
+    # the pvcLabels rule in velero-skip-smb-policy, so it is copied once a night
+    # rather than three or four times. Remove this label if VolSync stops
+    # covering the volume, or it becomes backed up by nothing.
+    backup.vollminlab.com/volsync: "true"
     app: qbittorrent
     env: production
     category: media

--- a/clusters/vollminlab-cluster/mediastack/radarr/app/pvc-radarr-config.yaml
+++ b/clusters/vollminlab-cluster/mediastack/radarr/app/pvc-radarr-config.yaml
@@ -4,6 +4,11 @@ metadata:
   name: pvc-radarr-config
   namespace: mediastack
   labels:
+    # Protected by VolSync (offsite-first, restic to B2). Velero FSB skips it via
+    # the pvcLabels rule in velero-skip-smb-policy, so it is copied once a night
+    # rather than three or four times. Remove this label if VolSync stops
+    # covering the volume, or it becomes backed up by nothing.
+    backup.vollminlab.com/volsync: "true"
     app: radarr
     env: production
     category: media

--- a/clusters/vollminlab-cluster/mediastack/readarr/app/pvc-readarr-config.yaml
+++ b/clusters/vollminlab-cluster/mediastack/readarr/app/pvc-readarr-config.yaml
@@ -4,6 +4,11 @@ metadata:
   name: pvc-readarr-config
   namespace: mediastack
   labels:
+    # Protected by VolSync (offsite-first, restic to B2). Velero FSB skips it via
+    # the pvcLabels rule in velero-skip-smb-policy, so it is copied once a night
+    # rather than three or four times. Remove this label if VolSync stops
+    # covering the volume, or it becomes backed up by nothing.
+    backup.vollminlab.com/volsync: "true"
     app: readarr
     env: production
     category: media

--- a/clusters/vollminlab-cluster/mediastack/sabnzbd/app/pvc-sabnzbd-config.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sabnzbd/app/pvc-sabnzbd-config.yaml
@@ -4,6 +4,11 @@ metadata:
   name: pvc-sabnzbd-config
   namespace: mediastack
   labels:
+    # Protected by VolSync (offsite-first, restic to B2). Velero FSB skips it via
+    # the pvcLabels rule in velero-skip-smb-policy, so it is copied once a night
+    # rather than three or four times. Remove this label if VolSync stops
+    # covering the volume, or it becomes backed up by nothing.
+    backup.vollminlab.com/volsync: "true"
     app: sabnzbd
     env: production
     category: media

--- a/clusters/vollminlab-cluster/mediastack/seerr/app/pvc-seerr-config.yaml
+++ b/clusters/vollminlab-cluster/mediastack/seerr/app/pvc-seerr-config.yaml
@@ -4,6 +4,11 @@ metadata:
   name: pvc-seerr-config
   namespace: mediastack
   labels:
+    # Protected by VolSync (offsite-first, restic to B2). Velero FSB skips it via
+    # the pvcLabels rule in velero-skip-smb-policy, so it is copied once a night
+    # rather than three or four times. Remove this label if VolSync stops
+    # covering the volume, or it becomes backed up by nothing.
+    backup.vollminlab.com/volsync: "true"
     app: seerr
     env: production
     category: media

--- a/clusters/vollminlab-cluster/mediastack/sonarr/app/pvc-sonarr-config.yaml
+++ b/clusters/vollminlab-cluster/mediastack/sonarr/app/pvc-sonarr-config.yaml
@@ -4,6 +4,11 @@ metadata:
   name: pvc-sonarr-config
   namespace: mediastack
   labels:
+    # Protected by VolSync (offsite-first, restic to B2). Velero FSB skips it via
+    # the pvcLabels rule in velero-skip-smb-policy, so it is copied once a night
+    # rather than three or four times. Remove this label if VolSync stops
+    # covering the volume, or it becomes backed up by nothing.
+    backup.vollminlab.com/volsync: "true"
     app: sonarr
     env: production
     category: media

--- a/clusters/vollminlab-cluster/velero/velero/app/resource-policy-configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/resource-policy-configmap.yaml
@@ -14,6 +14,26 @@ data:
   policy.yaml: |
     version: v1
     volumePolicies:
+      # Volumes already protected by VolSync, which is offsite-first (restic to B2)
+      # and has a shorter RPO than the nightly Velero pass. Without this they were
+      # copied 3-4x every night — once by VolSync, then again by Velero FSB into
+      # BOTH the MinIO 96h tier and the B2 2160h tier — while pvc-minecraft-datadir
+      # (the 20Gi world save) and harbor-db pgdata were copied by neither. The
+      # overlap was accidental, not a division of labour.
+      #
+      # pvcLabels was verified on this cluster before being relied on: velero
+      # v1.18.1, a probe backup of `portainer` produced 1 PodVolumeBackup without the
+      # label and 0 with it. An unsupported condition would have been silently
+      # ignored and the backup would still have reported Completed.
+      #
+      # The label lives on the PVC manifests in git, so wiring a new VolSync source
+      # is one edit next to the PVC rather than a pod annotation somewhere else.
+      - conditions:
+          pvcLabels:
+            backup.vollminlab.com/volsync: "true"
+        action:
+          type: skip
+
       # NAS shares — backed up by TrueNAS itself, not by Velero.
       - conditions:
           storageClass:


### PR DESCRIPTION
12 mediastack PVCs were copied **3–4 times every night** — once by VolSync, then again by Velero FSB into *both* the MinIO 96h tier and the B2 2160h tier — while `pvc-minecraft-datadir` (the 20Gi world save) and `harbor-db` pgdata were copied by **neither**.

The overlap was accidental rather than a division of labour, and the most irreplaceable volumes were the ones outside it.

VolSync keeps them: it's offsite-first with a shorter RPO than the nightly Velero pass. Velero now skips them.

## One rule, not 13 annotations

Implemented as a single `pvcLabels` condition plus a label on each PVC manifest, rather than 12 `backup.velero.io/backup-volumes-excludes` pod annotations scattered across app values. Wiring a new VolSync source becomes one edit *next to the PVC*, where someone looking at it will see it.

## pvcLabels was verified, not assumed

I didn't trust the version number. Probe on velero v1.18.1 against `portainer`:

| | PodVolumeBackups |
|---|---|
| without the label | **1** |
| with the label | **0** |

That check mattered: **an unsupported condition is silently ignored and the backup still reports `Completed`** — indistinguishable from success. Probe backups and the test policy have been cleaned up.

## Expected effect

Roughly one fewer full copy per night in each of the two BSLs. That also relieves #1154, where MinIO sits at 82% — though the trend there has already reversed since #1153.

## Not included

**`harbor-registry`** — its PVC is created by the Harbor chart rather than declared in git, so it can't carry the label from a manifest here. That's the largest single volume in the set (4.15 GiB/night), so it's worth a follow-up on #1161 rather than dropping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReBNuj9oheJm4PihWXh23N