### PR TITLE
refactor(foundry): move the Ingress to a standalone manifest

### DIFF
--- a/clusters/vollminlab-cluster/foundry/foundry/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/foundry/foundry/app/configmap.yaml
@@ -53,41 +53,13 @@ data:
       type: ClusterIP
       port: 80
 
+    # The chart CAN render an Ingress, but this repo keeps Ingresses as standalone
+    # manifests (ingress.yaml) so they are greppable in git and are not re-submitted
+    # to the API server by CI's HelmRelease dry-run. Disabling it here costs the
+    # three FOUNDRY_* proxy env vars the chart only emits alongside its own Ingress,
+    # so the HelmRelease re-injects them via postRenderers. See ingress.yaml.
     ingress:
-      enabled: true
-      className: nginx
-      annotations:
-        nginx.ingress.kubernetes.io/ssl-redirect: "false"
-        # 0 = unlimited, so large map/audio uploads work from the LAN. Cloudflare
-        # still caps uploads THROUGH THE TUNNEL at 100 MB and a tunnel hostname
-        # cannot be un-proxied, so upload big assets on the LAN (Pi-hole points
-        # LAN clients at the ingress VIP, bypassing the tunnel).
-        nginx.ingress.kubernetes.io/proxy-body-size: "0"
-        nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-        nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
-        nginx.ingress.kubernetes.io/proxy-buffering: "off"
-        nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
-        nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
-        nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
-        nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=https://$http_host$escaped_request_uri"
-        nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
-        nginx.ingress.kubernetes.io/auth-snippet: |
-          proxy_set_header X-Forwarded-Host $http_host;
-        shlink.vollminlab.com/slug: foundry
-      hosts:
-        - host: foundry.vollminlab.com
-          paths:
-            - path: /
-              pathType: Prefix
-      # A NON-EMPTY tls list is what makes the chart emit FOUNDRY_PROXY_SSL=true
-      # and FOUNDRY_PROXY_PORT=443. Without it Foundry hands out broken
-      # http://...:30000 invite links. The wildcard-tls Secret does not exist in
-      # this namespace and does not need to: ingress-nginx runs with
-      # --default-ssl-certificate=cert-manager/wildcard-tls.
-      tls:
-        - hosts:
-            - foundry.vollminlab.com
-          secretName: wildcard-tls
+      enabled: false
 
     # Kyverno require-resources: requests for cpu+memory and a memory limit are
     # mandatory. A CPU limit is deliberately omitted per .claude/rules/kyverno.md.

--- a/clusters/vollminlab-cluster/foundry/foundry/app/helmrelease.yaml
+++ b/clusters/vollminlab-cluster/foundry/foundry/app/helmrelease.yaml
@@ -22,3 +22,30 @@ spec:
     - kind: ConfigMap
       name: foundry-values
       valuesKey: values.yaml
+  # The chart only emits these three alongside its own Ingress, which is disabled
+  # in configmap.yaml because this repo keeps Ingresses as standalone manifests.
+  # Without them Foundry advertises http://<pod>:30000 and every invitation link
+  # is unreachable. Pod-template env is mutable, so this patch is upgrade-safe.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: StatefulSet
+              name: foundry
+            patch: |
+              apiVersion: apps/v1
+              kind: StatefulSet
+              metadata:
+                name: foundry
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: foundryvtt
+                        env:
+                          - name: FOUNDRY_HOSTNAME
+                            value: foundry.vollminlab.com
+                          - name: FOUNDRY_PROXY_SSL
+                            value: "true"
+                          - name: FOUNDRY_PROXY_PORT
+                            value: "443"

--- a/clusters/vollminlab-cluster/foundry/foundry/app/ingress.yaml
+++ b/clusters/vollminlab-cluster/foundry/foundry/app/ingress.yaml
@@ -1,0 +1,44 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: foundry-ingress
+  namespace: foundry
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    # 0 = unlimited, so large map/audio uploads work from the LAN. Cloudflare
+    # still caps uploads THROUGH THE TUNNEL at 100 MB and a tunnel hostname
+    # cannot be un-proxied, so upload big assets on the LAN (Pi-hole points
+    # LAN clients at the ingress VIP, bypassing the tunnel).
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://authentik.vollminlab.com/outpost.goauthentik.io/start?rd=https://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/auth-snippet: |
+      proxy_set_header X-Forwarded-Host $http_host;
+    shlink.vollminlab.com/slug: foundry
+  labels:
+    app: foundry
+    env: production
+    category: gaming
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: foundry.vollminlab.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: foundry
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - foundry.vollminlab.com
+      secretName: wildcard-tls

--- a/clusters/vollminlab-cluster/foundry/foundry/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/foundry/foundry/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - foundry-credentials-externalsecret.yaml
   - configmap.yaml
   - helmrelease.yaml
+  - ingress.yaml


### PR DESCRIPTION
Foundry was the only app of 35 whose Helm chart rendered its own Ingress. This moves it to a standalone `ingress.yaml`, matching every other app.

## Why

**Consistency, and it isn't cosmetic.** A standalone Ingress is a file in git, so it's visible to the grep-based audits this repo depends on — CLAUDE.md's "28 of 34 Ingresses carry a slug" measurement cannot see a chart-rendered one. The same applies to any future sweep of Authentik annotations, TLS secrets or proxy timeouts.

**It also fixes a CI failure at source.** CI's server-side dry-run only processes `kind: HelmRelease` files, so a standalone `ingress.yaml` never reaches it. A chart-rendered one does, and ingress-nginx's webhook rejects a host+path another Ingress already owns in any namespace — which, once deployed, is the app's own live Ingress. #1198 (an unrelated VolSync change) failed exactly this way. After this, #1198 needs no CI workaround.

## The catch, and how it's handled

The chart only emits `FOUNDRY_HOSTNAME`, `FOUNDRY_PROXY_SSL` and `FOUNDRY_PROXY_PORT` alongside its own Ingress, and offers no `extraEnv`:

```
{{- else if .Values.ingress.enabled }}
    FOUNDRY_HOSTNAME
    {{- with (first .Values.ingress.tls) }} FOUNDRY_PROXY_SSL / FOUNDRY_PROXY_PORT {{- end }}
{{- end }}
```

Without them Foundry advertises `http://<pod>:30000` and every invitation link is unreachable. So the HelmRelease re-injects them with a `postRenderers` strategic-merge patch, in the same style metallb already uses. Pod-template env is mutable, so this is upgrade-safe — unlike the `volumeClaimTemplates` label case in #1198, which genuinely cannot be patched.

## Verification

- Chart render now emits **0** `kind: Ingress` documents; `containerPort: 30000` and the `foundry` object names unchanged.
- postRenderer simulated through `kustomize build`: container env goes **14 → 17**, the three added with correct values, and **nothing dropped** — `FOUNDRY_USERNAME`, `FOUNDRY_PASSWORD`, `FOUNDRY_ADMIN_KEY`, `FOUNDRY_LICENSE_KEY`, `FOUNDRY_LOCAL_HOSTNAME` and every `CONTAINER_*` var survive the merge. Targets container `foundryvtt` (the chart uses `.Chart.Name`, which `nameOverride` does not change).
- New `ingress.yaml` carries all 12 annotations the chart was rendering, verified programmatically against the old values block. Backend uses the **Service** port 80, not the container port.
- `check-helm-values.py` → 0 problems. `kubectl kustomize clusters/vollminlab-cluster/foundry` builds and contains `foundry-ingress`.

## ⚠️ Merging this causes a brief outage — read before merging

The live Ingress is `foundry` (Helm-owned). This PR creates `foundry-ingress` and removes the Helm one. They cannot coexist: the webhook rejects the second with the same host+path.

Likely sequence: kustomize-controller applies the new Ingress → **rejected** while the Helm one still exists → helm-controller upgrades and removes the Helm one → nothing serves the host until kustomize-controller retries, up to its 10m interval.

So expect Foundry to 404 for a few minutes. To cut that short, right after the Helm upgrade completes:

```bash
flux reconcile kustomization foundry --with-source
kubectl get ingress -n foundry     # expect exactly one: foundry-ingress
```

Worth doing when nobody is mid-session. No data is at risk — this touches only routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Fuk2t1KKrrLikj2xghzn9