### PR TITLE
feat(minio): mirror the CNPG backup bucket to Backblaze B2

### DIFF
--- a/.claude/rules/networkpolicy.md
+++ b/.claude/rules/networkpolicy.md
@@ -84,6 +84,7 @@ Keep this table current whenever a new NetworkPolicy namespace is added.
 | `authentik` | n/a (egress target → ingress-nginx) | 80 | cloudflared tunnel **origin** — `ingress-nginx-controller.ingress-nginx.svc:80`; svc 80→targetPort `http`→containerPort 80 | allow-cloudflared-nginx-egress egress (`app: cloudflared-authentik` only) |
 | `harbor` | n/a (ingress target) | 8000 | CNPG instance status API | allow-cnpg-operator ingress |
 | `minio` | `minio` | 9000 | S3 API — reached by the Helm post-upgrade hook pod (`app: minio-job`) to create buckets/users | allow-post-job-egress (from hook) + allow-post-job-ingress (to minio); intra-namespace |
+| `minio` | `minio` | 9000 | S3 API — reached by the `cnpg-b2-mirror` CronJob (`app: cnpg-b2-mirror`) reading the `cnpg-backups` bucket. Its other hop, Backblaze B2 on 443, needs no rule: `allow-https-egress` has `podSelector: {}` | allow-cnpg-b2-mirror-egress + allow-cnpg-b2-mirror-ingress; intra-namespace |
 | `tofu` | n/a (egress target → mediastack) | 7878/8989/8787/9696 | radarr/sonarr/readarr/prowlarr API (arr Terraform providers) | allow-mediastack-arr-egress egress |
 | `tofu` | n/a (egress target → harbor) | 8443 | Harbor API; svc 443→**8443**, egress evaluated post-DNAT so 443 ≠ enough | allow-harbor-egress egress |
 | `longhorn-system` | `longhorn-manager` | 9500 | Longhorn manager metrics — chart 1.12.1+ ships its own policies that exclude Prometheus | allow-monitoring-scrape ingress (from monitoring) |

--- a/clusters/vollminlab-cluster/minio/cnpg-b2-mirror/app/cnpg-b2-credentials-externalsecret.yaml
+++ b/clusters/vollminlab-cluster/minio/cnpg-b2-mirror/app/cnpg-b2-credentials-externalsecret.yaml
@@ -1,0 +1,31 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cnpg-b2-credentials
+  namespace: minio
+  labels:
+    app: cnpg-b2-mirror
+    env: production
+    category: storage
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: onepassword-cluster-store
+    kind: ClusterSecretStore
+  target:
+    name: cnpg-b2-credentials
+    creationPolicy: Owner
+  # Field labels here are the 1Password item's own, not the repo's usual
+  # access_key_id / secret_access_key. The item is an API Credential type, which
+  # names them `keyID` and `credential`; renaming them in 1Password would break
+  # this reference, so the ExternalSecret matches the item rather than the other
+  # way round. Item notes carry the do-not-rename warning.
+  data:
+    - secretKey: B2_ACCESS_KEY
+      remoteRef:
+        key: "Backblaze B2 - vollminlab-k8s-cnpg"
+        property: keyID
+    - secretKey: B2_SECRET_KEY
+      remoteRef:
+        key: "Backblaze B2 - vollminlab-k8s-cnpg"
+        property: credential

--- a/clusters/vollminlab-cluster/minio/cnpg-b2-mirror/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/minio/cnpg-b2-mirror/app/cronjob.yaml
@@ -1,0 +1,136 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cnpg-b2-mirror
+  namespace: minio
+  labels:
+    app: cnpg-b2-mirror
+    env: production
+    category: storage
+spec:
+  # 09:00 UTC. After the last CNPG ScheduledBackup (jellystat, 03:00) so the
+  # day's base backups are included, and clear of every other window: VolSync
+  # 00:00-02:00, the other four ScheduledBackups 01:00-01:45, velero daily-full
+  # 03:00, daily-b2 04:00, grafana-b2 05:00, monthly-b2 06:00, vmbackup 07:30
+  # with a 2h ceiling.
+  schedule: "0 9 * * *"
+  timeZone: Etc/UTC
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 3600
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 86400
+      # The first run uploads the whole bucket (8.4 GB measured 2026-08-22).
+      # Every run after that copies only objects B2 does not already have, so
+      # the steady state is one day of base backups plus that day's WAL.
+      activeDeadlineSeconds: 5400
+      # backoffLimit 0 would make a single transient B2 error a failed day.
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app: cnpg-b2-mirror
+            env: production
+            category: storage
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: mirror
+              image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+              env:
+                # Source: the existing cnpg-svc principal, whose MinIO policy
+                # (cnpg-policy, in minio/app/configmap.yaml) is already scoped to
+                # the cnpg-backups bucket and nothing else. This job only ever
+                # reads through it, so a dedicated read-only principal would add
+                # a second 1Password item and a MinIO Helm post-job run against
+                # the backup store for no reduction in blast radius.
+                #
+                # The access key is not a secret: it is declared in plain text as
+                # `accessKey: cnpg-svc` in the MinIO chart values. Only the secret
+                # key comes from 1Password, via the cnpg-minio-user ExternalSecret
+                # this namespace already has for the Helm post-job.
+                - name: MINIO_ACCESS_KEY
+                  value: cnpg-svc
+                - name: MINIO_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: cnpg-minio-user
+                      key: secretKey
+                - name: B2_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: cnpg-b2-credentials
+                      key: B2_ACCESS_KEY
+                - name: B2_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: cnpg-b2-credentials
+                      key: B2_SECRET_KEY
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+
+                  MC="mc --config-dir /tmp/mc"
+
+                  # >/dev/null on both: `mc alias set` echoes the alias it just
+                  # created, and a failure here must not print the credential.
+                  $MC alias set src http://minio.minio.svc.cluster.local:9000 \
+                      "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" > /dev/null
+                  $MC alias set b2 https://s3.us-west-000.backblazeb2.com \
+                      "$B2_ACCESS_KEY" "$B2_SECRET_KEY" > /dev/null
+
+                  # Prove both endpoints answer before mirroring. Without this a
+                  # credential or endpoint fault would surface as "0 objects
+                  # copied" and exit 0, which is indistinguishable from "already
+                  # up to date" and is exactly how a backup reports success while
+                  # protecting nothing.
+                  $MC ls src/cnpg-backups > /dev/null
+                  $MC ls b2/vollminlab-k8s-cnpg > /dev/null
+
+                  # No --remove. B2 therefore keeps objects after MinIO's 7d
+                  # (authentik) / 14d (the rest) retention has expired them, so
+                  # the offsite copy reaches further back than the local one.
+                  # Bound it with a B2 lifecycle rule, not with --remove.
+                  $MC mirror src/cnpg-backups b2/vollminlab-k8s-cnpg
+
+                  # Content guard. A mirror that copies nothing into an empty
+                  # destination still exits 0.
+                  n="$($MC ls --recursive b2/vollminlab-k8s-cnpg | wc -l)"
+                  echo "objects in B2 after mirror: $n"
+                  if [ "$n" -le 0 ]; then
+                    echo "ERROR: destination is empty after a successful mirror" >&2
+                    exit 1
+                  fi
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  memory: 512Mi
+          volumes:
+            # readOnlyRootFilesystem is on. mc writes its config and session
+            # state under --config-dir, and scratch files under /tmp, so one
+            # emptyDir at /tmp covers both. Skipped by Velero FSB globally via
+            # the volumeTypes: [emptyDir] rule in velero-skip-smb-policy.
+            - name: tmp
+              emptyDir: {}

--- a/clusters/vollminlab-cluster/minio/cnpg-b2-mirror/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/minio/cnpg-b2-mirror/app/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cnpg-b2-credentials-externalsecret.yaml
+  - cronjob.yaml

--- a/clusters/vollminlab-cluster/minio/kustomization.yaml
+++ b/clusters/vollminlab-cluster/minio/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - namespace.yaml
   - networkpolicies
   - minio/app
+  - cnpg-b2-mirror/app

--- a/clusters/vollminlab-cluster/minio/networkpolicies/networkpolicy.yaml
+++ b/clusters/vollminlab-cluster/minio/networkpolicies/networkpolicy.yaml
@@ -268,3 +268,60 @@ spec:
       ports:
         - protocol: TCP
           port: 9000
+---
+# The cnpg-b2-mirror CronJob reads the cnpg-backups bucket and copies it to
+# Backblaze B2. Two hops, and only one of them needs a rule here:
+#
+#   * MinIO on 9000 — intra-namespace, needs these two policies. Verified
+#     container port: svc minio 9000 -> targetPort 9000 -> containerPort 9000
+#     (named `http`), so 9000 is correct on both sides of the DNAT.
+#   * Backblaze B2 on 443 — already granted by allow-https-egress, whose
+#     podSelector is {} and therefore covers every pod in this namespace.
+#     DNS likewise comes from allow-dns.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cnpg-b2-mirror-egress
+  namespace: minio
+  labels:
+    app: cnpg-b2-mirror
+    env: production
+    category: storage
+spec:
+  podSelector:
+    matchLabels:
+      app: cnpg-b2-mirror
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: minio
+      ports:
+        - protocol: TCP
+          port: 9000
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cnpg-b2-mirror-ingress
+  namespace: minio
+  labels:
+    app: cnpg-b2-mirror
+    env: production
+    category: storage
+spec:
+  podSelector:
+    matchLabels:
+      app: minio
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: cnpg-b2-mirror
+      ports:
+        - protocol: TCP
+          port: 9000

--- a/docs/cluster-reference.md
+++ b/docs/cluster-reference.md
@@ -586,7 +586,48 @@ Kubernetes manifests are **not** backed up by Velero — they are restored by Fl
 | API endpoint (in-cluster) | `http://minio.minio.svc.cluster.local:9000` |
 | Console | `minio.vollminlab.com` (port 9001) |
 | Root user | `root` (password in 1Password: **MinIO**) |
-| Bucket | `velero` (auto-provisioned on startup) |
+| Buckets | `velero`, `loki`, `cnpg-backups`, `terraform-state` (auto-provisioned on startup) |
+| Service accounts | `cnpg-svc` (cnpg-policy, `cnpg-backups` only), `tofu-svc` (tofu-state-policy, `terraform-state` only) |
+
+### cnpg-b2-mirror (CNPG offsite copy)
+
+CronJob in the `minio` namespace that mirrors the `cnpg-backups` bucket to Backblaze B2.
+
+| Parameter | Value |
+|---|---|
+| Manifests | `./clusters/vollminlab-cluster/minio/cnpg-b2-mirror/app` |
+| Image | `docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z` |
+| Schedule | 09:00 UTC daily |
+| Source | `s3://cnpg-backups` via the `cnpg-svc` principal (read only in practice) |
+| Destination | `s3://vollminlab-k8s-cnpg` |
+| B2 endpoint | `https://s3.us-west-000.backblazeb2.com` |
+| B2 credentials | 1Password: **Backblaze B2 - vollminlab-k8s-cnpg** (fields `keyID`, `credential`) |
+| Retention | none applied by the job; set a B2 lifecycle rule on the bucket |
+
+**Why it exists.** CloudNativePG writes base backups and WAL to exactly one object store.
+`spec.backup.barmanObjectStore` is a single object, and the newer barman-cloud plugin does not
+fan out either: its second `ObjectStore` is a *recovery source* for a replica cluster, not a
+second backup destination. All five clusters therefore archive only to MinIO, which puts every
+restorable Postgres backup on one Longhorn PVC in one rack.
+
+Velero's `daily-b2` does copy each `pgdata` volume to B2 nightly, but that is a filesystem walk
+of a running PostgreSQL data directory with no `pg_backup_start()` / `pg_backup_stop()` bracket.
+It is torn across files, carries no WAL continuity, supports no PITR, and CloudNativePG cannot
+bootstrap a `Cluster` from it. It reports `Completed` every night regardless, so it reads as
+protection without being any.
+
+Mirroring the bucket sidesteps the single-destination limit without touching CNPG: what lands in
+B2 is the real barman artifacts, and a recovery `Cluster` can be pointed straight at them.
+
+**The job runs without `--remove`**, so B2 keeps objects after MinIO's retention (7d for
+`authentik-db`, 14d for the other four) has expired them. The offsite copy therefore reaches
+further back than the local one, and B2 growth is bounded by a bucket lifecycle rule rather than
+by the mirror.
+
+**It fails loudly rather than quietly.** It lists both endpoints before mirroring and counts
+objects in the destination afterwards, exiting non-zero if the destination is empty. A mirror
+that copies nothing into an empty bucket otherwise exits 0, which is indistinguishable from
+"already up to date".
 
 ### Velero
 


### PR DESCRIPTION
Addresses #1158, but not the way the issue proposes. Two of its premises turned out to be wrong, and the correction changes the design.

## CNPG cannot write to two object stores

`spec.backup.barmanObjectStore` is a single object. The newer barman-cloud plugin (not installed here; the cluster is on CNPG 1.30.0) does not fan out either. Its docs describe a second `ObjectStore` only as a **recovery source** for a replica cluster, and state no dual-destination capability. So "add a second `barmanObjectStore` on all 5 clusters" has no supported form.

## There *is* an offsite copy — it just isn't restorable

`velero-daily-b2-20260822040000` carries every CNPG `pgdata` volume to B2, all `Completed`, ~5.0 GB, 90-day TTL:

```
harbor/harbor-db-2 653MB   harbor/harbor-db-3 636MB   authentik/authentik-db-1 1042MB
vollmint/vollmint-db-1 637MB   vollmint/vollmint-db-2 621MB
shlink/shlink-db-1 637MB   mediastack/jellystat-db-1 774MB
```

That is a restic walk of a **running** PostgreSQL data directory with no `pg_backup_start()` / `pg_backup_stop()` bracket: torn across files, no WAL continuity, no PITR, and CNPG cannot bootstrap a `Cluster` from it. It reports `Completed` every night regardless. The gap is **"no restorable offsite backup"**, not "no offsite bytes" — and the second phrasing is the more dangerous one, because it reads as protection.

## What this does instead

A CronJob in `minio` mirrors `s3://cnpg-backups` (8.4 GB measured) to `s3://vollminlab-k8s-cnpg`. It sidesteps the single-destination limit without touching CNPG: no plugin install, no migration of five production databases, local restore stays fast, and what lands in B2 is the real barman artifacts that a recovery `Cluster` can be pointed straight at.

| | |
|---|---|
| Schedule | 09:00 UTC — after the last ScheduledBackup (jellystat 03:00), clear of VolSync 00:00–02:00, all four velero windows 03:00–06:00, and vmbackup 07:30 + 2h |
| Source principal | `cnpg-svc`, already scoped by `cnpg-policy` to the `cnpg-backups` bucket and nothing else |
| Retention | no `--remove`, so B2 keeps objects past MinIO's 7d/14d expiry |

**On `--remove`:** leaving it off means the offsite copy reaches further back than the local one, which is what you want from offsite. It also means B2 grows unboundedly, so **please set a lifecycle rule on the bucket** (90 days would mirror velero's B2 tier). The key already has `writeBucketLifecycleRules` if you'd rather I did it.

**On the principal:** a dedicated read-only user would be strictly tidier, but it needs a second 1Password item and a MinIO Helm post-job run against the live backup store — and #971 is on record for how that goes. `cnpg-svc` cannot reach any bucket other than the one being read. Happy to add the read-only user as a follow-up if you'd prefer it.

**It fails loudly.** It lists both endpoints before mirroring and counts destination objects after, exiting non-zero if the destination is empty. A mirror that copies nothing into an empty bucket otherwise exits 0, which is indistinguishable from "already up to date" — the same shape as the empty-Velero-backup trap already in the rules.

## Verified before committing

- **B2 S3 round-trip with the real credentials:** `LIST 200`, `PUT 200`, `GET 200` byte-exact, `DELETE 204`, `404` after. Bucket left clean.
- **The key is bucket-scoped.** `b2_authorize_account` reports `bucketName=vollminlab-k8s-cnpg`, so it structurally cannot reach velero's bucket — the thing that took down all three B2 schedules on 2026-08-17. Capabilities cover `listFiles`/`readFiles`/`writeFiles`/`deleteFiles`.
- **ESO reads the item's `MENU`-type `keyID` field.** Not assumed: a throwaway ExternalSecret synced `True`/`SecretSynced` and both values matched 1Password byte-for-byte (compared by hash, never printed). Removed afterwards.
- **MinIO container port is 9000** (svc `9000` → targetPort `9000` → containerPort `http`/`9000`), so no port trap on either netpol. B2's 443 hop needs no rule: `allow-https-egress` has `podSelector: {}`.
- **Server dry-run of the whole rendered namespace:** accepted.
- **`kyverno apply` of the five new `-batch` policies against this CronJob:** `5 pass, 0 fail, 0 error`.
- **`scripts/check-doc-currency.sh` passes** with the new app directory documented in `cluster-reference.md`.

## Also

Corrects the MinIO bucket row in `cluster-reference.md`, which listed only `velero` when four buckets are provisioned, and adds the service-account row.

## Verify after Flux reconciles

```bash
kubectl get externalsecret -n minio cnpg-b2-credentials
kubectl create job -n minio --from=cronjob/cnpg-b2-mirror mirror-manual-$(date +%s)
kubectl logs -n minio -l job-name=mirror-manual-<ts> --tail=20
```

Expect a non-zero `objects in B2 after mirror:` count. Per the CronJob trap in `.claude/rules/velero.md`, **check the job pod's exit code, not the CronJob's status** — a merged, Ready, reconciled CronJob ran at exit 137 on every invocation for a full PR cycle once already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MJ9d87kNJjoBbKfHPBFAx