### PR TITLE
docs(tofu): record why the minio service accounts ignore secret changes

### DIFF
--- a/terraform/minio/users.tf
+++ b/terraform/minio/users.tf
@@ -1,3 +1,20 @@
+# MinIO service accounts consumed by other systems.
+#
+# Every user here carries `ignore_changes = [secret]`, and the reason is the same
+# in each case: Terraform does not own these passwords. Each secret is generated
+# out of band, stored in 1Password, and delivered to the consuming workload by an
+# ExternalSecret. If Terraform managed the value it would rewrite the credential on
+# any drift and break the consumer mid-flight -- for velero and cnpg that means
+# breaking the backup path, silently, until the next restore attempt.
+#
+# `ignore_changes` is exactly the construct that hides real drift, so it is worth
+# being explicit that this is deliberate rather than inherited. The arr quality
+# profiles were inverted for months behind an `ignore_changes` nobody had written
+# down; this note exists so the same question does not have to be re-derived here.
+#
+# To rotate one of these: change it in MinIO, update the 1Password item, then
+# force-sync the consuming ExternalSecret. Terraform is not involved.
+
 resource "minio_iam_user" "cnpg_svc" {
   name = "cnpg-svc"
   lifecycle { ignore_changes = [secret] }


### PR DESCRIPTION
Four `minio_iam_user` resources carry `lifecycle { ignore_changes = [secret] }` with no stated reason.

The reason is sound — **Terraform doesn't own these passwords.** Each is generated out of band, stored in 1Password, and delivered to the consuming workload by an ExternalSecret. If Terraform managed the value it would rewrite the credential on any drift and break the consumer mid-flight; for `velero-svc` and `cnpg-svc` that means silently breaking the backup path until someone attempts a restore.

But none of that was written down, and **`ignore_changes` is precisely the construct that hides real drift.**

That's not hypothetical here — the arr quality profiles were inverted for months behind an `ignore_changes` nobody had recorded. This note means the question doesn't have to be re-derived, and it includes the rotation procedure (change in MinIO → update 1Password → force-sync the ExternalSecret; Terraform is not involved).

Closes #1165. The other half — the 1Password ServiceMonitor blocked by its own NetworkPolicy — shipped in #1174 and is confirmed working: `up=1` after 82 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReBNuj9oheJm4PihWXh23N