### PR TITLE
feat(foundry): Authentik application and Cloudflare DNS for Foundry VTT

### DIFF
--- a/terraform/authentik/applications.tf
+++ b/terraform/authentik/applications.tf
@@ -37,6 +37,20 @@ resource "authentik_policy_binding" "filebrowser_users" {
   order  = 0
 }
 
+resource "authentik_application" "foundry" {
+  name             = "Foundry VTT"
+  slug             = "foundry"
+  meta_description = "Virtual tabletop for online tabletop RPG sessions"
+  meta_launch_url  = "https://foundry.vollminlab.com"
+  open_in_new_tab  = false
+}
+
+resource "authentik_policy_binding" "foundry_users" {
+  target = authentik_application.foundry.uuid
+  group  = authentik_group.foundry_users.id
+  order  = 0
+}
+
 resource "authentik_application" "grafana" {
   name              = "Grafana"
   slug              = "grafana"

--- a/terraform/authentik/groups.tf
+++ b/terraform/authentik/groups.tf
@@ -13,6 +13,11 @@ resource "authentik_group" "filebrowser_users" {
   users = toset([authentik_user.vollmin.id, authentik_user.jvollmin.id, authentik_user.gkroner.id, authentik_user.jkvedaras.id])
 }
 
+resource "authentik_group" "foundry_users" {
+  name  = "Foundry Users"
+  users = toset([authentik_user.vollmin.id, authentik_user.jvollmin.id, authentik_user.rjutkiewicz.id, authentik_user.speterson.id])
+}
+
 resource "authentik_group" "grafana_admins" {
   name  = "Grafana Admins"
   users = [authentik_user.vollmin.id]

--- a/terraform/cloudflare/dns.tf
+++ b/terraform/cloudflare/dns.tf
@@ -108,6 +108,15 @@ resource "cloudflare_dns_record" "filebrowser" {
   ttl     = 1
 }
 
+resource "cloudflare_dns_record" "foundry" {
+  zone_id = var.cloudflare_zone_id
+  name    = "foundry.vollminlab.com"
+  type    = "CNAME"
+  content = "${cloudflare_zero_trust_tunnel_cloudflared.nginx.id}.cfargotunnel.com"
+  proxied = true
+  ttl     = 1
+}
+
 resource "cloudflare_dns_record" "jellyfin" {
   zone_id = var.cloudflare_zone_id
   name    = "jellyfin.vollminlab.com"

--- a/terraform/cloudflare/tunnels.tf
+++ b/terraform/cloudflare/tunnels.tf
@@ -112,6 +112,10 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "nginx" {
         service  = "http://ingress-nginx-controller.ingress-nginx.svc.cluster.local:80"
       },
       {
+        hostname = "foundry.vollminlab.com"
+        service  = "http://ingress-nginx-controller.ingress-nginx.svc.cluster.local:80"
+      },
+      {
         service = "http_status:404"
       },
     ]


### PR DESCRIPTION
Adds the Authentik Application, access group and policy binding for Foundry VTT, plus the Cloudflare DNS record and tunnel hostname. First of three PRs; the cluster manifests and the VolSync backup follow.

## Why this ships first

An nginx Ingress carrying Authentik forward-auth annotations whose host has no matching Authentik Application makes the outpost return 400, which nginx converts to 500. The Application has to exist before the Ingress reconciles.

## What's here

- `authentik_group.foundry_users` — Scott, Justin, Ricky, Shaun. All four users already existed; no new user resources.
- `authentik_application.foundry` — deliberately **no** `protocol_provider`. Foundry uses the domain-wide `vollminlab-forward-auth` `forward_domain` provider, same shape as `alertmanager`/`bazarr`/`filebrowser`. A `forward_single` ProxyProvider would cause an OAuth callback loop.
- `authentik_policy_binding.foundry_users` — restricts the app to that group.
- `cloudflare_dns_record.foundry` — CNAME to the **existing shared `nginx` tunnel**, the one `filebrowser` already uses. No new tunnel, no new cloudflared Deployment, no inbound firewall ports.
- `foundry.vollminlab.com` added to that tunnel's ingress config, before the `http_status:404` catch-all.

## Notes for review

- 32 insertions, 0 deletions across 4 files — pure additions, nothing existing is replaced or reordered. Relevant because these Terraform CRs are `approvePlan: auto`.
- No `meta_icon`: `homarr-labs/dashboard-icons` has no Foundry icon (svg/png variants all 404).
- `docs/roadmap.md` currently lists Foundry under Deferred with "sequence after Cilium migration". Proceeding deliberately — the chart used in PR 2 ships a native `HTTPRoute` template, so the Phase 8 migration is a values change rather than a rewrite, and Phase 8 will touch all 34 ingresses regardless. The roadmap entry is corrected in PR 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Fuk2t1KKrrLikj2xghzn9