### PR TITLE
fix(harbor): stop Velero double-backing-up the registry VolSync already protects

### DIFF
--- a/.claude/rules/velero.md
+++ b/.claude/rules/velero.md
@@ -45,6 +45,27 @@ on both; the hand-applied `app` label is usually pod-only. Verify, don't assume:
 kubectl get pvc -n <ns> <pvc> -o jsonpath='{.metadata.labels}' | python3 -m json.tool
 ```
 
+## Dividing VolSync and Velero — and labelling a PVC a chart owns
+
+13 PVCs run a nightly VolSync `ReplicationSource` (restic to B2). Velero FSB would
+otherwise copy each of them again into *both* the MinIO 96h tier and the B2 2160h tier, so
+`velero-skip-smb-policy` skips any PVC carrying `backup.vollminlab.com/volsync: "true"`.
+That label is the whole contract: **VolSync owns the volume, Velero stands down.**
+
+Wiring a new VolSync source therefore means two edits, and the second is the one that gets
+forgotten — the `ReplicationSource`, and the label on the PVC. A missing label is invisible:
+both systems just succeed, and you pay for the volume three times a night.
+
+**When the PVC is templated by the app's own chart, put the label on with a `postRenderers`
+kustomize patch on the HelmRelease** — `harbor/harbor/app/helmrelease.yaml` is the worked
+example. Do **not** reach for the chart's `existingClaim` so you can declare the PVC in
+git: that drops the PVC out of the Helm release manifest, and every Longhorn StorageClass
+is `reclaimPolicy: Delete` (#1160), so Helm removing it deletes the data. That is the exact
+mechanism that made the Portainer loss permanent.
+
+Labels are mutable, so a post-render patch relabels the live PVC in place — no rebind, no
+data movement, no restart.
+
 ## The monitoring namespace is deliberately mostly unbacked
 
 `monitoring` is in `excludedNamespaces` on `daily-full`, `daily-b2` and `monthly-b2`.

--- a/clusters/vollminlab-cluster/harbor/harbor/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/harbor/harbor/app/helmrelease.yaml
@@ -22,3 +22,32 @@ spec:
     - kind: ConfigMap
       name: harbor-values
       valuesKey: values.yaml
+  # The registry PVC is templated by the chart, so it cannot carry the
+  # `backup.vollminlab.com/volsync` label from a manifest in git the way the 12
+  # mediastack PVCs do. Without that label Velero FSB copies registry-data into
+  # both the MinIO and the B2 tier every night — 4.79 GB measured in
+  # velero-daily-full-20260821030059 — on top of the nightly VolSync restic pass
+  # that already sends it offsite. Three copies of the same volume.
+  #
+  # A post-render patch is the only way to label it that stays in git. The
+  # alternative — switching the chart to `existingClaim` and declaring the PVC
+  # here — would drop the PVC out of the Helm release manifest, and every
+  # Longhorn StorageClass is reclaimPolicy: Delete (#1160), so Helm removing it
+  # takes the data with it. That is the mechanism that made the Portainer loss
+  # permanent; don't repeat it for 3.4 GiB of registry content.
+  #
+  # Labels are mutable, so this patches the existing PVC in place on the next
+  # reconcile — no rebind, no data movement.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: PersistentVolumeClaim
+              name: harbor-registry
+            patch: |
+              apiVersion: v1
+              kind: PersistentVolumeClaim
+              metadata:
+                name: harbor-registry
+                labels:
+                  backup.vollminlab.com/volsync: "true"

--- a/clusters/vollminlab-cluster/velero/velero/app/resource-policy-configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/resource-policy-configmap.yaml
@@ -28,6 +28,11 @@ data:
       #
       # The label lives on the PVC manifests in git, so wiring a new VolSync source
       # is one edit next to the PVC rather than a pod annotation somewhere else.
+      #
+      # For a PVC the app's chart templates rather than git — harbor-registry is
+      # the only one — the label is applied by a `postRenderers` kustomize patch
+      # on the HelmRelease. See harbor/harbor/app/helmrelease.yaml for why that,
+      # and not `existingClaim`.
       - conditions:
           pvcLabels:
             backup.vollminlab.com/volsync: "true"


### PR DESCRIPTION
Closes #1161 — the last remaining piece.

12 of the 13 VolSync-protected PVCs carry `backup.vollminlab.com/volsync: "true"`, which
`velero-skip-smb-policy` matches via `pvcLabels` so Velero stands down. `harbor-registry`
was the one that couldn't: its PVC is templated by the Harbor chart, so no manifest in git
owns its metadata.

Measured in `velero-daily-full-20260821030059`:

| pod | volume | bytes |
|---|---|---|
| `harbor-registry-fc8b7b9df-t84kd` | `registry-data` | **4,790,491,578** |

That is copied into the MinIO 96h tier *and* the B2 2160h tier, on top of the nightly
VolSync restic pass that already sends the same volume offsite. Three copies a night of one
volume — while `#1154` has MinIO at 82%.

## The fix

A `postRenderers` kustomize patch on the HelmRelease, which is how five other HelmReleases
in this repo already adjust chart output:

```yaml
postRenderers:
  - kustomize:
      patches:
        - target:
            kind: PersistentVolumeClaim
            name: harbor-registry
          patch: |
            apiVersion: v1
            kind: PersistentVolumeClaim
            metadata:
              name: harbor-registry
              labels:
                backup.vollminlab.com/volsync: "true"
```

## Why not `existingClaim`

The obvious alternative is to switch the chart to `persistence.persistentVolumeClaim.registry.existingClaim`
and declare the PVC in git, the way `pvc-minecraft-datadir` works. **That would delete the
registry.** It drops the PVC out of the Helm release manifest, so the next reconcile removes
it — and every Longhorn StorageClass is `reclaimPolicy: Delete` (#1160), so the PV and its
3.4 GiB of images go with it. That is the exact mechanism that made the Portainer data loss
permanent.

Labels are mutable, so the post-render patch relabels the live PVC in place: no rebind, no
data movement, no restart.

## Verified before committing

- **All 13 `ReplicationSource`s are healthy.** `harbor/harbor-registry-restic` last completed
  `2026-08-21T02:04:43Z` in `4m43s`. This drops Velero coverage onto a working offsite copy,
  not onto nothing — which is the thing worth checking before removing a backup path.
- **The patch renders correctly.** Run through `kustomize` against the chart's own PVC labels
  (`app`/`chart`/`component`/`heritage`/`release`); the new label is added and none are lost.
- **Server dry-run of the HelmRelease:** `configured`.

## Also

Records the VolSync↔Velero contract and this chart-owned-PVC recipe in
`.claude/rules/velero.md`. A missing label is silent — both systems report success and you
simply pay for the volume three times — so the two-edit rule (`ReplicationSource` **and**
the PVC label) is worth having written down.

## Verify after Flux reconciles

```bash
kubectl get pvc -n harbor harbor-registry -o jsonpath='{.metadata.labels}' | python3 -m json.tool
```

Then after the next `velero-daily-full`, confirm the PVB is gone:

```bash
LAST=$(kubectl get backups.velero.io -n velero -l velero.io/schedule-name=velero-daily-full \
  --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1].metadata.name}')
kubectl get podvolumebackups.velero.io -n velero -l velero.io/backup-name=$LAST \
  -o custom-columns='POD:.spec.pod.name,VOL:.spec.volume' | grep registry
```

Expect no `registry-data` row. `harbor-db` `pgdata` and `harbor-jobservice` `job-logs` should
still be there — those have no VolSync source and Velero remains their only protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MJ9d87kNJjoBbKfHPBFAx