### PR TITLE
feat(kyverno): add Audit-mode Job/CronJob counterparts to the five enforce policies

### DIFF
--- a/.claude/rules/kyverno.md
+++ b/.claude/rules/kyverno.md
@@ -18,6 +18,12 @@ description: Kyverno policy rules, required labels, DMZ constraints, and enforce
 | `require-standard-labels`        | Every pod/controller/namespace must have `app`, `env`, `category` labels      |
 | `dmz-restrict-external-access`   | `external-access` / `internet-egress` labels only inside `dmz`                |
 
+**These five match `Deployment`, `StatefulSet` and `DaemonSet` — not `Pod`, and not `Job`
+or `CronJob`.** Autogen does not close that gap: it derives *controller* rules from
+*Pod*-matching policies, never the reverse. So a policy written against controller kinds
+covers exactly the kinds it lists. Job and CronJob were unvalidated by anything until the
+`-batch` policies below (#1164).
+
 **A CPU limit is deliberately NOT required.** Throttling degrades latency-sensitive
 workloads and cannot protect a node from exhaustion the way a memory limit does —
 `coredns` and `kyverno-admission-controller` both omit theirs upstream. Set requests
@@ -36,6 +42,37 @@ there is nothing to block.
 | `inject-resource-requirements`    | Injects resources for Longhorn workloads the chart can't set     |
 | `mutate-default-sa-automount`     | Disables token automount on the `default` ServiceAccount         |
 | `mutate-default-sa-pod-automount` | Same, for pods using the `default` ServiceAccount                |
+
+## The `-batch` policies — Job and CronJob coverage
+
+`require-resources-batch`, `restrict-privileged-batch`, `restrict-latest-tag-batch`,
+`restrict-hostpath-usage-batch` and `restrict-image-registries-batch` are one-for-one
+counterparts of the Enforce five, matching `Job` and `CronJob`. They are **separate
+policies, in Audit**, for two reasons:
+
+1. **The container path differs per kind** — `spec.template.spec.containers` on a Job,
+   `spec.jobTemplate.spec.template.spec.containers` on a CronJob. One rule matching both
+   kinds resolves to null on whichever kind it wasn't written for, and a null `foreach.list`
+   emits *no result at all* rather than a failure — the inert-policy mode of #1104/#1109.
+   So each kind gets its own rule, and `pass` counts are the only proof they evaluate.
+2. **Adding the kinds to the existing Enforce policies would have been a same-day
+   Enforce.** These reach operator-created objects — velero's kopia maintenance Jobs,
+   VolSync mover Jobs, trivy scan Jobs, Helm hook Jobs — that no manifest in this repo
+   controls, on a fail-closed webhook. Audit first, then flip from a read report.
+
+Measured 2026-08-22 with `kyverno apply` over every live object (18 CronJobs, 152 Jobs):
+**pass 544, fail 133, error 0.** Every failure is `require-resources-batch`, and every one
+comes from a workload not authored in this repo — 129 velero `*-kopia-maintain-job-*` Jobs,
+plus the 2 CronJobs longhorn-manager generates from the `filesystem-trim` /
+`snapshot-retention` `RecurringJob` CRs and the 2 Jobs those CronJobs had running. The
+other four policies are clean cluster-wide.
+
+**Before flipping any of these to Enforce**, read the live PolicyReport after at least one
+full backup cycle, one VolSync cycle and one Helm reconcile — a snapshot of currently
+*running* Jobs cannot see the transient ones, and VolSync's 13 ReplicationSources all have
+`moverResources: null`, so their mover Jobs will fail `require-resources-batch` when they
+next run.
+
 
 ## A policy with zero pass results is not enforcing
 

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-kubeadm-cert-renew.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-kubeadm-cert-renew.yaml
@@ -13,12 +13,20 @@ spec:
   # The restrict-privileged and restrict-hostpath-usage policies are currently
   # Enforce mode — this exception ensures the renewal Jobs and Pods are not
   # blocked if kube-system is ever removed from the policy exclude list.
+  #
+  # Until #1164 this named only the Deployment/StatefulSet/DaemonSet policies,
+  # which never matched a Job or a CronJob in the first place — so the exception
+  # was inert and the workload was unvalidated rather than excepted. The
+  # -batch policies are the ones that actually reach these objects; CronJob is
+  # matched here too, because that is the object admission sees when the
+  # manifest is applied.
   match:
     any:
       - resources:
           kinds:
             - Pod
             - Job
+            - CronJob
           namespaces:
             - kube-system
           names:
@@ -30,3 +38,11 @@ spec:
     - policyName: restrict-hostpath-usage
       ruleNames:
         - disallow-hostpath-except-system
+    - policyName: restrict-privileged-batch
+      ruleNames:
+        - block-privileged-job
+        - block-privileged-cronjob
+    - policyName: restrict-hostpath-usage-batch
+      ruleNames:
+        - disallow-hostpath-except-system-job
+        - disallow-hostpath-except-system-cronjob

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/kustomization.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/kustomization.yaml
@@ -21,9 +21,14 @@ resources:
   - mutate-default-sa-pod-automount.yaml
   - require-labels.yaml
   - require-resources.yaml
+  - require-resources-batch.yaml
   - restrict-default.yaml
   - restrict-image-registries.yaml
+  - restrict-image-registries-batch.yaml
   - restrict-hostpath.yaml
+  - restrict-hostpath-batch.yaml
   - restrict-latest-tag.yaml
+  - restrict-latest-tag-batch.yaml
   - restrict-loadbalancer.yaml
   - restrict-privileged.yaml
+  - restrict-privileged-batch.yaml

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/require-resources-batch.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/require-resources-batch.yaml
@@ -1,0 +1,64 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-resources-batch
+  annotations:
+    policies.kyverno.io/title: Require Resource Requests & a Memory Limit (Job/CronJob)
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      The batch counterpart to require-resources. That policy matches Deployment,
+      StatefulSet and DaemonSet only, and because it matches controller kinds
+      rather than Pod, autogen does not extend it — autogen derives controller
+      rules from Pod-matching policies, not the reverse. Job and CronJob were
+      therefore validated by nothing.
+    # Staged in Audit. The Enforce flip is deliberately a separate change,
+    # gated on reading this policy's report — see the note on Job below.
+    kyverno.io/enable-background: "true"
+  labels:
+    app: kyverno
+    env: production
+    category: security
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    # Job and CronJob need separate rules: the container path differs
+    # (spec.template.spec vs spec.jobTemplate.spec.template.spec), so a single
+    # rule matching both kinds would silently iterate nothing on one of them —
+    # the inert-foreach failure mode of #1104/#1109.
+    - name: require-limits-job
+      match:
+        resources:
+          kinds:
+            - Job
+      skipBackgroundRequests: false
+      validate:
+        message: "All containers must declare CPU and memory requests and a memory limit."
+        foreach:
+          - list: "request.object.spec.template.spec.containers"
+            pattern:
+              resources:
+                requests:
+                  cpu: "?*"
+                  memory: "?*"
+                limits:
+                  memory: "?*"
+
+    - name: require-limits-cronjob
+      match:
+        resources:
+          kinds:
+            - CronJob
+      skipBackgroundRequests: false
+      validate:
+        message: "All containers must declare CPU and memory requests and a memory limit."
+        foreach:
+          - list: "request.object.spec.jobTemplate.spec.template.spec.containers"
+            pattern:
+              resources:
+                requests:
+                  cpu: "?*"
+                  memory: "?*"
+                limits:
+                  memory: "?*"

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-hostpath-batch.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-hostpath-batch.yaml
@@ -1,0 +1,79 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-hostpath-usage-batch
+  annotations:
+    policies.kyverno.io/title: Restrict hostPath Usage (Job/CronJob)
+    policies.kyverno.io/category: Pod Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      The batch counterpart to restrict-hostpath-usage. Same namespace
+      exclusions, applied to Job and CronJob.
+    kyverno.io/enable-background: "true"
+  labels:
+    app: kyverno
+    env: production
+    category: security
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: disallow-hostpath-except-system-job
+      match:
+        resources:
+          kinds:
+            - Job
+      exclude:
+        resources:
+          namespaces:
+            - kube-system
+            - calico-system
+            - longhorn-system
+            - monitoring
+            - tigera-operator
+            - velero
+      skipBackgroundRequests: false
+      validate:
+        message: "Using hostPath volumes is not allowed outside system namespaces."
+        anyPattern:
+          - spec:
+              template:
+                spec:
+                  =(volumes): []
+          - spec:
+              template:
+                spec:
+                  volumes:
+                    - =(hostPath): null
+
+    - name: disallow-hostpath-except-system-cronjob
+      match:
+        resources:
+          kinds:
+            - CronJob
+      exclude:
+        resources:
+          namespaces:
+            - kube-system
+            - calico-system
+            - longhorn-system
+            - monitoring
+            - tigera-operator
+            - velero
+      skipBackgroundRequests: false
+      validate:
+        message: "Using hostPath volumes is not allowed outside system namespaces."
+        anyPattern:
+          - spec:
+              jobTemplate:
+                spec:
+                  template:
+                    spec:
+                      =(volumes): []
+          - spec:
+              jobTemplate:
+                spec:
+                  template:
+                    spec:
+                      volumes:
+                        - =(hostPath): null

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-image-registries-batch.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-image-registries-batch.yaml
@@ -1,0 +1,118 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-image-registries-batch
+  annotations:
+    kyverno.io/enable-background: "true"
+    policies.kyverno.io/title: Restrict Image Registries (Job/CronJob)
+    policies.kyverno.io/category: Supply Chain Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      The batch counterpart to restrict-image-registries. Same approved list,
+      applied to Job and CronJob: harbor.vollminlab.com, ghcr.io, quay.io,
+      registry.k8s.io, docker.io, mirror.gcr.io, oci.trueforge.org,
+      reg.kyverno.io, us-docker.pkg.dev. Short names without an explicit
+      registry domain (defaulting to docker.io) are also permitted.
+  labels:
+    app: kyverno
+    env: production
+    category: security
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: restrict-image-registries-job-containers
+      match:
+        resources:
+          kinds:
+            - Job
+      skipBackgroundRequests: false
+      validate:
+        message: >-
+          Image uses a registry not in the approved list. Approved:
+          harbor.vollminlab.com, ghcr.io, quay.io, registry.k8s.io, docker.io,
+          mirror.gcr.io, oci.trueforge.org, reg.kyverno.io, us-docker.pkg.dev.
+          Short names without an explicit domain are also permitted.
+        foreach:
+          - list: "request.object.spec.template.spec.containers || `[]`"
+            deny:
+              conditions:
+                all:
+                  - key: "{{ regex_match('^[a-z0-9][a-z0-9._-]*\\.[a-z]', element.image) }}"
+                    operator: Equals
+                    value: true
+                  - key: "{{ regex_match('^(harbor\\.vollminlab\\.com|ghcr\\.io|quay\\.io|registry\\.k8s\\.io|docker\\.io|mirror\\.gcr\\.io|oci\\.trueforge\\.org|reg\\.kyverno\\.io|us-docker\\.pkg\\.dev)/', element.image) }}"  # yamllint disable-line rule:line-length
+                    operator: Equals
+                    value: false
+
+    - name: restrict-image-registries-job-init-containers
+      match:
+        resources:
+          kinds:
+            - Job
+      skipBackgroundRequests: false
+      validate:
+        message: >-
+          initContainer image uses a registry not in the approved list. Approved:
+          harbor.vollminlab.com, ghcr.io, quay.io, registry.k8s.io, docker.io,
+          mirror.gcr.io, oci.trueforge.org, reg.kyverno.io, us-docker.pkg.dev.
+          Short names without an explicit domain are also permitted.
+        foreach:
+          - list: "request.object.spec.template.spec.initContainers || `[]`"
+            deny:
+              conditions:
+                all:
+                  - key: "{{ regex_match('^[a-z0-9][a-z0-9._-]*\\.[a-z]', element.image) }}"
+                    operator: Equals
+                    value: true
+                  - key: "{{ regex_match('^(harbor\\.vollminlab\\.com|ghcr\\.io|quay\\.io|registry\\.k8s\\.io|docker\\.io|mirror\\.gcr\\.io|oci\\.trueforge\\.org|reg\\.kyverno\\.io|us-docker\\.pkg\\.dev)/', element.image) }}"  # yamllint disable-line rule:line-length
+                    operator: Equals
+                    value: false
+
+    - name: restrict-image-registries-cronjob-containers
+      match:
+        resources:
+          kinds:
+            - CronJob
+      skipBackgroundRequests: false
+      validate:
+        message: >-
+          Image uses a registry not in the approved list. Approved:
+          harbor.vollminlab.com, ghcr.io, quay.io, registry.k8s.io, docker.io,
+          mirror.gcr.io, oci.trueforge.org, reg.kyverno.io, us-docker.pkg.dev.
+          Short names without an explicit domain are also permitted.
+        foreach:
+          - list: "request.object.spec.jobTemplate.spec.template.spec.containers || `[]`"
+            deny:
+              conditions:
+                all:
+                  - key: "{{ regex_match('^[a-z0-9][a-z0-9._-]*\\.[a-z]', element.image) }}"
+                    operator: Equals
+                    value: true
+                  - key: "{{ regex_match('^(harbor\\.vollminlab\\.com|ghcr\\.io|quay\\.io|registry\\.k8s\\.io|docker\\.io|mirror\\.gcr\\.io|oci\\.trueforge\\.org|reg\\.kyverno\\.io|us-docker\\.pkg\\.dev)/', element.image) }}"  # yamllint disable-line rule:line-length
+                    operator: Equals
+                    value: false
+
+    - name: restrict-image-registries-cronjob-init-containers
+      match:
+        resources:
+          kinds:
+            - CronJob
+      skipBackgroundRequests: false
+      validate:
+        message: >-
+          initContainer image uses a registry not in the approved list. Approved:
+          harbor.vollminlab.com, ghcr.io, quay.io, registry.k8s.io, docker.io,
+          mirror.gcr.io, oci.trueforge.org, reg.kyverno.io, us-docker.pkg.dev.
+          Short names without an explicit domain are also permitted.
+        foreach:
+          - list: "request.object.spec.jobTemplate.spec.template.spec.initContainers || `[]`"
+            deny:
+              conditions:
+                all:
+                  - key: "{{ regex_match('^[a-z0-9][a-z0-9._-]*\\.[a-z]', element.image) }}"
+                    operator: Equals
+                    value: true
+                  - key: "{{ regex_match('^(harbor\\.vollminlab\\.com|ghcr\\.io|quay\\.io|registry\\.k8s\\.io|docker\\.io|mirror\\.gcr\\.io|oci\\.trueforge\\.org|reg\\.kyverno\\.io|us-docker\\.pkg\\.dev)/', element.image) }}"  # yamllint disable-line rule:line-length
+                    operator: Equals
+                    value: false

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-latest-tag-batch.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-latest-tag-batch.yaml
@@ -1,0 +1,51 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-latest-tag-batch
+  annotations:
+    kyverno.io/enable-background: "true"
+    policies.kyverno.io/title: Disallow `:latest` Image Tags (Job/CronJob)
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      The batch counterpart to restrict-latest-tag, which matched Deployment,
+      StatefulSet and DaemonSet only.
+  labels:
+    app: kyverno
+    env: production
+    category: security
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: restrict-latest-tag-job
+      match:
+        resources:
+          kinds:
+            - Job
+      skipBackgroundRequests: false
+      validate:
+        message: "Use of ':latest' image tag is not allowed in containers."
+        pattern:
+          spec:
+            template:
+              spec:
+                containers:
+                  - image: "!*:latest"
+
+    - name: restrict-latest-tag-cronjob
+      match:
+        resources:
+          kinds:
+            - CronJob
+      skipBackgroundRequests: false
+      validate:
+        message: "Use of ':latest' image tag is not allowed in containers."
+        pattern:
+          spec:
+            jobTemplate:
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - image: "!*:latest"

--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-privileged-batch.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/restrict-privileged-batch.yaml
@@ -1,0 +1,85 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-privileged-batch
+  annotations:
+    policies.kyverno.io/title: Block Privileged Pods (Job/CronJob)
+    policies.kyverno.io/category: Pod Security
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      The batch counterpart to restrict-privileged. Same namespace exclusions,
+      applied to Job and CronJob, which no Enforce policy matched.
+    kyverno.io/enable-background: "true"
+  labels:
+    app: kyverno
+    env: production
+    category: security
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: block-privileged-job
+      match:
+        resources:
+          kinds:
+            - Job
+      exclude:
+        resources:
+          namespaces:
+            - kube-system
+            - calico-system
+            - longhorn-system
+            - metallb-system
+            - csi-driver
+            - tigera-operator
+            - ingress-nginx
+      skipBackgroundRequests: false
+      validate:
+        message: "Privileged mode is not allowed."
+        anyPattern:
+          - spec:
+              template:
+                spec:
+                  containers:
+                    - =(securityContext):
+                        =(privileged): false
+          - spec:
+              template:
+                spec:
+                  containers:
+                    - X(securityContext): null
+
+    - name: block-privileged-cronjob
+      match:
+        resources:
+          kinds:
+            - CronJob
+      exclude:
+        resources:
+          namespaces:
+            - kube-system
+            - calico-system
+            - longhorn-system
+            - metallb-system
+            - csi-driver
+            - tigera-operator
+            - ingress-nginx
+      skipBackgroundRequests: false
+      validate:
+        message: "Privileged mode is not allowed."
+        anyPattern:
+          - spec:
+              jobTemplate:
+                spec:
+                  template:
+                    spec:
+                      containers:
+                        - =(securityContext):
+                            =(privileged): false
+          - spec:
+              jobTemplate:
+                spec:
+                  template:
+                    spec:
+                      containers:
+                        - X(securityContext): null


### PR DESCRIPTION
Addresses the first half of #1164. (The second half — the Flux wildcard exemption — was
already narrowed by #1178.)

## The gap

All five Enforce policies match `Deployment`, `StatefulSet` and `DaemonSet` and nothing
else. Because they match *controller* kinds rather than `Pod`, autogen does not extend
them — autogen derives controller rules from Pod-matching policies, never the reverse. So
18 CronJobs and every Job in the cluster were validated by nothing at all: no resource
requirements, no privileged restriction, no `:latest` block, no hostPath block, no registry
allowlist.

## What this adds

Five counterpart policies matching `Job` and `CronJob`, in **Audit**:

| New policy | Mirrors |
|---|---|
| `require-resources-batch` | `require-resources` |
| `restrict-privileged-batch` | `restrict-privileged` |
| `restrict-latest-tag-batch` | `restrict-latest-tag` |
| `restrict-hostpath-usage-batch` | `restrict-hostpath-usage` |
| `restrict-image-registries-batch` | `restrict-image-registries` |

Namespace excludes are copied verbatim from each original. The registry regexes are
byte-identical to the originals' (checked by parsing both files and comparing the
resolved condition keys, not by eye — the YAML escaping is easy to get one level wrong).

Each kind gets its **own rule** rather than sharing one. The container path differs —
`spec.template.spec.containers` on a Job, `spec.jobTemplate.spec.template.spec.containers`
on a CronJob — and a `foreach.list` that resolves to null emits *no result at all* rather
than a failure. That is the inert-policy mode of #1104/#1109, and splitting the rules is
what makes the pass counts below mean something.

## Audit, not Enforce

These are the first policies to reach objects no manifest in this repo controls — velero's
kopia maintenance Jobs, VolSync mover Jobs, trivy scan Jobs, Helm hook Jobs — on a webhook
that is fail-closed and took the cluster down for ~2 hours on 2026-04-05. The Enforce flip
is a deliberate follow-up, gated on reading the live report (see below).

## Measured before committing

`kyverno apply` over **every live object** — 18 CronJobs and 152 Jobs — run under both the
local CLI v1.17.1 and CI's pinned v1.12.1, with identical results:

```
pass 544, fail 133, error 0
```

Every single failure is `require-resources-batch`, and every one is a workload not authored
in this repo:

| Source | Count | Why it can't be fixed from git |
|---|---|---|
| velero `*-kopia-maintain-job-*` Jobs | 129 | created by the velero server at runtime |
| `longhorn-system` `filesystem-trim` / `snapshot-retention` CronJobs | 2 | generated by longhorn-manager from `RecurringJob` CRs (`longhorn.io/managed-by: longhorn-manager`) |
| the Jobs those two CronJobs had running | 2 | same |

The other four policies are **clean cluster-wide** — zero privileged, hostPath, `:latest`
or off-registry findings across all 170 objects. All 64 in-repo CronJob evaluations pass,
which is also the proof the rules are evaluating rather than silently iterating nothing.

## Also: the exception that was never doing anything

`exceptions-kubeadm-cert-renew` named only `restrict-privileged` and
`restrict-hostpath-usage` — neither of which has ever matched a `Job` or a `CronJob`. So
the exception was inert and those three CronJobs were *unvalidated* rather than *excepted*.
That mismatch is exactly what #1164 spotted ("an exception was authored for policies that
never applied in the first place"). It now names the `-batch` rules and matches `CronJob`
as well, so it will still hold if `kube-system` is ever removed from the namespace excludes.

## Before flipping any of these to Enforce

Read the live PolicyReport after at least one full backup cycle, one VolSync cycle and one
Helm reconcile. A snapshot of currently *running* Jobs cannot see the transient ones, and
in particular **all 13 VolSync `ReplicationSource`s have `moverResources: null`**, so their
mover Jobs will fail `require-resources-batch` when they next run. That one is fixable in
git rather than exceptable, and is worth its own change.

## Post-merge check (per `.claude/rules/kyverno.md`, autogen danger zone)

```bash
for p in require-resources-batch restrict-privileged-batch restrict-latest-tag-batch \
         restrict-hostpath-usage-batch restrict-image-registries-batch; do
  echo -n "$p: "; kubectl get clusterpolicy $p -o jsonpath='{.spec.rules[*].name}'; echo
done
```

Expect only the hand-written rule names, no `autogen-*` variants. None of these match
`Pod`, so autogen should not fire — but that is the check the rules file requires after
any policy change, and it is cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MJ9d87kNJjoBbKfHPBFAx