### PR TITLE
fix(homepage): use the real Foundry VTT icon

### DIFF
--- a/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/homepage/homepage/app/configmap.yaml
@@ -391,7 +391,7 @@ data:
             - Foundry VTT:
                 description: Virtual tabletop for tabletop RPG sessions
                 href: https://foundry.vollminlab.com
-                icon: mdi-dice-d20
+                icon: foundry-vtt.png
                 namespace: foundry
                 app: foundry
             - Vollminlab Org:


### PR DESCRIPTION
Swaps the Foundry tile's placeholder `mdi-dice-d20` for the actual Foundry VTT logo.

The tile shipped in #1184 with an MDI dice glyph because I concluded `homarr-labs/dashboard-icons` had no Foundry icon. That was wrong: I checked `svg/foundry-vtt.svg` and `png/foundryvtt.png` — both genuinely 404 — but never `png/foundry-vtt.png`, which exists. I mismatched the name and extension across the candidates I tried.

`png/foundry-vtt.png` is a real 448×512 RGBA logo, verified fetched. A bare filename resolves against dashboard-icons, which is exactly how every other tile here references its icon (`jellyfin.png`, `audiobookshelf.png`, `filebrowser.png`, …), so this is also more consistent than the `mdi-` form.

`services.yaml` re-parsed after the edit. No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Fuk2t1KKrrLikj2xghzn9