### PR TITLE
docs(velero): correct the claim that minecraft backupdir is PVC-backed

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero/app/resource-policy-configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/resource-policy-configmap.yaml
@@ -69,7 +69,17 @@ data:
       # them here would be dead configuration.
       #
       # PVC-backed volumes are deliberately NOT skipped — pgdata, registry-data,
-      # config, metadata, media, backupdir and datadir hold real state.
+      # config, metadata, media and datadir hold real state.
+      #
+      # `backupdir` was listed here as PVC-backed. It is not: it is an emptyDir on
+      # the minecraft Deployment, so this rule skips it. That is correct, and it
+      # costs nothing — verified 2026-08-22 that NOTHING writes to it. The itzg
+      # chart mounts /backups by default, but the pod runs a single container with
+      # no BACKUP* env vars, so the in-server backup feature was never enabled.
+      # There are no rotated world backups being discarded, because none are taken.
+      #
+      # The live world IS protected: `datadir` is a PVC and is backed up nightly.
+      # What does not exist is in-game rollback to an earlier point — see #1159.
       - conditions:
           volumeTypes:
             - emptyDir


### PR DESCRIPTION
The emptyDir skip rule's comment listed `backupdir` among the PVC-backed volumes that "hold real state". It's an **emptyDir** on the minecraft Deployment, so the rule skips it — the comment asserted the opposite of what the manifest does.

## This corrects #1159's premise

Verified 2026-08-22: **nothing writes to `/backups`.**

```
volumes:    tmp (emptyDir), datadir (PVC), backupdir (emptyDir)
containers: minecraft          <- one container, no sidecar
env:        no BACKUP* variables
```

The itzg chart mounts `/backups` by default, but the in-server backup feature was never enabled. So **no rotated world backups are being discarded, because none are taken** — the loss #1159 describes isn't happening.

## What is and isn't protected

- **The live world IS protected** — `datadir` is a PVC, backed up nightly (5.41 GiB in the last run).
- **What doesn't exist is in-game rollback** to an earlier point — recovering from a grief or a bad plugin means restoring last night's Velero copy, not yesterday's in-server snapshot.

That's a real gap, but it's a *feature that was never turned on*, not data being silently destroyed. #1159 should be re-scoped to "decide whether we want in-game backup rotation at all" — which is a different, lower-urgency question, and needs a PVC sized against Longhorn headroom if the answer is yes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReBNuj9oheJm4PihWXh23N