### PR TITLE
feat(monitoring): catch silent LAN AAAA leaks on tunnel-exposed hosts

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/dns-aaaa-check/app/check.sh
+++ b/clusters/vollminlab-cluster/monitoring/dns-aaaa-check/app/check.sh
@@ -1,0 +1,113 @@
+#!/bin/sh
+# dns-aaaa-check: detect a silent split-horizon DNS leak.
+#
+# Split-horizon DNS on this cluster is A-only: Pi-hole holds a local A record
+# for every Ingress host, pointing at the ingress VIP, so LAN clients reach
+# nginx directly. AAAA is left to forward upstream. For the handful of hosts
+# that also have a Cloudflare tunnel CNAME, upstream returns Cloudflare's
+# proxied IPv6 -- so an IPv6-capable LAN client hairpins out through the
+# tunnel instead of hitting nginx directly. That adds a needless dependency
+# on the tunnel from the LAN and puts Cloudflare's 100MB request-body limit
+# in the path of LAN uploads that should never see it.
+#
+# The fix (append `local=/<host>/` to misc.dnsmasq_lines on pihole1) is hand-
+# maintained -- nothing creates it automatically when a new tunnel-exposed
+# Ingress appears, unlike the A record which external-dns creates for free.
+# This has recurred 5 times and is invisible from the LAN (browsers work
+# fine either way), so it is only observable from outside -- exactly how a
+# previous instance of this class of bug went unnoticed for 68 days. This
+# script makes it loud instead: list every Ingress host, ask Pi-hole for
+# AAAA, and fail loudly if anything answers. It does not touch Pi-hole.
+set -u
+
+PIHOLE_ADDR="${PIHOLE_ADDR:-192.168.100.4}"
+
+log() { echo "[$(date -u +%FT%TZ)] $*"; }
+
+# list_hosts: every distinct, non-empty Ingress host in the cluster, one per
+# line. Returns non-zero (and leaves nothing useful on stdout) if the kubectl
+# call itself fails -- that must NOT be reported as a clean pass.
+list_hosts() {
+  raw=$(kubectl get ingress -A -o jsonpath='{range .items[*]}{range .spec.rules[*]}{.host}{"\n"}{end}{end}' 2>&1)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "$raw" >&2
+    return 1
+  fi
+  printf '%s\n' "$raw" | sed '/^$/d' | sort -u
+}
+
+# aaaa_for_host: AAAA addresses nslookup returns for $1 against $PIHOLE_ADDR,
+# one per line. Empty output means no leak.
+#
+# nslookup exits 0 whether it finds an AAAA record, finds nothing, or hits
+# NXDOMAIN -- the exit code can NEVER be used to detect a leak, only the
+# parsed output can. `tail -n +3` skips the two header lines that name the
+# server itself (whose own "Address:" line is "<server>:53" and would
+# otherwise be misread as a leak).
+aaaa_for_host() {
+  host="$1"
+  nslookup -type=aaaa "$host" "$PIHOLE_ADDR" 2>/dev/null \
+    | tail -n +3 \
+    | awk '/^Address:/{print $2}' \
+    | grep -E '^[0-9a-fA-F:]+$'
+}
+
+main() {
+  log "dns-aaaa-check start (pihole=$PIHOLE_ADDR)"
+
+  if ! hosts=$(list_hosts); then
+    log "FAIL: kubectl get ingress failed -- see stderr above"
+    exit 1
+  fi
+
+  if [ -z "$hosts" ]; then
+    # This is not a clean result -- it means the query found nothing, which
+    # for a 30-Ingress cluster means the query itself is broken. A check that
+    # silently passes because it looked at nothing is the exact failure mode
+    # this job exists to prevent, so it must fail, not exit 0.
+    log "FAIL: no Ingress hosts found -- the query returned nothing, not a clean cluster"
+    exit 1
+  fi
+
+  host_count=$(printf '%s\n' "$hosts" | grep -c .)
+
+  leaking_hosts=""
+  leak_count=0
+  for host in $hosts; do
+    addrs=$(aaaa_for_host "$host")
+    if [ -n "$addrs" ]; then
+      leak_count=$((leak_count + 1))
+      leaking_hosts="$leaking_hosts $host"
+      log "LEAK: $host resolves AAAA via $PIHOLE_ADDR -> $(printf '%s' "$addrs" | tr '\n' ' ')"
+    fi
+  done
+
+  if [ "$leak_count" -eq 0 ]; then
+    log "OK: queried $host_count hosts, none leaking"
+    exit 0
+  fi
+
+  echo ""
+  echo "=== DNS AAAA LEAK: $leak_count of $host_count Ingress hosts return AAAA from Pi-hole ($PIHOLE_ADDR) ==="
+  echo "Each host below should be A-only on the LAN but resolves an upstream (Cloudflare) IPv6"
+  echo "address instead, so an IPv6-capable LAN client hairpins out through the tunnel."
+  echo ""
+  echo "Remediation -- pihole1 (192.168.100.2) ONLY, nebula-sync replicates to pihole2 hourly:"
+  echo "  1. Read the CURRENT array first -- misc.dnsmasq_lines is a REPLACE, not an append:"
+  echo "       ssh pihole1 sudo pihole-FTL --config misc.dnsmasq_lines"
+  echo "  2. Write it back with every existing entry carried forward, plus one new line per"
+  echo "     leaking host below:"
+  for host in $leaking_hosts; do
+    echo "       local=/$host/"
+  done
+  echo "     e.g.: sudo pihole-FTL --config misc.dnsmasq_lines '[ ...existing entries..., \"local=/<host>/\" ]'"
+  echo "  3. ssh pihole1 sudo pihole reloaddns"
+  echo "  4. nebula-sync (hourly cron) replicates pihole1 -> pihole2 -- no action needed there"
+  echo ""
+
+  log "dns-aaaa-check done: $leak_count of $host_count hosts leaking"
+  exit 1
+}
+
+[ -n "${DNS_AAAA_CHECK_TEST:-}" ] || main "$@"

--- a/clusters/vollminlab-cluster/monitoring/dns-aaaa-check/app/check.sh
+++ b/clusters/vollminlab-cluster/monitoring/dns-aaaa-check/app/check.sh
@@ -21,6 +21,9 @@
 set -u
 
 PIHOLE_ADDR="${PIHOLE_ADDR:-192.168.100.4}"
+# Any name that is guaranteed to have a real AAAA record. Queried before the
+# host loop as a canary -- see canary_check() for why.
+CANARY_HOST="${CANARY_HOST:-cloudflare.com}"
 
 log() { echo "[$(date -u +%FT%TZ)] $*"; }
 
@@ -38,23 +41,64 @@ list_hosts() {
 }
 
 # aaaa_for_host: AAAA addresses nslookup returns for $1 against $PIHOLE_ADDR,
-# one per line. Empty output means no leak.
+# one per line, on stdout. Empty output means no leak -- but the caller MUST
+# also check the exit status ($?), not just whether stdout is empty.
 #
 # nslookup exits 0 whether it finds an AAAA record, finds nothing, or hits
-# NXDOMAIN -- the exit code can NEVER be used to detect a leak, only the
-# parsed output can. `tail -n +3` skips the two header lines that name the
-# server itself (whose own "Address:" line is "<server>:53" and would
-# otherwise be misread as a leak).
+# NXDOMAIN -- measured against the live Pi-hole 2026-08-22 -- and exits
+# non-zero ONLY when the resolver itself could not be reached. So rc is a
+# reliable resolver-failure signal, but only if it is captured directly from
+# nslookup: reading $? after the pipe below would instead get awk/grep's
+# status (0 if a line matched, 1 if not), which can never distinguish "no
+# AAAA" from "no answer at all". That is why raw output is captured first,
+# with rc read immediately, before it is ever piped anywhere.
+#
+# `tail -n +3` skips the two header lines that name the server itself (whose
+# own "Address:" line is "<server>:53" and would otherwise be misread as a
+# leak).
 aaaa_for_host() {
-  host="$1"
-  nslookup -type=aaaa "$host" "$PIHOLE_ADDR" 2>/dev/null \
-    | tail -n +3 \
-    | awk '/^Address:/{print $2}' \
-    | grep -E '^[0-9a-fA-F:]+$'
+  raw=$(nslookup -type=aaaa "$1" "$PIHOLE_ADDR" 2>/dev/null)
+  rc=$?
+  [ "$rc" -eq 0 ] || return "$rc"
+  printf '%s\n' "$raw" | tail -n +3 | awk '/^Address:/{print $2}' | grep -E '^[0-9a-fA-F:]+$'
+  # Explicit return 0, not left implicit: without it, the function's own exit
+  # status would be grep's -- 1 whenever nothing matched, i.e. on every
+  # genuinely clean host -- which would make a clean result indistinguishable
+  # from a resolver failure to any caller checking $?. That is the exact bug
+  # this function exists to prevent, just one level further down.
+  return 0
+}
+
+# canary_check: confirm the resolver can produce an AAAA for a name that
+# definitely has one, before trusting a "no AAAA" result for anything else.
+#
+# Without this, a Pi-hole that is down or unreachable looks EXACTLY like a
+# clean cluster: nslookup's timeout/no-answer output never matches
+# "^Address:", so aaaa_for_host() returns empty either way, and the run would
+# report "OK: none leaking" -- a false all-clear produced by this monitoring
+# job's own dependency failing, which is precisely the class of silent-pass
+# this job exists to catch. Checking this first also fails fast: an
+# unreachable resolver costs nslookup ~10s per query in retries, so finding
+# out up front avoids burning ~5 minutes discovering it one host at a time
+# across ~30 hosts.
+canary_check() {
+  addrs=$(aaaa_for_host "$CANARY_HOST")
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    log "FAIL: canary lookup for $CANARY_HOST via $PIHOLE_ADDR failed (nslookup rc=$rc) -- resolver is unreachable, refusing to trust any 'no AAAA' result from it"
+    return 1
+  fi
+  if [ -z "$addrs" ]; then
+    log "FAIL: canary $CANARY_HOST returned no AAAA via $PIHOLE_ADDR, but it has one -- resolver answered but is not trustworthy right now"
+    return 1
+  fi
+  return 0
 }
 
 main() {
-  log "dns-aaaa-check start (pihole=$PIHOLE_ADDR)"
+  log "dns-aaaa-check start (pihole=$PIHOLE_ADDR canary=$CANARY_HOST)"
+
+  canary_check || exit 1
 
   if ! hosts=$(list_hosts); then
     log "FAIL: kubectl get ingress failed -- see stderr above"
@@ -74,8 +118,22 @@ main() {
 
   leaking_hosts=""
   leak_count=0
+  error_hosts=""
+  error_count=0
   for host in $hosts; do
     addrs=$(aaaa_for_host "$host")
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+      # The resolver failed for this one host specifically (mid-run outage,
+      # or a single flaky query) even though the canary passed at startup.
+      # This must never be folded into "clean" -- an unanswered query and a
+      # genuinely absent AAAA record are indistinguishable by output alone,
+      # so an unanswered query has to be reported as its own outcome.
+      error_count=$((error_count + 1))
+      error_hosts="$error_hosts $host"
+      log "ERROR: resolver failed for $host via $PIHOLE_ADDR (nslookup rc=$rc) -- not counted as clean"
+      continue
+    fi
     if [ -n "$addrs" ]; then
       leak_count=$((leak_count + 1))
       leaking_hosts="$leaking_hosts $host"
@@ -83,30 +141,43 @@ main() {
     fi
   done
 
-  if [ "$leak_count" -eq 0 ]; then
+  if [ "$leak_count" -eq 0 ] && [ "$error_count" -eq 0 ]; then
     log "OK: queried $host_count hosts, none leaking"
     exit 0
   fi
 
-  echo ""
-  echo "=== DNS AAAA LEAK: $leak_count of $host_count Ingress hosts return AAAA from Pi-hole ($PIHOLE_ADDR) ==="
-  echo "Each host below should be A-only on the LAN but resolves an upstream (Cloudflare) IPv6"
-  echo "address instead, so an IPv6-capable LAN client hairpins out through the tunnel."
-  echo ""
-  echo "Remediation -- pihole1 (192.168.100.2) ONLY, nebula-sync replicates to pihole2 hourly:"
-  echo "  1. Read the CURRENT array first -- misc.dnsmasq_lines is a REPLACE, not an append:"
-  echo "       ssh pihole1 sudo pihole-FTL --config misc.dnsmasq_lines"
-  echo "  2. Write it back with every existing entry carried forward, plus one new line per"
-  echo "     leaking host below:"
-  for host in $leaking_hosts; do
-    echo "       local=/$host/"
-  done
-  echo "     e.g.: sudo pihole-FTL --config misc.dnsmasq_lines '[ ...existing entries..., \"local=/<host>/\" ]'"
-  echo "  3. ssh pihole1 sudo pihole reloaddns"
-  echo "  4. nebula-sync (hourly cron) replicates pihole1 -> pihole2 -- no action needed there"
-  echo ""
+  if [ "$error_count" -gt 0 ]; then
+    echo ""
+    echo "=== DNS AAAA CHECK INCOMPLETE: resolver failed for $error_count of $host_count hosts ==="
+    echo "The hosts below got no answer from Pi-hole at all -- that is NOT the same as a clean"
+    echo "'no AAAA record' result. They were skipped, not cleared, and need a re-check:"
+    for host in $error_hosts; do
+      echo "  $host"
+    done
+    echo ""
+  fi
 
-  log "dns-aaaa-check done: $leak_count of $host_count hosts leaking"
+  if [ "$leak_count" -gt 0 ]; then
+    echo ""
+    echo "=== DNS AAAA LEAK: $leak_count of $host_count Ingress hosts return AAAA from Pi-hole ($PIHOLE_ADDR) ==="
+    echo "Each host below should be A-only on the LAN but resolves an upstream (Cloudflare) IPv6"
+    echo "address instead, so an IPv6-capable LAN client hairpins out through the tunnel."
+    echo ""
+    echo "Remediation -- pihole1 (192.168.100.2) ONLY, nebula-sync replicates to pihole2 hourly:"
+    echo "  1. Read the CURRENT array first -- misc.dnsmasq_lines is a REPLACE, not an append:"
+    echo "       ssh pihole1 sudo pihole-FTL --config misc.dnsmasq_lines"
+    echo "  2. Write it back with every existing entry carried forward, plus one new line per"
+    echo "     leaking host below:"
+    for host in $leaking_hosts; do
+      echo "       local=/$host/"
+    done
+    echo "     e.g.: sudo pihole-FTL --config misc.dnsmasq_lines '[ ...existing entries..., \"local=/<host>/\" ]'"
+    echo "  3. ssh pihole1 sudo pihole reloaddns"
+    echo "  4. nebula-sync (hourly cron) replicates pihole1 -> pihole2 -- no action needed there"
+    echo ""
+  fi
+
+  log "dns-aaaa-check done: $leak_count leaking, $error_count resolver error(s) of $host_count hosts"
   exit 1
 }
 

--- a/clusters/vollminlab-cluster/monitoring/dns-aaaa-check/app/check_test.sh
+++ b/clusters/vollminlab-cluster/monitoring/dns-aaaa-check/app/check_test.sh
@@ -4,9 +4,10 @@
 # Stubs kubectl and nslookup as real executables on PATH (PATH shims in a temp
 # dir), not shell-function overrides -- check.sh calls them directly exactly as
 # it will in the CronJob pod, so this exercises the real subprocess/pipe/
-# exit-code boundaries (nslookup's "always exits 0" behavior in particular)
-# instead of an approximation of them. Mirrors the shape of
-# velero/velero-pvb-healer/app/heal_test.sh (stub, assert, no cluster needed).
+# exit-code boundaries (nslookup's "always exits 0 except when unreachable"
+# behavior in particular) instead of an approximation of them. Mirrors the
+# shape of velero/velero-pvb-healer/app/heal_test.sh (stub, assert, no
+# cluster needed).
 set -u
 HERE=$(dirname "$0")
 HERE=$(cd "$HERE" && pwd)
@@ -33,10 +34,27 @@ chmod +x "$STUBDIR/kubectl"
 
 # Fake `nslookup -type=aaaa <host> <server>`. Emits real nslookup-shaped
 # output: two header lines naming the server (which check.sh's tail -n +3
-# must skip), then either an AAAA Address: line (leak, if $host is listed in
-# STUB_LEAK_HOSTS) or an NXDOMAIN body (clean) -- and always exits 0 either
-# way, exactly like real nslookup, which is the whole reason check.sh must
-# parse output and can never trust $?.
+# must skip), then either an AAAA Address: line (leak) or an NXDOMAIN body
+# (clean) -- exiting 0 in both cases, exactly like real nslookup.
+#
+# Three independent failure knobs, matched to check.sh's three distinct
+# failure paths:
+#   STUB_RESOLVER_DOWN=true   -- EVERY query fails, canary included (total
+#                                 outage; caught by the canary before any
+#                                 host is even listed).
+#   STUB_CANARY_FAIL=true     -- only the canary host's query fails to reach
+#                                 the server (rc=1).
+#   STUB_CANARY_NO_AAAA=true  -- the canary's query succeeds (rc=0) but
+#                                 returns NXDOMAIN, simulating a resolver
+#                                 that answers but is not trustworthy.
+#   STUB_ERROR_HOSTS          -- space-separated real hosts (never the
+#                                 canary) whose query fails to reach the
+#                                 server, simulating the resolver dying
+#                                 partway through the host loop after the
+#                                 canary already passed.
+# A failing query prints nslookup's real "connection timed out" wording to
+# stderr and exits 1 -- never 0 -- because that is the one behavior check.sh
+# depends on to tell "resolver failed" from "genuinely no AAAA".
 cat > "$STUBDIR/nslookup" <<'SCRIPT'
 #!/bin/sh
 host=""
@@ -46,7 +64,35 @@ for a in "$@"; do
     *) [ -n "$host" ] || host="$a" ;;
   esac
 done
+
+fail() {
+  echo ";; connection timed out; no servers could be reached" >&2
+  exit 1
+}
+
+[ "${STUB_RESOLVER_DOWN:-false}" = "true" ] && fail
+
+canary="${STUB_CANARY_HOST:-cloudflare.com}"
 server="${STUB_PIHOLE_ADDR:-192.168.100.4}"
+
+if [ "$host" = "$canary" ]; then
+  [ "${STUB_CANARY_FAIL:-false}" = "true" ] && fail
+  echo "Server:    $server"
+  echo "Address:   $server:53"
+  echo ""
+  if [ "${STUB_CANARY_NO_AAAA:-false}" = "true" ]; then
+    echo "** server can't find $host: NXDOMAIN"
+  else
+    echo "Name:      $host"
+    echo "Address:   2606:4700:3033::6815:4479"
+  fi
+  exit 0
+fi
+
+for h in ${STUB_ERROR_HOSTS:-}; do
+  [ "$h" = "$host" ] && fail
+done
+
 echo "Server:    $server"
 echo "Address:   $server:53"
 echo ""
@@ -72,6 +118,13 @@ assert_contains() { # $1=haystack $2=needle $3=msg
        FAILS=$((FAILS + 1)) ;;
   esac
 }
+assert_not_contains() { # $1=haystack $2=needle $3=msg
+  case "$1" in
+    *"$2"*) printf 'FAIL - %s (output unexpectedly contained [%s])\n--- output ---\n%s\n--------------\n' "$3" "$2" "$1"
+       FAILS=$((FAILS + 1)) ;;
+    *) printf 'ok   - %s\n' "$3" ;;
+  esac
+}
 assert_rc() { # $1=actual $2=expected $3=msg
   if [ "$1" = "$2" ]; then printf 'ok   - %s\n' "$3"
   else printf 'FAIL - %s (rc got [%s] want [%s])\n' "$3" "$1" "$2"; FAILS=$((FAILS + 1)); fi
@@ -79,11 +132,17 @@ assert_rc() { # $1=actual $2=expected $3=msg
 
 # Everything the stubs read must be exported so it survives into the child
 # `sh check.sh` process and, from there, into the kubectl/nslookup it execs.
-export STUB_KUBECTL_FAIL STUB_KUBECTL_HOSTS STUB_LEAK_HOSTS STUB_PIHOLE_ADDR
+export STUB_KUBECTL_FAIL STUB_KUBECTL_HOSTS STUB_LEAK_HOSTS STUB_PIHOLE_ADDR \
+  STUB_RESOLVER_DOWN STUB_CANARY_FAIL STUB_CANARY_NO_AAAA STUB_ERROR_HOSTS STUB_CANARY_HOST
 STUB_KUBECTL_FAIL=false
 STUB_KUBECTL_HOSTS=""
 STUB_LEAK_HOSTS=""
 STUB_PIHOLE_ADDR="192.168.100.4"
+STUB_RESOLVER_DOWN=false
+STUB_CANARY_FAIL=false
+STUB_CANARY_NO_AAAA=false
+STUB_ERROR_HOSTS=""
+STUB_CANARY_HOST="cloudflare.com"
 
 chmod +x "$HERE/check.sh"
 
@@ -128,10 +187,10 @@ case "$OUT" in
     FAILS=$((FAILS + 1)) ;;
   *) printf 'ok   - %s\n' "clean host among two is not misreported as leaking" ;;
 esac
+STUB_LEAK_HOSTS=''
 
 # --- 3. zero hosts found: the query itself is broken, not a clean cluster ---
 STUB_KUBECTL_HOSTS=''
-STUB_LEAK_HOSTS=''
 run_check
 assert_rc "$RC" "1" "zero Ingress hosts is a failure, not a clean pass"
 assert_contains "$OUT" "no Ingress hosts found" "zero-hosts case names itself distinctly from the clean-pass message"
@@ -155,6 +214,61 @@ assert_rc "$RC" "1" "multiple leaking hosts still fail the run"
 assert_contains "$OUT" "2 of 3 Ingress hosts" "leak summary reports the correct leak/total counts"
 assert_contains "$OUT" "local=/a.vollminlab.com/" "first leaking host gets its own remediation line"
 assert_contains "$OUT" "local=/c.vollminlab.com/" "second leaking host gets its own remediation line"
+STUB_LEAK_HOSTS=''
+
+# --- 6. resolver totally unreachable: the canary must catch this BEFORE any
+#        host is checked, and it must never be reported as a clean pass ---
+STUB_KUBECTL_HOSTS='radarr.vollminlab.com
+sonarr.vollminlab.com
+'
+STUB_RESOLVER_DOWN=true
+run_check
+assert_rc "$RC" "1" "a totally unreachable resolver fails the run"
+assert_contains "$OUT" "resolver" "unreachable-resolver message names the resolver failure"
+assert_not_contains "$OUT" "none leaking" "unreachable resolver is never reported as 'none leaking'"
+STUB_RESOLVER_DOWN=false
+
+# --- 7. canary answers but has no AAAA for a host that definitely has one:
+#        the run must fail on the canary, before trusting any host result ---
+STUB_KUBECTL_HOSTS='radarr.vollminlab.com
+sonarr.vollminlab.com
+'
+STUB_CANARY_NO_AAAA=true
+run_check
+assert_rc "$RC" "1" "a failing canary fails the run"
+assert_contains "$OUT" "canary" "canary failure message identifies itself as the canary"
+assert_contains "$OUT" "$STUB_CANARY_HOST" "canary failure message names the canary host"
+assert_not_contains "$OUT" "OK: queried" "a failed canary short-circuits before any host is reported clean"
+STUB_CANARY_NO_AAAA=false
+
+# --- 8. canary passes, one real host leaks: canary must not mask or
+#        duplicate the leak report ---
+STUB_KUBECTL_HOSTS='radarr.vollminlab.com
+authentik.vollminlab.com
+'
+STUB_LEAK_HOSTS='authentik.vollminlab.com'
+run_check
+assert_rc "$RC" "1" "a leak is still reported when the canary passes"
+assert_contains "$OUT" "1 of 2 Ingress hosts" "leak count is exactly the one leaking host, canary not counted"
+# awk, not grep -c, so a line appearing more than once still fails clearly.
+leak_lines=$(printf '%s\n' "$OUT" | grep -c '^\[.*\] LEAK: authentik.vollminlab.com')
+assert_rc "$leak_lines" "1" "the leaking host is reported exactly once, not duplicated by the canary"
+assert_not_contains "$OUT" "LEAK: $STUB_CANARY_HOST" "the canary host itself is never reported as leaking"
+STUB_LEAK_HOSTS=''
+
+# --- 9. resolver dies partway through the host loop, after the canary
+#        already passed: the failing host must be named and not counted as
+#        clean, and the run must still fail ---
+STUB_KUBECTL_HOSTS='radarr.vollminlab.com
+sonarr.vollminlab.com
+'
+STUB_ERROR_HOSTS='sonarr.vollminlab.com'
+run_check
+assert_rc "$RC" "1" "a resolver failure mid-run still fails the whole run"
+assert_contains "$OUT" "ERROR: resolver failed for sonarr.vollminlab.com" "the specific host the resolver failed on is named"
+assert_not_contains "$OUT" "LEAK: sonarr.vollminlab.com" "an unanswered host is never reported as a leak"
+assert_not_contains "$OUT" "none leaking" "a partial resolver failure is never reported as a clean pass"
+STUB_ERROR_HOSTS=''
 
 if [ "$FAILS" -gt 0 ]; then printf '\n%s test(s) failed\n' "$FAILS"; exit 1; fi
 printf '\nall tests passed\n'

--- a/clusters/vollminlab-cluster/monitoring/dns-aaaa-check/app/check_test.sh
+++ b/clusters/vollminlab-cluster/monitoring/dns-aaaa-check/app/check_test.sh
@@ -1,0 +1,160 @@
+#!/bin/sh
+# Tests for check.sh. Run: sh check_test.sh
+#
+# Stubs kubectl and nslookup as real executables on PATH (PATH shims in a temp
+# dir), not shell-function overrides -- check.sh calls them directly exactly as
+# it will in the CronJob pod, so this exercises the real subprocess/pipe/
+# exit-code boundaries (nslookup's "always exits 0" behavior in particular)
+# instead of an approximation of them. Mirrors the shape of
+# velero/velero-pvb-healer/app/heal_test.sh (stub, assert, no cluster needed).
+set -u
+HERE=$(dirname "$0")
+HERE=$(cd "$HERE" && pwd)
+
+STUBDIR=$(mktemp -d)
+trap 'rm -rf "$STUBDIR"' EXIT
+
+# Fake `kubectl get ingress -A -o jsonpath=...`.
+# STUB_KUBECTL_FAIL=true simulates an apiserver/RBAC failure (nonzero exit,
+# something on stderr, nothing useful on stdout).
+# STUB_KUBECTL_HOSTS is printed verbatim as stdout otherwise -- one host per
+# line, blank for "found nothing".
+cat > "$STUBDIR/kubectl" <<'SCRIPT'
+#!/bin/sh
+if [ "${STUB_KUBECTL_FAIL:-false}" = "true" ]; then
+  echo "stub kubectl: Unauthorized" >&2
+  exit 1
+fi
+if [ -n "${STUB_KUBECTL_HOSTS:-}" ]; then
+  printf '%s' "$STUB_KUBECTL_HOSTS"
+fi
+SCRIPT
+chmod +x "$STUBDIR/kubectl"
+
+# Fake `nslookup -type=aaaa <host> <server>`. Emits real nslookup-shaped
+# output: two header lines naming the server (which check.sh's tail -n +3
+# must skip), then either an AAAA Address: line (leak, if $host is listed in
+# STUB_LEAK_HOSTS) or an NXDOMAIN body (clean) -- and always exits 0 either
+# way, exactly like real nslookup, which is the whole reason check.sh must
+# parse output and can never trust $?.
+cat > "$STUBDIR/nslookup" <<'SCRIPT'
+#!/bin/sh
+host=""
+for a in "$@"; do
+  case "$a" in
+    -*) ;;
+    *) [ -n "$host" ] || host="$a" ;;
+  esac
+done
+server="${STUB_PIHOLE_ADDR:-192.168.100.4}"
+echo "Server:    $server"
+echo "Address:   $server:53"
+echo ""
+leak=false
+for h in ${STUB_LEAK_HOSTS:-}; do
+  [ "$h" = "$host" ] && leak=true
+done
+if [ "$leak" = "true" ]; then
+  echo "Name:      $host"
+  echo "Address:   2606:4700:3033::abcd"
+else
+  echo "** server can't find $host: NXDOMAIN"
+fi
+exit 0
+SCRIPT
+chmod +x "$STUBDIR/nslookup"
+
+FAILS=0
+assert_contains() { # $1=haystack $2=needle $3=msg
+  case "$1" in
+    *"$2"*) printf 'ok   - %s\n' "$3" ;;
+    *) printf 'FAIL - %s (output did not contain [%s])\n--- output ---\n%s\n--------------\n' "$3" "$2" "$1"
+       FAILS=$((FAILS + 1)) ;;
+  esac
+}
+assert_rc() { # $1=actual $2=expected $3=msg
+  if [ "$1" = "$2" ]; then printf 'ok   - %s\n' "$3"
+  else printf 'FAIL - %s (rc got [%s] want [%s])\n' "$3" "$1" "$2"; FAILS=$((FAILS + 1)); fi
+}
+
+# Everything the stubs read must be exported so it survives into the child
+# `sh check.sh` process and, from there, into the kubectl/nslookup it execs.
+export STUB_KUBECTL_FAIL STUB_KUBECTL_HOSTS STUB_LEAK_HOSTS STUB_PIHOLE_ADDR
+STUB_KUBECTL_FAIL=false
+STUB_KUBECTL_HOSTS=""
+STUB_LEAK_HOSTS=""
+STUB_PIHOLE_ADDR="192.168.100.4"
+
+chmod +x "$HERE/check.sh"
+
+# check.sh is invoked as an executable (kernel shebang execve), never as
+# `sh check.sh`. Under busybox ash, `sh nslookup`-style bare-word lookups
+# prefer busybox's own built-in applets (both `sh` and `nslookup` are
+# busybox applets -- confirmed via `busybox --list`) over anything found by
+# searching $PATH, which would silently defeat the PATH stub above and mask
+# it with busybox's real nslookup implementation. Running check.sh as a file
+# forces the kernel to exec its #!/bin/sh shebang directly, sidestepping
+# that applet-preference entirely, so the stub is honored the same way
+# whether check_test.sh itself is run under dash or busybox ash.
+run_check() { # sets OUT and RC
+  OUT=$(PATH="$STUBDIR:$PATH" "$HERE/check.sh" 2>&1)
+  RC=$?
+}
+
+# --- 1. clean run: two hosts, neither leaks -> exit 0 ---
+STUB_KUBECTL_HOSTS='radarr.vollminlab.com
+sonarr.vollminlab.com
+'
+STUB_LEAK_HOSTS=''
+run_check
+assert_rc "$RC" "0" "clean run exits 0"
+assert_contains "$OUT" "queried 2 hosts, none leaking" "clean run distinguishes 'queried N, none leaking' from 'found nothing'"
+
+# --- 2. one leaking host -> exit non-zero, host + AAAA + remediation named ---
+STUB_KUBECTL_HOSTS='radarr.vollminlab.com
+authentik.vollminlab.com
+'
+STUB_LEAK_HOSTS='authentik.vollminlab.com'
+run_check
+assert_rc "$RC" "1" "a leaking host makes the run fail"
+assert_contains "$OUT" "authentik.vollminlab.com" "leaking host is named in the output"
+assert_contains "$OUT" "2606:4700:3033::abcd" "leaking host's AAAA address is printed"
+assert_contains "$OUT" "local=/authentik.vollminlab.com/" "remediation names the exact local= line to add"
+assert_contains "$OUT" "pihole1" "remediation calls out pihole1 specifically"
+# The clean host must NOT show up in the leak list.
+case "$OUT" in
+  *"LEAK: radarr.vollminlab.com"*)
+    printf 'FAIL - %s\n' "clean host among two is not misreported as leaking"
+    FAILS=$((FAILS + 1)) ;;
+  *) printf 'ok   - %s\n' "clean host among two is not misreported as leaking" ;;
+esac
+
+# --- 3. zero hosts found: the query itself is broken, not a clean cluster ---
+STUB_KUBECTL_HOSTS=''
+STUB_LEAK_HOSTS=''
+run_check
+assert_rc "$RC" "1" "zero Ingress hosts is a failure, not a clean pass"
+assert_contains "$OUT" "no Ingress hosts found" "zero-hosts case names itself distinctly from the clean-pass message"
+
+# --- 4. kubectl itself fails ---
+STUB_KUBECTL_FAIL=true
+STUB_KUBECTL_HOSTS='radarr.vollminlab.com'
+run_check
+assert_rc "$RC" "1" "a kubectl failure fails the run"
+assert_contains "$OUT" "kubectl get ingress failed" "kubectl failure is reported by name, not swallowed"
+STUB_KUBECTL_FAIL=false
+
+# --- 5. multiple leaking hosts are all reported, count is correct ---
+STUB_KUBECTL_HOSTS='a.vollminlab.com
+b.vollminlab.com
+c.vollminlab.com
+'
+STUB_LEAK_HOSTS='a.vollminlab.com c.vollminlab.com'
+run_check
+assert_rc "$RC" "1" "multiple leaking hosts still fail the run"
+assert_contains "$OUT" "2 of 3 Ingress hosts" "leak summary reports the correct leak/total counts"
+assert_contains "$OUT" "local=/a.vollminlab.com/" "first leaking host gets its own remediation line"
+assert_contains "$OUT" "local=/c.vollminlab.com/" "second leaking host gets its own remediation line"
+
+if [ "$FAILS" -gt 0 ]; then printf '\n%s test(s) failed\n' "$FAILS"; exit 1; fi
+printf '\nall tests passed\n'

--- a/clusters/vollminlab-cluster/monitoring/dns-aaaa-check/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/monitoring/dns-aaaa-check/app/cronjob.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: dns-aaaa-check
+  namespace: monitoring
+  labels:
+    app: dns-aaaa-check
+    env: production
+    category: observability
+spec:
+  # Daily. The thing being detected (a new tunnel-exposed Ingress with no
+  # matching local= line) changes at most a few times a month, so daily is
+  # more than enough cadence while still catching a new leak within 24h of
+  # the Ingress landing. 06:30 UTC is a free :30 slot -- no other CronJob in
+  # this repo uses it (checked against every schedule: in the monitoring
+  # namespace the closest neighbor is victoria-metrics-lt's 07:30 backup).
+  schedule: "30 6 * * *"
+  timeZone: Etc/UTC
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      # Daily, one kubectl list + up to ~30 nslookups. Generous headroom.
+      activeDeadlineSeconds: 300
+      # restartPolicy Never + backoffLimit 0, deliberately -- NOT the healer
+      # pattern. This script fails ON PURPOSE when it finds a leak (or when
+      # the query itself found nothing) specifically to raise KubeJobFailed.
+      # OnFailure or a nonzero backoffLimit would retry and could mask a
+      # single real failure behind a later clean re-run within the same Job,
+      # or just delay the alert -- either way it defeats the one purpose this
+      # job has: being loud.
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: dns-aaaa-check
+            env: production
+            category: observability
+        spec:
+          serviceAccountName: dns-aaaa-check
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: check
+              image: docker.io/alpine/kubectl:1.33.4
+              command: ["/bin/sh", "/scripts/check.sh"]
+              env:
+                # Pi-hole VIP (keepalived) -- both pihole1 (.2) and pihole2
+                # (.3) answer identically for AAAA today, so querying the VIP
+                # is representative of what a LAN client actually resolves.
+                - name: PIHOLE_ADDR
+                  value: "192.168.100.4"
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+                  readOnly: true
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  memory: 64Mi
+          volumes:
+            - name: script
+              configMap:
+                name: dns-aaaa-check-script

--- a/clusters/vollminlab-cluster/monitoring/dns-aaaa-check/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/monitoring/dns-aaaa-check/app/cronjob.yaml
@@ -21,8 +21,22 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      # Daily, one kubectl list + up to ~30 nslookups. Generous headroom.
+      # Daily, one kubectl list + a canary lookup + up to ~30 nslookups.
+      # Generous headroom.
       activeDeadlineSeconds: 300
+      # WITHOUT THIS THE ALERT NEVER CLEARS. kube_job_failed is reported per
+      # Job OBJECT and stays 1 for as long as the Job exists; a later
+      # successful run does not touch it. failedJobsHistoryLimit only evicts
+      # a failed Job once three NEWER failures replace it, which for a daily
+      # schedule with no leaks in between could take weeks (see the six-week
+      # stuck sealed-secrets kopia job cited in
+      # monitoring/vcenter-credential-age/app/cronjob.yaml). 86400 matches
+      # velero-backup-content-guard, the other daily deliberate-failure
+      # CronJob: the alert fires the morning of a leak, self-clears a day
+      # later once this schedule's own Job object ages out, and re-fires the
+      # next run if the leak is still unfixed -- a daily nag rather than a
+      # permanently stuck alert.
+      ttlSecondsAfterFinished: 86400
       # restartPolicy Never + backoffLimit 0, deliberately -- NOT the healer
       # pattern. This script fails ON PURPOSE when it finds a leak (or when
       # the query itself found nothing) specifically to raise KubeJobFailed.
@@ -55,6 +69,13 @@ spec:
                 # is representative of what a LAN client actually resolves.
                 - name: PIHOLE_ADDR
                   value: "192.168.100.4"
+                # A name that is guaranteed to have a real AAAA record.
+                # Queried once before the host loop: if the resolver can't
+                # answer for this, it can't be trusted to mean anything by
+                # "no AAAA" for the hosts that follow. See check.sh's
+                # canary_check() for the full reasoning.
+                - name: CANARY_HOST
+                  value: "cloudflare.com"
               volumeMounts:
                 - name: script
                   mountPath: /scripts

--- a/clusters/vollminlab-cluster/monitoring/dns-aaaa-check/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/monitoring/dns-aaaa-check/app/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: dns-aaaa-check
+# Required: configMapGenerator emits a ConfigMap with no namespace. rbac.yaml
+# (ServiceAccount) and cronjob.yaml already carry namespace: monitoring
+# explicitly; this makes the generated ConfigMap match them. Same convention
+# as velero/velero-pvb-healer/app and monitoring/vcenter-credential-age/app.
+namespace: monitoring
+resources:
+  - rbac.yaml
+  - cronjob.yaml
+configMapGenerator:
+  - name: dns-aaaa-check-script
+    files:
+      - check.sh
+generatorOptions:
+  disableNameSuffixHash: true
+  labels:
+    app: dns-aaaa-check
+    env: production
+    category: observability

--- a/clusters/vollminlab-cluster/monitoring/dns-aaaa-check/app/rbac.yaml
+++ b/clusters/vollminlab-cluster/monitoring/dns-aaaa-check/app/rbac.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dns-aaaa-check
+  namespace: monitoring
+  labels:
+    app: dns-aaaa-check
+    env: production
+    category: observability
+---
+# ClusterRole, not Role: Ingress hosts to check live across every namespace,
+# not just monitoring. get/list on ingresses only -- this job is strictly
+# read-only and never touches Pi-hole or any cluster object.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dns-aaaa-check
+  labels:
+    app: dns-aaaa-check
+    env: production
+    category: observability
+rules:
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dns-aaaa-check
+  labels:
+    app: dns-aaaa-check
+    env: production
+    category: observability
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dns-aaaa-check
+subjects:
+  - kind: ServiceAccount
+    name: dns-aaaa-check
+    namespace: monitoring

--- a/clusters/vollminlab-cluster/monitoring/kustomization.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - networkpolicies
   - harbor-vollminlab-pull-externalsecret.yaml
   - b2-exporter/app
+  - dns-aaaa-check/app
   - karma/app
   - kube-prometheus-stack/app
   - loki/app

--- a/docs/cluster-reference.md
+++ b/docs/cluster-reference.md
@@ -1120,7 +1120,7 @@ expiry monitors; the credentials behind the 78 `ExternalSecret` CRs are not cove
 | Kind | CronJob |
 | Image | `docker.io/alpine/kubectl:1.33.4` |
 | Schedule | `30 6 * * *` (daily) |
-| Tunables | `PIHOLE_ADDR` `192.168.100.4` (keepalived VIP) |
+| Tunables | `PIHOLE_ADDR` `192.168.100.4` (keepalived VIP); `CANARY_HOST` `cloudflare.com` |
 
 Split-horizon DNS here is **A-only**: Pi-hole holds a local A record for every Ingress host
 pointing at the ingress VIP, but AAAA is forwarded upstream. For a host that also has a Cloudflare
@@ -1136,8 +1136,17 @@ from the LAN: browsers work either way, and only an off-LAN client notices.
 
 This job queries every Ingress host for AAAA and **exits non-zero** if any answers, which the
 existing `KubeJobFailed` alert turns into a Pushover notification — no dedicated PrometheusRule.
-`nslookup` exits 0 whether or not the host leaks, so the script parses output rather than `$?`;
-finding **zero** Ingress hosts is also treated as a failure, because a check that passes because it
+`nslookup` exits 0 whether the host has an AAAA, has none, or hits NXDOMAIN — but exits non-zero
+when the resolver itself is unreachable, and that distinction matters: a dead Pi-hole and a
+genuinely clean host both print nothing matching `Address:`, so a check that only parsed output
+would call a dead resolver "clean". The script therefore captures `nslookup`'s own exit status
+per host (not the exit status of the `awk`/`grep` pipeline it feeds, which reflects only whether a
+line matched) and reports a resolver failure as its own outcome, distinct from both a leak and a
+clean pass. Before checking any host it also queries `CANARY_HOST` — a name guaranteed to have a
+real AAAA — and fails immediately if that lookup errors or comes back empty, on the reasoning that
+an unreachable or untrustworthy resolver makes "no AAAA" for every other host meaningless; this
+also avoids burning nslookup's ~10s unreachable-server retry on all ~30 hosts one at a time. Finding
+**zero** Ingress hosts is likewise treated as a failure, because a check that passes because it
 looked at nothing is the exact failure mode being guarded against.
 
 ### b2-exporter

--- a/docs/cluster-reference.md
+++ b/docs/cluster-reference.md
@@ -1112,6 +1112,34 @@ opt-out**. It expired silently once, which is what `vcenter-credential-age` now 
 Warns before the vCenter metrics password expires. Note this is one of three bespoke
 expiry monitors; the credentials behind the 78 `ExternalSecret` CRs are not covered.
 
+### dns-aaaa-check
+
+| Parameter | Value |
+|---|---|
+| Namespace | `monitoring` |
+| Kind | CronJob |
+| Image | `docker.io/alpine/kubectl:1.33.4` |
+| Schedule | `30 6 * * *` (daily) |
+| Tunables | `PIHOLE_ADDR` `192.168.100.4` (keepalived VIP) |
+
+Split-horizon DNS here is **A-only**: Pi-hole holds a local A record for every Ingress host
+pointing at the ingress VIP, but AAAA is forwarded upstream. For a host that also has a Cloudflare
+tunnel CNAME, upstream returns Cloudflare's IPv6 — so an IPv6-capable LAN client hairpins out
+through the tunnel instead of reaching nginx directly, and Cloudflare's 100 MB request-body cap
+starts applying to uploads that should bypass it.
+
+The fix per host is one `local=/<host>/` line in `misc.dnsmasq_lines` on **pihole1 only**
+(nebula-sync `FULL_SYNC=true`, hourly, replicates to pihole2). **Nothing automates that line** —
+external-dns creates the A record when an Ingress appears, so every new tunnel-exposed host
+silently reintroduces the leak. It recurred five times before this job existed, and it is invisible
+from the LAN: browsers work either way, and only an off-LAN client notices.
+
+This job queries every Ingress host for AAAA and **exits non-zero** if any answers, which the
+existing `KubeJobFailed` alert turns into a Pushover notification — no dedicated PrometheusRule.
+`nslookup` exits 0 whether or not the host leaks, so the script parses output rather than `$?`;
+finding **zero** Ingress hosts is also treated as a failure, because a check that passes because it
+looked at nothing is the exact failure mode being guarded against.
+
 ### b2-exporter
 
 | Parameter | Value |
@@ -1146,6 +1174,7 @@ Cluster-level scheduled maintenance outside the storage and backup namespaces.
 | `velero-pvb-healer` | `velero` | `alpine/kubectl:1.33.4` | `*/10 * * * *` | See Backup |
 | `velero-backup-content-guard` | `velero` | `alpine/kubectl:1.33.4` | `0 9 * * *` | See Backup |
 | `vcenter-credential-age` | `monitoring` | `alpine:3.23.4` | `17 8 * * 1` | See Monitoring |
+| `dns-aaaa-check` | `monitoring` | `alpine/kubectl:1.33.4` | `30 6 * * *` | See Monitoring |
 
 **A merged, Ready, reconciled CronJob is not a working CronJob.** `velero-pvb-healer` ran and exited
 137 on *every* invocation for one PR cycle while Flux reported success throughout. After any CronJob


### PR DESCRIPTION
A daily CronJob that detects a DNS misconfiguration which has now recurred five times, is invisible from the LAN, and is only observable from off-LAN.

## The problem

Split-horizon DNS here is **A-only**. Pi-hole holds a local A record for every Ingress host pointing at the ingress VIP, so LAN clients reach nginx directly. AAAA is forwarded upstream — and for a host that also has a Cloudflare tunnel CNAME, upstream returns Cloudflare's IPv6. An IPv6-capable LAN client therefore hairpins out through the tunnel instead of hitting nginx, and Cloudflare's hard 100 MB request-body cap starts applying to uploads that should bypass it entirely.

The fix per host is one `local=/<host>/` line in `misc.dnsmasq_lines` on **pihole1 only** (nebula-sync `FULL_SYNC=true`, hourly, replicates to pihole2). **Nothing automates that line.** external-dns creates the A record when an Ingress appears; the `local=` line is hand-maintained. So every new tunnel-exposed host silently reintroduces the leak, and browsers work fine either way, so nobody notices. This is the same shape as the tunnel-origin 502 that went unseen for 68 days.

## Design

Lists every Ingress host, queries the Pi-hole for AAAA, **exits non-zero** if any answers. Exiting non-zero *is* the alert — the existing `KubeJobFailed` rule fires it to Pushover, so no new PrometheusRule. `restartPolicy: Never` + `backoffLimit: 0` so one bad run yields exactly one failed Job.

## Two things that would have made this worse than nothing

Both were caught in review and fixed before this PR existed.

**1. It could have reported all-clear while blind.** `nslookup` prints `;; connection timed out` on failure, which never matches `^Address:` — so an unreachable Pi-hole produced empty output, **byte-identical to a genuinely clean host**. The job would have logged "queried 30 hosts, none leaking" and exited 0. A monitoring job that goes quiet when its own dependency dies is actively harmful.

Fixed two ways. Measured exit codes against the live Pi-hole:

| case | rc |
|---|---|
| host WITH AAAA, server up | 0 |
| host with NO AAAA, server up | 0 |
| NXDOMAIN, server up | 0 |
| **server unreachable** | **1** |

So `rc` is an unambiguous resolver-failure signal, and it's now captured directly rather than being the pipeline's (i.e. `grep`'s). Plus a **startup canary** (`CANARY_HOST`, default `cloudflare.com`): if the resolver can't return an AAAA for a name that definitely has one, then "no AAAA for X" carries no information, so the job fails fast without reporting anything clean. That also avoids 30 × ~10s of timeouts.

**2. The alert would never have cleared.** `ttlSecondsAfterFinished` was missing. `kube_job_failed` is reported per Job *object* and stays 1 while that Job exists; `failedJobsHistoryLimit` only evicts it once three newer failures replace it, and a later success never clears it. This is already documented in this repo on `vcenter-credential-age`, opening "WITHOUT THIS THE ALERT NEVER CLEARS" and citing a Job stuck at `kube_job_failed=1` for six weeks. All three sibling deliberate-failure CronJobs set it; this one didn't. Now `86400`, matching `velero-backup-content-guard`, which is also daily.

## Guards against silent success

Three cases are treated as failures, not clean passes: **kubectl errors**, **zero Ingress hosts found** (the query broke — "nothing found" and "nothing wrong" must not look alike), and **any resolver error**, reported separately from leaks and never folded into "none leaking".

## Verification

`check_test.sh` — pure shell, PATH-shimmed stubs, no cluster. **31 assertions, identical under `dash` and `busybox ash`.** The harness invokes `check.sh` via kernel shebang exec rather than `sh check.sh`, because busybox ash prefers its own `nslookup` applet over a PATH stub — an earlier harness passed falsely for exactly that reason.

Mutation-tested rather than assumed. Neutering the resolver-failure guard fails 3 assertions; neutering the canary function fails 2; skipping the canary call fails 2. Working tree verified clean after each.

Also: `kubectl apply -k --dry-run=client` creates all 5 objects; local `kyverno apply` over the rendered manifests is `pass 4, fail 0`; `check-doc-currency.sh` passes with the new `dns-aaaa-check` entry in `cluster-reference.md` — documented rather than added to `.cluster-reference-exempt`, which is a ratchet meant only to shrink.

RBAC is `get`/`list` on `ingresses` and nothing else. Egress is already permitted by `monitoring`'s existing `allow-all-egress`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Fuk2t1KKrrLikj2xghzn9