### PR TITLE
feat(ci): enforce documentation currency for the reference and roadmap

### DIFF
--- a/.claude/rules/docs.md
+++ b/.claude/rules/docs.md
@@ -1,0 +1,79 @@
+# Documentation Currency Rules
+
+Two documents in this repo describe live infrastructure, and both silently rotted until a
+2026-08-22 audit. `docs/roadmap.md` had six wrong statuses; `docs/cluster-reference.md` — the
+"Full configuration reference" CLAUDE.md points every session at — was missing **46 of 93 app
+directories** and still listed Plex, Overseerr, Tautulli and sealed-secrets as running.
+
+## The two rules
+
+**1. A new app directory updates `docs/cluster-reference.md` in the same PR.**
+
+`cluster-reference.md` is the *inventory*: what exists, at what version, on what port, with what
+PVC. Every `clusters/<namespace>/<app>/` directory belongs in it. CI enforces this — see below.
+
+**2. A PR that changes what a roadmap phase _means_ updates `docs/roadmap.md` in the same PR.**
+
+Completing a phase, dropping one, splitting one, or invalidating its premise. **Not** every
+deployment. `roadmap.md` is the *plan*: goals, rationale, rejected options and their reasons,
+sequencing constraints. Most app directories here were never on a plan — `longhorn-trim`,
+`velero-pvb-healer`, `longhorn-mount-healer` and `vcenter-credential-age` are all incident
+responses. Retroactively roadmapping them fabricates a plan that never existed and turns the
+roadmap into a second copy of the reference, which is the duplication that caused this.
+
+## Which document does a change belong in?
+
+| Change | Reference | Roadmap |
+| --- | --- | --- |
+| New app deployed | **yes** | only if it completes a phase |
+| App removed | **yes** | only if it changes a phase's meaning |
+| Version/port/PVC changed | **yes** | no |
+| Incident-response CronJob added | **yes** | no |
+| A phase is finished, dropped or split | no | **yes** |
+| An approach is rejected | no | **yes** — record *why*, or it gets re-proposed |
+
+## `scripts/check-doc-currency.sh`
+
+Runs unconditionally on every PR as a step in the existing CI job — no new required check, no
+tooling, no cluster access. Three checks:
+
+1. **Every app directory appears in `cluster-reference.md.`** Baselined in
+   `docs/.cluster-reference-exempt`, seeded with the 46 already missing so the check could land
+   without a mass-documentation PR. **That file is a ratchet and must only shrink.** Adding a new
+   app to it to silence CI defeats the check.
+2. **Retired components stay retired.** `docs/.retired-components` lists removed components; each
+   must not reappear as a live app directory, and must not appear in an *inventory table row* in
+   `cluster-reference.md`. Prose is not checked — the note that `bootstrap/sealed-secrets/` is
+   kept as historical DR reference is correct and should stay.
+3. **`roadmap.md` carries a `Last verified against the live cluster: YYYY-MM-DD` line**, warned at
+   90 days and failed at 180.
+
+## Why the check is not path-filtered
+
+**The drift comes from the _other_ file changing.** Plex was deleted from `clusters/` on
+2026-05-09 and both documents went on describing it for over three months. A check gated on
+`docs/**` would never have fired — inert in exactly the case it exists for, which is the same
+failure as a Kyverno rule whose `foreach.list` resolves to null and reports zero fails because it
+evaluates nothing.
+
+## What the check cannot catch
+
+**Prose.** Four of the six stale roadmap statuses were sentences, not status fields: "deployed
+alongside Plex", a section titled "Tautulli / Plex Metrics Dashboard", "SealedSecret changes
+trigger restarts". No string comparison finds those.
+
+Check 3 is the only defence, and it is a prompt for a human to re-read — not a test. When that
+warning fires, re-read both documents against the live cluster and move the date. Do not move the
+date without doing the reading.
+
+## How the drift happened, so it is recognisable next time
+
+**Every wrong field described something that was _replaced_ rather than removed** — Plex by
+Jellyfin, Tautulli by Jellystat, SealedSecrets by ESO. The replacement got documented in a new
+section while the old section kept its `done`. `roadmap.md` section 3.7 said "SealedSecret changes
+trigger restarts" while 3.8, four sections later, described removing the controller. Both were
+written by someone who knew.
+
+**A `done` status records that something was built, not that it is still running.** Sections
+describing live infrastructure need verifying against the cluster, not against the PR that shipped
+them.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,6 +94,17 @@ jobs:
       - name: Check README structure block
         run: ./scripts/check-readme-structure.sh
 
+      # Same rationale as the README check above, and the same placement — a step
+      # in this job rather than a job of its own, so it blocks merges through the
+      # existing required check.
+      #
+      # Unconditional on purpose. The drift this catches comes from the *other*
+      # file changing: Plex was deleted from clusters/ on 2026-05-09 and both docs
+      # described it as running for 3.5 months afterwards. A check path-filtered
+      # to docs/** would never have fired. See .claude/rules/docs.md.
+      - name: Check documentation currency
+        run: ./scripts/check-doc-currency.sh
+
 
       # Single source of truth. .kubernetes-version is the file Renovate bumps, so
       # reading it here means CI's kubectl follows the version the upgrade PR proposes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ GitOps-managed Kubernetes cluster using Flux CD. All workloads are Helm-based Fl
 - `.claude/rules/velero.md` — backup schedules, circular backup check, kopia GC, status commands
 - `.claude/rules/git-workflow.md` — branch naming, session hygiene, /compact reminders
 - `.claude/rules/networkpolicy.md` — container port verification, per-namespace port table, pre-PR checklist
+- `.claude/rules/docs.md` — which doc a change belongs in, and the CI check that enforces it
 
 **Operational runbooks** (reference when needed, not loaded every session):
 `docs/runbooks/` — flux-templates, kyverno-recovery, homepage, external-dns, incidents, tofu-provider-bumps

--- a/docs/.cluster-reference-exempt
+++ b/docs/.cluster-reference-exempt
@@ -1,0 +1,48 @@
+# Baseline of app directories not yet documented in docs/cluster-reference.md,
+# captured 2026-08-22. This is a RATCHET, not an allowlist: it exists so the
+# check can land without a mass-documentation PR, and it is meant to shrink to
+# empty. Backfill is tracked as a GitHub issue.
+#
+# Do NOT add a new app here to silence a CI failure. Document the app instead.
+
+1password-connect
+authentik-config
+authentik-proxy
+b2-config
+b2-exporter
+bazarr-exportarr
+cloudflare-config
+csi-snapshot-crds
+descheduler
+etcd-defrag
+filebrowser
+flaresolverr
+foundry
+goldilocks
+grafana-config
+harbor-config
+harbor-db
+jellystat-db
+karma
+kubeadm-cert-monitor
+longhorn-mount-healer
+longhorn-rebalancing-controller
+longhorn-snapshot-retention
+longhorn-trim
+masters-league
+minio-config
+readarr-config
+reloader
+shlink-db
+tailscale-config
+tailscale-operator
+tailscale-svc
+tofu-controller
+trivy-operator
+vcenter-credential-age
+velero-backup-content-guard
+velero-pvb-healer
+victoria-metrics
+victoria-metrics-lt
+vmware-exporter
+volsync

--- a/docs/.retired-components
+++ b/docs/.retired-components
@@ -1,0 +1,13 @@
+# Components removed from the cluster. Checked by scripts/check-doc-currency.sh:
+# each must not reappear as a live app directory, and must not be described in
+# docs/cluster-reference.md as though it were running.
+#
+# The roadmap is deliberately not checked against this list — it is a historical
+# record as well as a plan, and may describe these in the past tense.
+#
+# Format: one directory/component name per line.
+
+plex
+tautulli
+overseerr
+sealed-secrets

--- a/docs/cluster-reference.md
+++ b/docs/cluster-reference.md
@@ -134,7 +134,7 @@ kubectl create secret generic onepassword-connect -n 1password \
 1. Install Kubernetes control plane (kubeadm)
 2. Install Calico CNI              → bootstrap/calico/README.md
 3. Apply CoreDNS custom config     → bootstrap/coredns/coredns-configmap.yaml
-4. Restore sealed-secrets key      → bootstrap/sealed-secrets/README.md
+4. Apply the onepassword-connect Secret → .claude/rules/secrets.md (must precede Flux bootstrap)
 5. Bootstrap Flux CD               → flux bootstrap github ...
 6. All apps                        → Flux reconciles automatically
 ```
@@ -348,7 +348,6 @@ All Kustomizations use `interval: 10m`, `prune: true`, source `flux-system` GitR
 | `policy-reporter-patch` | patch only | |
 | `portainer` | `./clusters/vollminlab-cluster/portainer` | |
 | `renovate` | `./clusters/vollminlab-cluster/renovate` | |
-| `sealed-secrets` | `./clusters/vollminlab-cluster/sealed-secrets` | |
 | `shlink` | `./clusters/vollminlab-cluster/shlink` | |
 | `velero` | `./clusters/vollminlab-cluster/velero` | |
 | `vollmint` | `./clusters/vollminlab-cluster/vollmint` | |
@@ -388,19 +387,15 @@ All Kustomizations use `interval: 10m`, `prune: true`, source `flux-system` GitR
 | metrics-server-repo | HelmRepository | https://kubernetes-sigs.github.io/metrics-server/ |
 | minecraft-repo | HelmRepository | https://itzg.github.io/minecraft-server-charts/ |
 | minio-repo | HelmRepository | https://charts.min.io/ |
-| overseerr-repo | OCIRepository | oci://oci.trueforge.org/truecharts/overseerr |
-| plex-repo | OCIRepository | oci://oci.trueforge.org/truecharts/plex |
 | portainer-repo | HelmRepository | https://portainer.github.io/k8s |
 | prometheus-community-repo | HelmRepository | https://prometheus-community.github.io/helm-charts |
 | prowlarr-repo | OCIRepository | oci://oci.trueforge.org/truecharts/prowlarr |
 | radarr-repo | OCIRepository | oci://oci.trueforge.org/truecharts/radarr |
 | renovate-repo | OCIRepository | oci://ghcr.io/renovatebot/charts/renovate |
 | sabnzbd-repo | OCIRepository | oci://oci.trueforge.org/truecharts/sabnzbd |
-| sealed-secrets-repo | HelmRepository | https://bitnami-labs.github.io/sealed-secrets |
 | shlink-repo | HelmRepository | https://charts.christianhuth.de |
 | smb-csi-driver-repo | HelmRepository | https://raw.githubusercontent.com/kubernetes-csi/csi-driver-smb/master/charts |
 | sonarr-repo | OCIRepository | oci://oci.trueforge.org/truecharts/sonarr |
-| tautulli-repo | HelmRepository | https://k8s-at-home.com/charts/ |
 | velero-repo | HelmRepository | https://vmware-tanzu.github.io/helm-charts |
 | vollminlab-repo | OCIRepository | oci://harbor.vollminlab.com/vollminlab/charts/shlink-ingress-controller |
 | vollmint-repo | OCIRepository | oci://harbor.vollminlab.com/vollminlab/charts/vollmint (tag: 0.1.0) |
@@ -454,10 +449,7 @@ All ingresses use `ingressClassName: nginx`, TLS termination via `wildcard-tls`,
 | `sabnzbd.vollminlab.com` | sabnzbd | 10097 | mediastack | wildcard-tls |
 | `prowlarr.vollminlab.com` | prowlarr | 9696 | mediastack | wildcard-tls |
 | `bazarr.vollminlab.com` | bazarr | 6767 | mediastack | wildcard-tls |
-| `overseerr.vollminlab.com` | overseerr | 5055 | mediastack | wildcard-tls |
 | `jellyfin.vollminlab.com` | jellyfin | 8096 | mediastack | wildcard-tls |
-| `plex.vollminlab.com` | plex | 32400 | mediastack | wildcard-tls |
-| `tautulli.vollminlab.com` | tautulli | 8181 | mediastack | wildcard-tls |
 | `go.vollminlab.com` | shlink-shlink-backend | 8080 | shlink | wildcard-tls |
 | `vl.vollminlab.com` | shlink-shlink-backend | 8080 | shlink | wildcard-tls |
 | `vollm.in` | shlink-shlink-backend | 8080 | shlink | vollm-in-tls (Let's Encrypt) |
@@ -503,10 +495,7 @@ All ingresses use `ingressClassName: nginx`, TLS termination via `wildcard-tls`,
 | `pvc-sabnzbd-config` | mediastack | 5Gi | longhorn | RWO |
 | `pvc-prowlarr-config` | mediastack | 5Gi | longhorn | RWO |
 | `pvc-bazarr-config` | mediastack | 5Gi | longhorn | RWO |
-| `pvc-overseerr-config` | mediastack | 5Gi | longhorn | RWO |
 | `pvc-jellyfin-config` | mediastack | 20Gi | longhorn | RWO |
-| `pvc-plex-config` | mediastack | 20Gi | longhorn | RWO |
-| `pvc-tautulli-config` | mediastack | 1Gi | longhorn | RWO |
 | `pvc-minecraft-datadir` | dmz | 20Gi | longhorn-dmz | RWX |
 | `portainer` | portainer | 1Gi | longhorn | RWO |
 | `minio` | minio | 75Gi | longhorn | RWO |
@@ -644,18 +633,18 @@ velero restore create --from-backup <backup-name>
 | CPU | req: 50m, limits: 200m |
 | Memory | req: 64Mi, limits: 128Mi |
 
-Two separate tunnels are deployed — one per externally-accessible media service, for independent blast-radius and revocability.
+**Four independent tunnels are deployed** — one per externally-accessible service, for independent
+blast-radius and revocability: `cloudflared-jellyfin` and `cloudflared-audiobookshelf` in
+`mediastack`, `cloudflared-nginx` in `ingress-nginx`, and `cloudflared-authentik` in `authentik`.
 
-#### cloudflared (Plex tunnel)
+A fifth, the original bare `cloudflared` Deployment, served the Plex tunnel and was removed with
+Plex on 2026-05-09.
 
-| Parameter | Value |
-|---|---|
-| Deployment | `cloudflared` in `mediastack` |
-| Tunnel token | ExternalSecret `cloudflared-tunnel-credentials` (1Password: "Cloudflare Tunnel Token - vollminlab") |
-
-| Hostname | Internal target |
-|---|---|
-| `plex.vollminlab.com` | `http://plex.mediastack.svc.cluster.local:32400` |
+> **A cloudflared tunnel needs two egress rules, not one.** Reaching the Cloudflare edge (7844) and
+> reaching the tunnel's *origin* are separate hops, and only the first fails loudly — the Cloudflare
+> dashboard shows the tunnel healthy while every request 502s. LAN clients mask this completely,
+> because Pi-hole's A-record override sends them straight to the ingress VIP and never through the
+> tunnel, so the breakage is visible only from outside. This went unnoticed for ~68 days.
 
 #### cloudflared-jellyfin (Jellyfin tunnel)
 
@@ -749,8 +738,6 @@ per-namespace port table.
 | sabnzbd | https://sabnzbd.vollminlab.com |
 | prowlarr | https://prowlarr.vollminlab.com |
 | bazarr | https://bazarr.vollminlab.com |
-| overseerr | https://overseerr.vollminlab.com |
-| tautulli | https://tautulli.vollminlab.com |
 | portainer | https://portainer.vollminlab.com |
 | shlink | https://shlink.vollminlab.com |
 
@@ -760,7 +747,6 @@ per-namespace port table.
 |---|---|
 | pihole | https://pihole.vollminlab.com |
 | npm | https://npm.vollminlab.com |
-| plex | https://plex.vollminlab.com |
 | truenas | https://truenas.vollminlab.com |
 | udm | https://udm.vollminlab.com |
 | vcenter | https://vcenter.vollminlab.com |
@@ -830,7 +816,7 @@ Operator deployed in `cnpg-system`. Manages PostgreSQL clusters in other namespa
 
 ## Media Stack
 
-All apps in the `mediastack` namespace. Shared SMB storage mounted at the namespace level. App configs stored on Longhorn (5Gi RWO each, except Tautulli at 1Gi).
+All apps in the `mediastack` namespace. Shared SMB storage mounted at the namespace level. App configs stored on Longhorn.
 
 ### Sonarr (TV automation)
 
@@ -881,15 +867,6 @@ All apps in the `mediastack` namespace. Shared SMB storage mounted at the namesp
 | Config PVC | 5Gi Longhorn RWO |
 | Volumes | pvc-movies (RWX), pvc-tv (RWX) |
 
-### Overseerr (Media requests)
-
-| Parameter | Value |
-|---|---|
-| Source | OCIRepository |
-| Ingress | `overseerr.vollminlab.com` |
-| Port | 5055 |
-| Config PVC | 5Gi Longhorn RWO |
-
 ### Jellyfin (Media server)
 
 | Parameter | Value |
@@ -901,32 +878,10 @@ All apps in the `mediastack` namespace. Shared SMB storage mounted at the namesp
 | Config PVC | `pvc-jellyfin-config` 20Gi Longhorn RWO |
 | Volumes | `pvc-movies` at `/movies` (RWX), `pvc-tv` at `/tv` (RWX) |
 | UID/GID | 568 |
-| External access | Cloudflare Tunnel via `cloudflared-jellyfin` Deployment (separate from Plex tunnel) |
+| External access | Cloudflare Tunnel via `cloudflared-jellyfin` Deployment (one of four independent tunnels) |
 | Security gate | Jellyfin built-in auth only — no Cloudflare Access (native apps require no browser challenge) |
 | Public signup | Disabled — accounts created manually by admin |
 | Hardware transcoding | Deferred — CPU only for initial deployment |
-
-### Plex (Media server)
-
-| Parameter | Value |
-|---|---|
-| Chart | TrueCharts plex 22.1.2 (OCIRepository) |
-| Ingress | `plex.vollminlab.com` |
-| Port | 32400 |
-| Config PVC | 20Gi Longhorn RWO |
-| Volumes | pvc-movies (RWX), pvc-tv (RWX) |
-| Allowed networks | `172.16.0.0/12, 10.0.0.0/8, 192.168.0.0/16` |
-| External access | Cloudflare Tunnel via cloudflared (see Infrastructure Services) |
-| Notes | Claim server via web UI on first launch from same-LAN browser |
-
-### Tautulli (Plex monitoring)
-
-| Parameter | Value |
-|---|---|
-| Chart version | v11.3.1 |
-| Ingress | `tautulli.vollminlab.com` |
-| Port | 8181 |
-| Config PVC | 1Gi Longhorn RWO |
 
 ### Shared Secrets
 
@@ -956,7 +911,7 @@ All apps in the `mediastack` namespace. Shared SMB storage mounted at the namesp
 
 | Group | Services |
 |---|---|
-| Media Stack | Plex, Overseerr, Tautulli, Sonarr, Radarr, Prowlarr, SABnzbd |
+| Media Stack | Jellyfin, Jellystat, Seerr, Sonarr, Radarr, Readarr, Bazarr, Prowlarr, SABnzbd, qBittorrent, Audiobookshelf |
 | Infrastructure | Pi-hole, TrueNAS, vCenter, Portainer, Nginx Proxy Manager, UDM, HAProxy stats |
 | Monitoring | Grafana, Prometheus |
 | Documentation | BookStack, Homepage, GitHub repo, ChatGPT, Reddit, Chocolatey |

--- a/scripts/check-doc-currency.sh
+++ b/scripts/check-doc-currency.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# Doc currency checks.
+#
+# Runs unconditionally in CI on every PR, with no tooling and no cluster access.
+# It only compares directories on disk to the text of two documents.
+#
+# WHY IT RUNS UNCONDITIONALLY: the drift this exists to catch comes from the
+# *other* file changing. Plex was deleted from clusters/ on 2026-05-09 and
+# docs/roadmap.md went on describing it as running for 3.5 months. A check
+# path-filtered to the docs would never have fired — it would have been inert in
+# exactly the case it exists for, which is the same failure as a Kyverno policy
+# whose foreach.list resolves to null and reports zero fails because it evaluates
+# nothing.
+#
+# WHAT THIS CANNOT CATCH: prose. Four of the six stale statuses found in the
+# 2026-08-22 audit were sentences, not status fields — "deployed alongside Plex",
+# a section titled "Tautulli / Plex Metrics Dashboard", "SealedSecret changes
+# trigger restarts". No string comparison finds those. Check 3 (staleness) is the
+# only defence there, and it is a prompt for a human to re-read, not a test.
+#
+# Deliberately exact, with no heuristics. A doc check that guesses produces false
+# failures, gets bypassed, and then reports green while measuring nothing.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+REFERENCE="docs/cluster-reference.md"
+ROADMAP="docs/roadmap.md"
+EXEMPT="docs/.cluster-reference-exempt"
+RETIRED="docs/.retired-components"
+
+STALE_WARN_DAYS=90
+STALE_FAIL_DAYS=180
+
+fail=0
+warn=0
+
+err()  { printf '::error::%s\n' "$1"; fail=1; }
+note() { printf '::warning::%s\n' "$1"; warn=1; }
+
+# ---------------------------------------------------------------------------
+# Check 1 — every app directory is documented in the configuration reference
+#
+# CLAUDE.md calls cluster-reference.md the "Full configuration reference".
+# On 2026-08-22 it was missing 46 of 93 app directories — half the cluster was
+# absent from the document every session is pointed at.
+#
+# The exemption file is a baseline, not an allowlist: it was seeded with those
+# 46 so this check passes on the day it lands and fails for anything NEW. It is
+# meant to shrink to empty. Do not add to it to silence a failure on a new app —
+# document the app instead.
+# ---------------------------------------------------------------------------
+[[ -f "$REFERENCE" ]] || { err "$REFERENCE is missing"; exit 1; }
+
+undocumented=()
+while IFS= read -r dir; do
+    name="$(basename "$dir")"
+    case "$name" in
+        networkpolicies|repositories|flux-kustomizations|secrets|pvcs) continue ;;
+    esac
+    grep -qiF -- "$name" "$REFERENCE" && continue
+    grep -qxF -- "$name" "$EXEMPT" 2>/dev/null && continue
+    undocumented+=("$name")
+done < <(find clusters -mindepth 3 -maxdepth 3 -type d ! -name app | sort)
+
+if (( ${#undocumented[@]} > 0 )); then
+    err "app directories absent from $REFERENCE: ${undocumented[*]}"
+    err "add each to $REFERENCE in this PR — see .claude/rules/docs.md"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 2 — retired components stay retired
+#
+# Two directions, both exact:
+#   a) a retired component must not reappear as a live app directory
+#   b) a retired component must not be described in the configuration reference,
+#      which documents what IS running
+#
+# The roadmap is deliberately NOT checked here. It is a historical record as well
+# as a plan, and it should be free to describe the Plex era in the past tense.
+# ---------------------------------------------------------------------------
+if [[ -f "$RETIRED" ]]; then
+    while IFS= read -r name; do
+        [[ -z "$name" || "$name" == \#* ]] && continue
+        if find clusters -mindepth 3 -maxdepth 3 -type d -name "$name" | grep -q .; then
+            err "'$name' is listed in $RETIRED but a live app directory exists for it"
+        fi
+        # Only TABLE ROWS are checked, not prose. The tables in this document are
+        # inventory — they assert what exists — so a retired component appearing in
+        # one is a factual error. Prose may legitimately discuss history, e.g. the
+        # note that bootstrap/sealed-secrets/ is kept as historical DR reference.
+        if grep -niF -- "$name" "$REFERENCE" | grep -qE '^[0-9]+:\s*\|'; then
+            err "'$name' is retired but still listed in an inventory table in $REFERENCE:"
+            grep -niF -- "$name" "$REFERENCE" | grep -E '^[0-9]+:\s*\|' | sed 's/^/    /'
+        fi
+    done < "$RETIRED"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 3 — the roadmap has been re-read against reality recently
+#
+# The only defence against prose drift. Not a test — a prompt to go and look.
+# ---------------------------------------------------------------------------
+if [[ -f "$ROADMAP" ]]; then
+    verified="$(grep -oiE 'Last verified against the live cluster: [0-9]{4}-[0-9]{2}-[0-9]{2}' "$ROADMAP" \
+                | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | head -1 || true)"
+    if [[ -z "$verified" ]]; then
+        err "$ROADMAP has no 'Last verified against the live cluster: YYYY-MM-DD' line"
+    else
+        age=$(( ( $(date -u +%s) - $(date -u -d "$verified" +%s) ) / 86400 ))
+        if   (( age >= STALE_FAIL_DAYS )); then
+            err "$ROADMAP was last verified $age days ago (>= $STALE_FAIL_DAYS). Re-read it against the live cluster and update the date."
+        elif (( age >= STALE_WARN_DAYS )); then
+            note "$ROADMAP was last verified $age days ago (>= $STALE_WARN_DAYS). Worth a pass soon."
+        fi
+    fi
+fi
+
+if (( fail )); then
+    echo "doc currency checks FAILED"
+    exit 1
+fi
+(( warn )) && echo "doc currency checks passed with warnings"
+echo "doc currency checks passed"


### PR DESCRIPTION
**Stacked on #1200** (base branch is `fix/cluster-reference-retired-services`). **Also needs #1196 merged** — check 3 reads the `Last verified` line that PR adds to the roadmap. Merge order: #1196 and #1200 in either order, then this.

## What it does

`scripts/check-doc-currency.sh`, run as a **step in the existing CI job** — same placement and rationale as `check-readme-structure.sh`, so it blocks merges through the current required check instead of needing a new entry in branch protection. No tooling, no secrets, no cluster access.

| # | Check | Fails on |
|---|---|---|
| 1 | Every app directory appears in `cluster-reference.md` | a new app shipped without documenting it |
| 2 | Retired components stay retired | a removed component reappearing as a directory, or lingering in an inventory table row |
| 3 | `roadmap.md` has a `Last verified` date | absent, or older than 180 days (warns at 90) |

## The baseline file is a ratchet

`docs/.cluster-reference-exempt` is seeded with the **41** app directories currently missing from the reference, so this lands without a mass-documentation PR. It is meant to shrink to empty — backfill tracked separately. The file says, and `.claude/rules/docs.md` repeats: **do not add a new app here to silence a failure.**

## Why it is not path-filtered

**The drift comes from the _other_ file changing.** Plex was deleted from `clusters/` on 2026-05-09 and both documents described it as running for 3.5 months afterwards. A check gated on `docs/**` would never have fired — inert in exactly the case it exists for, which is the same failure mode as a Kyverno rule whose `foreach.list` resolves to null and reports zero fails because it evaluates nothing.

## Verified, not assumed

```
check with #1196 roadmap present  →  doc currency checks passed        exit=0
pretend plex came back            →  'plex' is listed in .retired-components
                                      but a live app directory exists for it
undocumented new app directory    →  app directories absent from
                                      docs/cluster-reference.md: newthing
```

## What it cannot catch, stated in the script and the rules

**Prose.** Four of the six stale roadmap statuses were sentences, not status fields — "deployed alongside Plex", a section titled "Tautulli / Plex Metrics Dashboard", "SealedSecret changes trigger restarts". No string comparison finds those. Check 3 is the only defence and it is a prompt for a human to re-read, not a test. The rules file says explicitly: do not move the date without doing the reading.

## `.claude/rules/docs.md`

Answers which document a change belongs in, with the table that keeps the roadmap a *plan* rather than an inventory:

- **A new app directory updates `cluster-reference.md` in the same PR** — every deployment.
- **A PR that changes what a roadmap phase _means_ updates `roadmap.md` in the same PR** — completions, drops, splits. **Not** every deployment.

The second rule is deliberate. Most app directories here were never on a plan — `longhorn-trim`, `velero-pvb-healer`, `longhorn-mount-healer`, `vcenter-credential-age` are all incident responses. Roadmapping them retroactively fabricates a plan that never existed and makes the roadmap a second copy of the reference, which is the duplication that caused this.

Linked from CLAUDE.md's essential-reading list.