### PR TITLE
fix(ci): rewrite Ingress hosts before the server-side dry-run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -685,6 +685,23 @@ jobs:
             yq eval -i '(select(.kind == "Service") | .spec.ports[]?) |= del(.nodePort)' \
               "$RENDER_DIR/rendered.yaml"
 
+            # ── NOT a licence to let charts render Ingresses ───────────────────
+            # The convention in this repo is a STANDALONE ingress.yaml next to the
+            # HelmRelease. 35 of 35 apps follow it. A standalone Ingress is greppable
+            # in git (the "N of M Ingresses carry a slug" audits in CLAUDE.md depend
+            # on that) and never reaches this dry-run at all, because the loop above
+            # skips any file whose kind is not HelmRelease.
+            #
+            # So if a chart wants to emit its own Ingress: set `ingress.enabled: false`
+            # and write the ingress.yaml by hand. If that costs you chart behaviour
+            # wired to the Ingress — foundry's chart only emits FOUNDRY_PROXY_SSL /
+            # FOUNDRY_PROXY_PORT / FOUNDRY_HOSTNAME alongside its own Ingress — re-add
+            # it with a `postRenderers` patch, as foundry's HelmRelease does.
+            #
+            # This block exists only for a chart that gives you no such choice. It is a
+            # backstop, not an alternative to the convention.
+            # ───────────────────────────────────────────────────────────────────────
+            #
             # Rewrite Ingress hostnames before the dry-run, for the same reason as
             # nodePort above: the value in the rendered manifest is by definition
             # already held by the live object, so it cannot be meaningfully checked
@@ -700,10 +717,11 @@ jobs:
             # Ingress passes and every later PR touching that app's values fails, however
             # unrelated the change. #1198 (a VolSync backup) failed exactly this way.
             #
-            # Only Ingresses rendered BY A CHART are affected. This repo normally keeps
-            # Ingresses as standalone ingress.yaml files, which are not part of a
-            # HelmRelease render and never reach this dry-run — foundry is the first app
-            # whose chart emits its own Ingress, which is why this surfaced now.
+            # Only Ingresses rendered BY A CHART are affected. foundry surfaced this by
+            # briefly being the one app in that shape; it has since been moved to a
+            # standalone ingress.yaml like every other app, so as of writing NO app
+            # relies on this rewrite. It is kept because the next chart that emits an
+            # Ingress would otherwise fail in a way that reads as a manifest defect.
             #
             # The rewrite keeps the Ingress in the dry-run so its annotations, TLS block,
             # backend refs, schema and Kyverno admission are all still validated. Only the

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -685,6 +685,36 @@ jobs:
             yq eval -i '(select(.kind == "Service") | .spec.ports[]?) |= del(.nodePort)' \
               "$RENDER_DIR/rendered.yaml"
 
+            # Rewrite Ingress hostnames before the dry-run, for the same reason as
+            # nodePort above: the value in the rendered manifest is by definition
+            # already held by the live object, so it cannot be meaningfully checked
+            # against a cluster already running it.
+            #
+            # ingress-nginx's validating webhook rejects a host+path pair that another
+            # Ingress already owns, in ANY namespace:
+            #   admission webhook "validate.nginx.ingress.kubernetes.io" denied the
+            #   request: host "foundry.vollminlab.com" and path "/" is already defined
+            #   in ingress foundry/foundry
+            # That is not a manifest defect — it is the app's OWN live Ingress. It only
+            # bites once the app is deployed, so the PR that first adds a chart-rendered
+            # Ingress passes and every later PR touching that app's values fails, however
+            # unrelated the change. #1198 (a VolSync backup) failed exactly this way.
+            #
+            # Only Ingresses rendered BY A CHART are affected. This repo normally keeps
+            # Ingresses as standalone ingress.yaml files, which are not part of a
+            # HelmRelease render and never reach this dry-run — foundry is the first app
+            # whose chart emits its own Ingress, which is why this surfaced now.
+            #
+            # The rewrite keeps the Ingress in the dry-run so its annotations, TLS block,
+            # backend refs, schema and Kyverno admission are all still validated. Only the
+            # hostname — the one field guaranteed to collide — is swapped for a per-run
+            # unique name. The manifest on disk is untouched.
+            CI_HOST="ci-${RUN_SUFFIX}.ci.invalid"
+            yq eval -i "(select(.kind == \"Ingress\") | .spec.rules[]?.host) |= \"$CI_HOST\"" \
+              "$RENDER_DIR/rendered.yaml"
+            yq eval -i "(select(.kind == \"Ingress\") | .spec.tls[]?.hosts[]?) |= \"$CI_HOST\"" \
+              "$RENDER_DIR/rendered.yaml"
+
             # ── Server-side dry-run: real admission chain, zero side effects ────
             if kubectl apply --dry-run=server -n "$TEST_NAMESPACE" \
                  -f "$RENDER_DIR/rendered.yaml" > "$RENDER_DIR/dryrun.out" 2>&1; then


### PR DESCRIPTION
Unblocks #1198, and every future PR that touches the values of an app whose chart renders its own Ingress.

## The failure

ingress-nginx's validating webhook rejects a host+path pair that another Ingress already owns, in **any** namespace. For a chart-rendered Ingress, that "other" Ingress is the app's own live object:

```
admission webhook "validate.nginx.ingress.kubernetes.io" denied the request:
host "foundry.vollminlab.com" and path "/" is already defined in ingress foundry/foundry
```

That is not a manifest defect. It only appears once the app is deployed — so the PR that first adds the Ingress passes CI, and every later PR touching that app's values fails, however unrelated the change. #1198 is a VolSync backup that never goes near the Ingress, and it failed on this.

## Why now, and why it will recur

Only **chart-rendered** Ingresses are affected. This repo normally keeps Ingresses as standalone `ingress.yaml` files, which aren't part of a HelmRelease render and never reach this dry-run. `foundry` is the first app whose chart emits its own Ingress — which is exactly why this has never been seen before and will now recur on every Foundry values change.

## The fix

Same shape and rationale as the `nodePort` strip immediately above it: remove only the field that cannot be meaningfully validated against a cluster already running the real object.

The Ingress **stays in the dry-run** — annotations, TLS block, backend refs, schema and Kyverno admission are all still checked. Only `spec.rules[].host` and `spec.tls[].hosts[]` are swapped for a per-run unique name, and only in the rendered copy under `$RENDER_DIR`. The manifest on disk is untouched.

## Verified against the live cluster

Extracted Foundry's live Ingress, renamed it so the dry-run is a CREATE rather than an UPDATE (an update to itself never trips the duplicate check), and ran both cases:

```
A) original host  -> denied: host "foundry.vollminlab.com" and path "/" is already defined
B) rewritten host -> ingress.networking.k8s.io/foundry-citest created (server dry run)
```

Also confirmed the transform is surgical on the real rendered chart: 12 annotations preserved, `auth-url` intact, backend service and `wildcard-tls` secretName unchanged, StatefulSet untouched, document count unchanged. yq v4.44.3, the same version CI installs.

## Known limitation left alone deliberately

The same dry-run also logs two RBAC warnings for Foundry — the CI ServiceAccount cannot create `statefulsets` or `pods` in the test namespace, so those objects are skipped rather than admission-tested. That is already downgraded to a warning by existing logic and does **not** fail the job.

I have not granted those verbs. The ClusterRoleBinding is cluster-scoped, so `pods: create` would let the CI runner create pods in any namespace — a real privilege increase for marginal gain, given that schema validation (kubeconform) and Kyverno policy validation both run as separate jobs and already cover those manifests. Worth revisiting only if a future chart's StatefulSet needs genuine admission testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Fuk2t1KKrrLikj2xghzn9