### PR TITLE
feat(foundry): VolSync backup for Foundry data

### DIFF
--- a/.claude/rules/kyverno.md
+++ b/.claude/rules/kyverno.md
@@ -69,7 +69,7 @@ other four policies are clean cluster-wide.
 
 **Before flipping any of these to Enforce**, read the live PolicyReport after at least one
 full backup cycle, one VolSync cycle and one Helm reconcile — a snapshot of currently
-*running* Jobs cannot see the transient ones, and VolSync's 13 ReplicationSources all have
+*running* Jobs cannot see the transient ones, and VolSync's 14 ReplicationSources all have
 `moverResources: null`, so their mover Jobs will fail `require-resources-batch` when they
 next run.
 

--- a/.claude/rules/velero.md
+++ b/.claude/rules/velero.md
@@ -66,6 +66,13 @@ mechanism that made the Portainer loss permanent.
 Labels are mutable, so a post-render patch relabels the live PVC in place — no rebind, no
 data movement, no restart.
 
+**A StatefulSet `volumeClaimTemplates` PVC cannot take the label at all.** Kubernetes forbids
+updating `volumeClaimTemplates` after creation, so a `postRenderers` patch adding the label there
+makes every subsequent Helm upgrade of that release fail permanently (verified 2026-08-22 against
+`foundry` with a server-side dry-run). For that shape only, fall back to the pod annotation
+`backup.velero.io/backup-volumes-excludes: <volume-name>` in the chart's `podAnnotations` — it
+achieves the same skip, is mutable, and stays in git. `foundry` is the one instance today.
+
 ## The monitoring namespace is deliberately mostly unbacked
 
 `monitoring` is in `excludedNamespaces` on `daily-full`, `daily-b2` and `monthly-b2`.

--- a/clusters/vollminlab-cluster/foundry/foundry/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/foundry/foundry/app/configmap.yaml
@@ -87,6 +87,25 @@ data:
       env: production
       category: gaming
 
+    podAnnotations:
+      # Keep Velero's file-system backup away from the live LevelDB. Foundry's own
+      # docs are explicit that copying its database files while the server runs can
+      # corrupt them. The durable copy is the ReplicationSource added in this same
+      # PR, which restics a frozen Longhorn clone instead of the live volume.
+      #
+      # This is the documented EXCEPTION to the `backup.vollminlab.com/volsync: "true"`
+      # PVC-label contract in .claude/rules/velero.md. That contract's mechanism for a
+      # chart-templated PVC is a postRenderers patch (harbor is the worked example),
+      # but Foundry's PVC comes from the chart's StatefulSet volumeClaimTemplates,
+      # which Kubernetes forbids updating after creation — verified 2026-08-22, a
+      # server-side dry-run patch adding the label is rejected with "updates to
+      # statefulset spec for fields other than 'replicas', 'ordinals', 'template',
+      # 'updateStrategy', 'revisionHistoryLimit', 'persistentVolumeClaimRetentionPolicy'
+      # and 'minReadySeconds' are forbidden". A postRenderer would make every future
+      # Helm upgrade of this release fail permanently. The pod annotation achieves the
+      # same skip, is mutable, and stays in git.
+      backup.velero.io/backup-volumes-excludes: data
+
     # The chart default is 18 x 10s = 3 minutes, which is not enough for the
     # first-boot distribution download. 60 x 10s = 10 minutes.
     startupProbe:

--- a/clusters/vollminlab-cluster/foundry/foundry/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/foundry/foundry/app/configmap.yaml
@@ -101,9 +101,13 @@ data:
       # server-side dry-run patch adding the label is rejected with "updates to
       # statefulset spec for fields other than 'replicas', 'ordinals', 'template',
       # 'updateStrategy', 'revisionHistoryLimit', 'persistentVolumeClaimRetentionPolicy'
-      # and 'minReadySeconds' are forbidden". A postRenderer would make every future
-      # Helm upgrade of this release fail permanently. The pod annotation achieves the
-      # same skip, is mutable, and stays in git.
+      # and 'minReadySeconds' are forbidden". A postRenderer targeting that field would
+      # make every future Helm upgrade of this release fail permanently.
+      #
+      # Note this HelmRelease does carry a postRenderer — it patches the pod template's
+      # env, which IS mutable. The forbidden thing is volumeClaimTemplates specifically,
+      # not postRenderers as such. So the label cannot be reached by any means here, and
+      # the pod annotation achieves the same skip, is mutable, and stays in git.
       backup.velero.io/backup-volumes-excludes: data
 
     # The chart default is 18 x 10s = 3 minutes, which is not enough for the

--- a/clusters/vollminlab-cluster/foundry/kustomization.yaml
+++ b/clusters/vollminlab-cluster/foundry/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - namespace.yaml
   - foundry/app
   - networkpolicies
+  - volsync

--- a/clusters/vollminlab-cluster/foundry/volsync/foundry-data-replicationsource.yaml
+++ b/clusters/vollminlab-cluster/foundry/volsync/foundry-data-replicationsource.yaml
@@ -1,0 +1,20 @@
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: foundry-data-restic
+  namespace: foundry
+spec:
+  sourcePVC: data-foundry-0
+  trigger:
+    schedule: "10 2 * * *"
+  restic:
+    pruneIntervalDays: 7
+    repository: volsync-foundry-data-restic
+    retain:
+      daily: 7
+      weekly: 4
+      monthly: 3
+    copyMethod: Clone
+    storageClassName: longhorn-r1
+    cacheCapacity: 1Gi
+    cacheStorageClassName: longhorn

--- a/clusters/vollminlab-cluster/foundry/volsync/kustomization.yaml
+++ b/clusters/vollminlab-cluster/foundry/volsync/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - foundry-data-replicationsource.yaml
+  - volsync-foundry-data-restic-externalsecret.yaml

--- a/clusters/vollminlab-cluster/foundry/volsync/volsync-foundry-data-restic-externalsecret.yaml
+++ b/clusters/vollminlab-cluster/foundry/volsync/volsync-foundry-data-restic-externalsecret.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: volsync-foundry-data-restic
+  namespace: foundry
+  labels:
+    app: foundry
+    env: production
+    category: gaming
+spec:
+  refreshInterval: "0"
+  secretStoreRef:
+    name: onepassword-cluster-store
+    kind: ClusterSecretStore
+  target:
+    name: volsync-foundry-data-restic
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        AWS_ACCESS_KEY_ID: "{{ .b2_key_id }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .b2_key }}"
+        RESTIC_PASSWORD: '{{ index . "foundry-data" }}'
+        RESTIC_REPOSITORY: "s3:{{ .endpoint }}/{{ .bucket }}/foundry/foundry-data"
+  dataFrom:
+    - extract:
+        key: "Volsync Restic Credentials"

--- a/docs/superpowers/plans/foundry-vtt.md
+++ b/docs/superpowers/plans/foundry-vtt.md
@@ -1126,13 +1126,39 @@ resources:
 
 - [ ] **Step 5: Now exclude the data volume from Velero FSB**
 
+The repo's Velero contract (`.claude/rules/velero.md`, "Dividing VolSync and Velero") is that
+`velero-skip-smb-policy` skips any PVC carrying `backup.vollminlab.com/volsync: "true"`, applied
+via a `postRenderers` kustomize patch on the HelmRelease for a chart-templated PVC. That mechanism
+does not work here: Foundry's PVC comes from the chart's StatefulSet `volumeClaimTemplates`, and
+Kubernetes forbids updating `volumeClaimTemplates` after creation — verified 2026-08-22, a
+server-side dry-run patch adding the label is rejected. A `postRenderers` patch attempting it would
+make every future Helm upgrade of this release fail permanently. Do not use `existingClaim` either
+— that drops the PVC out of the Helm release, and every Longhorn StorageClass is
+`reclaimPolicy: Delete`, the exact mechanism that made the Portainer data loss permanent.
+
+So Foundry falls back to the documented exception: the pod annotation
+`backup.velero.io/backup-volumes-excludes: data`. It achieves the same skip, is mutable, and stays
+in git.
+
 Add this block to `clusters/vollminlab-cluster/foundry/foundry/app/configmap.yaml`, immediately after the `podLabels:` block:
 
     podAnnotations:
-      # Keep Velero's file-system backup away from the live LevelDB. Foundry's
-      # docs are explicit that copying its database files while the server runs
-      # can corrupt them. The durable copy is the ReplicationSource added in
-      # this same PR, which restics a frozen Longhorn clone instead.
+      # Keep Velero's file-system backup away from the live LevelDB. Foundry's own
+      # docs are explicit that copying its database files while the server runs can
+      # corrupt them. The durable copy is the ReplicationSource added in this same
+      # PR, which restics a frozen Longhorn clone instead of the live volume.
+      #
+      # This is the documented EXCEPTION to the `backup.vollminlab.com/volsync: "true"`
+      # PVC-label contract in .claude/rules/velero.md. That contract's mechanism for a
+      # chart-templated PVC is a postRenderers patch (harbor is the worked example),
+      # but Foundry's PVC comes from the chart's StatefulSet volumeClaimTemplates,
+      # which Kubernetes forbids updating after creation — verified 2026-08-22, a
+      # server-side dry-run patch adding the label is rejected with "updates to
+      # statefulset spec for fields other than 'replicas', 'ordinals', 'template',
+      # 'updateStrategy', 'revisionHistoryLimit', 'persistentVolumeClaimRetentionPolicy'
+      # and 'minReadySeconds' are forbidden". A postRenderer would make every future
+      # Helm upgrade of this release fail permanently. The pod annotation achieves the
+      # same skip, is mutable, and stays in git.
       backup.velero.io/backup-volumes-excludes: data
 
 This is deliberately in PR 3 and not PR 2: it disables Velero coverage, so it must land in the same commit as the VolSync ReplicationSource that replaces it. Adding it earlier leaves the volume covered by neither system.


### PR DESCRIPTION
Nightly VolSync backup of the Foundry VTT data volume to Backblaze B2. Third and final PR of the Foundry rollout (#1180, #1184).

## Why `copyMethod: Clone`

Foundry v11+ stores worlds in LevelDB, and Foundry's own docs are explicit that copying its database files while the server runs can corrupt them. `Clone` makes restic walk a frozen Longhorn block-level clone, so the torn-file window never opens. Do not change it to `Direct`.

Foundry's own snapshot/backup feature was evaluated and rejected: it is UI-only, with no API, CLI, or hook to trigger it non-interactively. The `foundryvtt-cli` is a compendium-pack build tool, not a backup mechanism, and isn't in the image.

## The Velero exclusion is a documented exception — please read this bit

The repo's contract (#1183) is that Velero skips PVCs labelled `backup.vollminlab.com/volsync: "true"`, applied to chart-templated PVCs via a `postRenderers` kustomize patch (harbor is the worked example).

**That mechanism cannot be used here.** Foundry's PVC comes from the chart's StatefulSet `volumeClaimTemplates`, which Kubernetes forbids updating after creation — verified with a server-side dry-run:

```
The StatefulSet "foundry" is invalid: spec: Forbidden: updates to statefulset spec for fields
other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'revisionHistoryLimit',
'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
```

A postRenderer would make every future Helm upgrade of this release fail permanently. `existingClaim` is also rejected — velero.md explains that drops the PVC out of the Helm release, and every Longhorn StorageClass is `reclaimPolicy: Delete`, which is the mechanism that made the Portainer loss permanent.

So this uses the pod annotation `backup.velero.io/backup-volumes-excludes: data`, and `.claude/rules/velero.md` gains a paragraph documenting the exception, scoped to that shape only.

The exclusion lands in **this** PR rather than #1184 on purpose: it disables Velero coverage, so it has to be in the same commit as the ReplicationSource that replaces it. Until now Velero has been covering the volume.

## Consistency with the fleet

Every field matches the existing 13 sources: `storageClassName: longhorn-r1`, `cacheStorageClassName: longhorn`, `cacheCapacity: 1Gi`, retain 7/4/3, `pruneIntervalDays: 7`, `refreshInterval: "0"` on the restic secret, and the `{namespace}/{source-name}` repository path. `02:10` is the next free ten-minute slot (others run 00:00–02:00) and clears Velero's 03:00 daily-full by 50 minutes.

## Verification

- `check-helm-values.py` → `ok foundry foundryvtt@15.2.3, 0 problems`
- Re-render confirms the annotation is present on the pod template and nothing regressed: zero `foundry-foundryvtt`, `hostname: foundry`, `containerPort: 30000`, `FOUNDRY_PROXY_SSL="true"`, `FOUNDRY_PROXY_PORT="443"`
- `kubectl kustomize clusters/vollminlab-cluster/foundry` builds cleanly
- The `foundry-data` field exists in the `Volsync Restic Credentials` 1Password item

**After merge**, per `.claude/rules/velero.md`'s "verify the artifact, not the status": confirm a PodVolumeBackup/snapshot actually exists with a non-trivial duration before trusting it. A sub-second sync means it backed up nothing. The roadmap row stays future-tense until that's confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Fuk2t1KKrrLikj2xghzn9