### PR TITLE
fix(kyverno): narrow the Flux policy exception from a wildcard to two named rules

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/flux-exception.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/flux-exception.yaml
@@ -19,6 +19,32 @@ spec:
           kinds: ["Deployment"]
           namespaces: ["flux-system"]
           names: ["helm-controller", "kustomize-controller", "notification-controller", "source-controller"]
+  # Narrowed from policyName: '*' / ruleNames: ['*'] on 2026-08-22.
+  #
+  # Measured before changing it: all four flux-system controllers currently PASS
+  # every policy -- no missing labels, no missing resources -- and gotk-components
+  # .yaml in this repo already carries both, so a re-bootstrap from here stays
+  # compliant. The wildcard was therefore protecting nothing that needed protecting.
+  #
+  # What it WAS doing is exempting the Flux controllers from restrict-privileged,
+  # restrict-hostpath-usage, restrict-image-registries and restrict-latest-tag --
+  # the four things most worth enforcing on a component that can apply anything to
+  # the cluster. Those now apply.
+  #
+  # The two named below are kept as a genuine safety net: `flux bootstrap`
+  # regenerates gotk-components.yaml, and an upstream default that drops the
+  # resource stanza or the app/env/category labels would otherwise block Flux from
+  # reconciling itself -- a deadlock where the thing that fixes the cluster is the
+  # thing being blocked.
+  #
+  # The GitRepository/Kustomization/HelmRelease match blocks above are currently
+  # inert: no policy in this cluster matches those kinds. They are retained
+  # deliberately so a future policy targeting Flux CRs cannot deadlock reconciliation
+  # the same way -- but they are not doing anything today.
   exceptions:
-    - policyName: '*'
-      ruleNames: ['*']
+    - policyName: require-resources
+      ruleNames:
+        - require-limits
+    - policyName: require-standard-labels
+      ruleNames:
+        - require-labels-on-controllers


### PR DESCRIPTION
`flux-exception.yaml` exempted the Flux controllers from **every policy and every rule**:

```yaml
  exceptions:
    - policyName: '*'
      ruleNames: ['*']
```

It's the only exception in the repo that does this, and the only one carrying no labels — which suggests it predates the conventions rather than being a decision.

## Measured before changing it

All four `flux-system` controllers currently **pass every policy** — no missing labels, no missing resources — and `gotk-components.yaml` in this repo already carries both, so a re-bootstrap from here stays compliant.

**The wildcard was protecting nothing that needed protecting.**

What it *was* doing is exempting Flux from `restrict-privileged`, `restrict-hostpath-usage`, `restrict-image-registries` and `restrict-latest-tag` — the four things most worth enforcing on a component that can apply anything to the cluster. Those now apply.

## What's kept, and why

`require-resources/require-limits` and `require-standard-labels/require-labels-on-controllers` stay as a genuine safety net. `flux bootstrap` regenerates `gotk-components.yaml`, and an upstream default that drops the resource stanza or the labels would block Flux from reconciling **itself** — a deadlock where the thing that fixes the cluster is the thing being blocked.

## One thing worth noting

No policy in this cluster matches the `GitRepository`/`OCIRepository`/`HelmRepository`/`Kustomization`/`HelmRelease` kinds in the match block — those are **inert today**. Retained deliberately so a future policy targeting Flux CRs can't deadlock reconciliation the same way, but now documented as inert rather than looking load-bearing.

## Deliberately not bundled

Extending enforcement to **Job/CronJob** is the other half of #1164 and is *not* in this PR. It needs new policies whose `foreach` paths differ between Job (`spec.template…`) and CronJob (`jobTemplate.spec.template…`), on a fail-closed webhook, staged through Audit first — 18 CronJobs are currently unvalidated and 5 would fail on day one. That deserves its own change with its own verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReBNuj9oheJm4PihWXh23N