### PR TITLE
fix(dmz): exclude RFC1918 from the minecraft 0.0.0.0/0 egress rule

### DIFF
--- a/.claude/rules/networkpolicy.md
+++ b/.claude/rules/networkpolicy.md
@@ -121,6 +121,20 @@ Harbor VIP on `:443`, but the LoadBalancer remaps `443→8443` and egress policy
 post-DNAT — so an egress `allow ... :443` rule never matches and the connection times out. Use the
 destination **container port** (8443) in the egress rule, exactly as for ingress.
 
+**An RFC1918 `except` on an 80/443 egress rule cannot break DNS.** This misconception kept
+`dmz/minecraft`'s `0.0.0.0/0` egress un-narrowed for months (#1162): the fear was that excluding
+`10.0.0.0/8` would take out the service CIDR and with it kube-dns. It cannot. DNS is UDP/TCP **53**,
+so an 80/443 rule never carried it in the first place, and it is granted separately by the
+namespace-wide `allow-dns` policy — NetworkPolicies are purely additive, so a narrower rule in one
+policy can never revoke what another policy allows.
+
+**So do not "carve back in" the service and pod CIDRs to make an `except` safe.** `10.96.0.0/12`
+and `172.18.0.0/16` cover every ClusterIP and every pod in the cluster; re-allowing them on 80/443
+restores almost exactly the exposure the `except` was added to remove, and the policy then reads as
+hardened while enforcing nearly nothing. Enumerate the workload's real in-cluster dependencies
+instead, and give each one its own rule with a `podSelector` — the way `dmz/masters-league` reaches
+`masters-redis`. If the enumeration comes back empty, the bare `except` is the correct policy.
+
 ## Checklist — before opening any NetworkPolicy PR
 
 - [ ] For every `port:` field, verify containerPort with `kubectl get pod ... ports` — not guessed, not from service YAML alone

--- a/clusters/vollminlab-cluster/dmz/minecraft/app/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/dmz/minecraft/app/networkpolicy.yaml
@@ -26,9 +26,32 @@ spec:
         - protocol: TCP
           port: 8100  # Web map interface
   egress:
+    # Outbound HTTP/HTTPS to the public internet only. Everything this pod fetches
+    # is external: the Paper jar (api.papermc.io), the BlueMap plugin
+    # (cdn.modrinth.com, see PLUGINS in configmap.yaml) and Mojang session auth.
+    #
+    # The `except` blocks are the same structure the neighbouring masters-league
+    # policy uses, and they deliberately cover the service CIDR (10.96.0.0/12) and
+    # the pod CIDR (172.18.0.0/16) as well as the LAN — this is the one
+    # internet-exposed workload in the cluster, so a compromise here must not be
+    # able to reach in-cluster HTTP endpoints either.
+    #
+    # This does NOT affect DNS. DNS is UDP/TCP 53 to kube-dns and is granted by the
+    # namespace-wide `allow-dns` policy; NetworkPolicies are additive, so nothing
+    # written here can take it away. (The issue this fixes, #1162, assumed an
+    # RFC1918 `except` would break DNS. It cannot — this rule only ever covered
+    # 80/443.)
+    #
+    # If a future in-cluster dependency is added, give it its own rule with a
+    # podSelector — the way masters-league reaches masters-redis — rather than
+    # re-opening a CIDR.
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8       # incl. service CIDR 10.96.0.0/12
+              - 172.16.0.0/12    # incl. pod CIDR 172.18.0.0/16
+              - 192.168.0.0/16   # LAN
       ports:
         - protocol: TCP
           port: 443


### PR DESCRIPTION
Closes #1162.

`dmz/minecraft`'s egress rule allowed TCP 80/443 to `0.0.0.0/0` with no exclusions. It is
the only internet-exposed workload in the cluster, currently on a Paper branch with no
security patches since 2026-01-04 (#1131), so a compromise there could reach any internal
HTTP/HTTPS endpoint the pod network routes to. The neighbouring `masters-league` policy in
the same namespace already excludes RFC1918; this brings minecraft in line.

## The premise that deferred this was wrong

#1162 records the blocker as: an RFC1918 `except` would swallow the service CIDR and take
out the server's own DNS, so the service and pod CIDRs have to be carved back in.

It would not. DNS is UDP/TCP **53**, and this rule only ever covered 80/443 — it never
carried DNS in the first place. DNS egress comes from the namespace-wide `allow-dns`
policy, and NetworkPolicies are purely additive, so nothing written in `minecraft` can
revoke what `allow-dns` grants.

## Why the CIDRs are not carved back in

`10.96.0.0/12` is every ClusterIP and `172.18.0.0/16` is every pod in the cluster.
Re-allowing both on 80/443 would restore nearly the whole exposure the `except` exists to
remove, leaving a policy that reads as hardened while enforcing little.

So the dependencies were enumerated instead, and they are all external:

- `api.papermc.io` — the Paper jar
- `cdn.modrinth.com` — the BlueMap plugin (`PLUGINS` in `configmap.yaml`)
- Mojang session auth

No internal hostname or address appears anywhere under `/data` (grepped for
`svc.cluster.local`, `192.168.`, `10.96.`, `172.18.`), the pod had no in-cluster socket
open, `dmz` has no Ingress objects, and there is no ServiceMonitor or PodMonitor in the
namespace. If an in-cluster dependency is added later it should get its own rule with a
`podSelector`, the way `masters-league` reaches `masters-redis`.

## Measured on the live pod before the change

| Target | Result |
|---|---|
| `api.papermc.io:443` | connects |
| `cdn.modrinth.com:443` | connects |
| `sessionserver.mojang.com:443` | connects |
| `kube-dns:53/tcp` | connects — unaffected by this rule |
| `10.96.0.1:443` | **already fails** — the apiserver ClusterIP DNATs to `192.168.152.x:6443`, and egress is evaluated post-DNAT |

That last row is the `.claude/rules/networkpolicy.md` port trap showing up on the egress
side, and it means the current rule was already not granting apiserver access.

Ingress is unchanged: HAProxy `192.168.160.2/3` on 25565 and 8100. Both `dmz` services are
NodePort, so no ingress-nginx path is involved.

## Also

Records both points in `.claude/rules/networkpolicy.md` — the DNS misconception and the
"don't carve the CIDRs back in" reasoning — so this class of fix doesn't get deferred on
the same wrong premise again.

## Verify after Flux reconciles

```bash
MCPOD=$(kubectl get pod -n dmz -l app=minecraft -o jsonpath='{.items[0].metadata.name}')
kubectl exec -n dmz $MCPOD -- bash -c '
  for t in api.papermc.io:443 cdn.modrinth.com:443 sessionserver.mojang.com:443; do
    timeout 6 bash -c "exec 3<>/dev/tcp/${t%:*}/${t#*:}" 2>/dev/null && echo "OK  $t" || echo "FAIL $t"
  done
  timeout 5 bash -c "exec 3<>/dev/tcp/kube-dns.kube-system.svc.cluster.local/53" 2>/dev/null \
    && echo "OK  dns" || echo "FAIL dns"'
```

Expect all four `OK`. Then confirm a player connect still works — that path is ingress and
untouched, but it is the one thing worth eyeballing rather than inferring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MJ9d87kNJjoBbKfHPBFAx