### PR TITLE
fix(foundry): stop the health probes leaking Foundry sessions

### DIFF
--- a/clusters/vollminlab-cluster/foundry/foundry/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/foundry/foundry/app/configmap.yaml
@@ -110,13 +110,49 @@ data:
       # the pod annotation achieves the same skip, is mutable, and stays in git.
       backup.velero.io/backup-volumes-excludes: data
 
-    # The chart default is 18 x 10s = 3 minutes, which is not enough for the
-    # first-boot distribution download. 60 x 10s = 10 minutes.
-    startupProbe:
-      httpGet:
-        path: /
+    # ALL THREE PROBES ARE tcpSocket, NOT httpGet. Foundry mints a new client
+    # session for EVERY HTTP request and never expires them, so the chart's
+    # default `httpGet: /` probes leak sessions forever. Measured 2026-08-22:
+    # 2,969 sessions in 4h06m -- ~17,000/day -- every one from kubelet, none
+    # from a human. Foundry walks that table per request, so it degrades
+    # continuously, and the log becomes unreadable (199 of 200 lines were probe
+    # sessions, burying the one real event).
+    #
+    # `/api/status` does NOT help: measured, 3 requests produced 3 sessions.
+    # ANY HTTP request mints one. A raw TCP connect produces ZERO (5 connects,
+    # delta 0), because it never reaches the HTTP layer.
+    #
+    # Trade-off, accepted deliberately: a TCP probe cannot detect a hung Node
+    # process that still accepts connections. For a single-replica app whose
+    # process either runs or does not, that is a far better bargain than a
+    # self-inflicted session leak -- the HTTP probes were themselves the
+    # degradation they were supposed to detect.
+    livenessProbe:
+      initialDelaySeconds: 600
+      failureThreshold: 10
+      periodSeconds: 300
+      # Helm DEEP-MERGES values maps, so the chart's default httpGet survives
+      # unless explicitly nulled -- leaving a probe with two handlers, which the
+      # API server rejects. Verified in the render before and after.
+      httpGet: null
+      tcpSocket:
         port: http
-        scheme: HTTP
+    readinessProbe:
+      initialDelaySeconds: 30
+      failureThreshold: 18
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 5
+      httpGet: null
+      tcpSocket:
+        port: http
+    # failureThreshold 60 x 10s = 10 minutes, because first boot downloads the
+    # ~1GB Foundry distribution before the port opens. The chart default of 18
+    # (3 minutes) is not enough.
+    startupProbe:
       failureThreshold: 60
       periodSeconds: 10
       timeoutSeconds: 5
+      httpGet: null
+      tcpSocket:
+        port: http


### PR DESCRIPTION
Foundry felt slow and unresponsive after admin login. The cause is the chart's default probes, not the infrastructure.

## What's happening

**Foundry mints a new client session for every HTTP request and never expires them.** The chart's default `httpGet: /` probes therefore leak sessions forever.

Measured on the live pod, 2026-08-22:

| | |
|---|---|
| Sessions created | **2,969 in 4h 06m** (~17,000/day) |
| Source | every one from kubelet `192.168.152.12`, none from a human |
| Log signal | **199 of the last 200 lines** were probe sessions |

Foundry walks that table per request, so it degrades continuously. The log noise also buried the only real event in the window — a single admin login.

**The infrastructure was never the problem**, which is worth stating because it's where you'd normally look first: the pod was idle at **1m CPU / 210Mi**, the ingress path measured **31ms total, 31ms TTFB**, egress reached foundryvtt.com in 438ms, worker02 had no Memory/Disk/PID pressure, and there were zero 4xx/5xx.

## Why tcpSocket, and why not a lighter HTTP path

Measured, not assumed:

- `/api/status` — 3 requests → **3 sessions**. Any HTTP request mints one.
- Raw TCP connect — 5 connects → **0 sessions**. It never reaches the HTTP layer.

So all three probes become `tcpSocket`.

**Trade-off, accepted deliberately:** a TCP probe cannot detect a hung Node process that still accepts connections. For a single-replica app whose process either runs or doesn't, that is a far better bargain than a self-inflicted session leak — the HTTP probes were themselves the degradation they were meant to detect.

## `httpGet: null` is load-bearing

Helm **deep-merges** values maps, so adding `tcpSocket` alone leaves the chart's default `httpGet` in place and the probe ends up with **two handlers**, which the API server rejects. First render caught exactly that:

```
livenessProbe: ['failureThreshold', 'httpGet', 'initialDelaySeconds', 'periodSeconds', 'tcpSocket']
```

After adding `httpGet: null` to each probe:

```
livenessProbe:  ['failureThreshold', 'initialDelaySeconds', 'periodSeconds', 'tcpSocket']
readinessProbe: ['failureThreshold', 'initialDelaySeconds', 'periodSeconds', 'successThreshold', 'tcpSocket', 'timeoutSeconds']
startupProbe:   ['failureThreshold', 'periodSeconds', 'tcpSocket', 'timeoutSeconds']
```

Exactly one handler each. `startupProbe.failureThreshold: 60` is retained — first boot downloads the ~1 GB distribution before the port opens.

## Verification

`check-helm-values.py` → 0 problems. Render asserted programmatically for one-handler-per-probe. Merging rolls the pod, which also clears the ~3k accumulated sessions (they are in-memory).

Upstream-worth: the chart's defaults are actively harmful for this specific app. Happy to raise it on the chart repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Fuk2t1KKrrLikj2xghzn9