### PR TITLE
feat(cloudflare): SRV record moving Minecraft off the default port

### DIFF
--- a/docs/cluster-reference.md
+++ b/docs/cluster-reference.md
@@ -1401,7 +1401,7 @@ The `dmz` namespace is a security boundary for internet-exposed workloads. Full 
 | JVM memory | 6G |
 | CPU | req: 2000m, limits: 4000m |
 | Memory | req: 6Gi, limits: 8Gi |
-| Config PVC | 20Gi `longhorn-dmz` RWX |
+| Data PVC | `pvc-minecraft-datadir`, 20Gi `longhorn-dmz`, RWX |
 | View distance | 8 |
 | Simulation distance | 6 |
 | Max players | 20 |
@@ -1412,10 +1412,33 @@ The `dmz` namespace is a security boundary for internet-exposed workloads. Full 
 | Service type | NodePort |
 | Minecraft port | NodePort `32565` |
 | BlueMap port | NodePort `32566` (container port 8100) |
+| Public hostname | `minecraft.vollminlab.com` (CNAME → `dynamic.vollminlab.com` → WAN IP, unproxied) |
+| Public port | **57913**, forwarded by the router to the HAProxy VIP `192.168.160.4:25565` |
+| SRV record | `_minecraft._tcp.minecraft.vollminlab.com` → `0 5 57913 dynamic.vollminlab.com` |
+
+**External access.** Players type the hostname with no port. A Java client resolves
+`_minecraft._tcp.<host>` before connecting and uses the port that record names, falling back to
+25565 only when no SRV exists. The record therefore lives on Cloudflare, the authoritative public
+zone, and is read client-side: it routes no traffic. The port translation is the router's, on its
+WAN interface.
+
+Cloudflare proxying must stay **off** for both records. The orange-cloud proxy carries HTTP/HTTPS
+only, not the Minecraft TCP protocol.
+
+Bedrock clients ignore SRV entirely and would need `:57913` typed. Not applicable here, the server
+is Paper (Java).
+
+One SRV serves LAN and WAN alike **only because Pi-hole holds no local override for this
+hostname** (verified 2026-08-23: `192.168.100.2` and `.3` both return the public address). LAN
+clients hairpin through the router like anyone else. Add an override for this name and LAN play
+breaks while external play keeps working, because the port translation lives on a WAN interface a
+LAN client never crosses; that case needs a matching `srv-host=` in both Pi-holes on port 25565.
 
 **Allowed ingress:** HAProxy nodes `192.168.160.2/32` and `192.168.160.3/32` on ports 25565 (game) and 8100 (BlueMap).
 
-**Allowed egress:** `0.0.0.0/0` on ports 80, 443 (downloads/updates) + DNS to `10.96.0.10:53`.
+**Allowed egress:** ports 80 and 443 to `0.0.0.0/0` **excluding RFC1918** (`10/8`, `172.16/12`,
+`192.168/16`), which covers the LAN, the service CIDR and the pod CIDR. DNS is granted separately
+by the namespace-wide `allow-dns` policy, not by this rule.
 
 **Probes:**
 - Readiness: initialDelay=30s, period=10s, failureThreshold=10

--- a/terraform/cloudflare/dns.tf
+++ b/terraform/cloudflare/dns.tf
@@ -68,6 +68,48 @@ resource "cloudflare_dns_record" "minecraft" {
   ttl     = 1
 }
 
+# Moves Java clients off the default port without anyone having to type one.
+#
+# A Java client given "minecraft.vollminlab.com" queries
+# _minecraft._tcp.<host> for an SRV record first, and only falls back to
+# A/AAAA plus port 25565 if there is none. So this record is read entirely on
+# the client side before it opens a socket: it reroutes nothing, it just tells
+# the client which WAN port to dial. The port translation itself stays on the
+# router (57913 -> 192.168.160.4:25565).
+#
+# One record covers LAN and WAN both. Pi-hole holds no local override for
+# minecraft.vollminlab.com (verified 2026-08-23: both 192.168.100.2 and .3
+# return 108.5.213.103, the public address), so LAN clients resolve exactly as
+# external ones do and hairpin through the router. If an override is ever added
+# for this name, this record has to be mirrored into both Pi-holes with port
+# 25565, or LAN players break while external ones keep working -- the same
+# split-horizon shape as the AAAA leak that hid the tunnel outage for 68 days.
+#
+# target is dynamic.vollminlab.com, not minecraft.vollminlab.com: RFC 2782
+# requires an SRV target to be a real hostname and minecraft.vollminlab.com is
+# a CNAME. Pointing at the A record also means the SRV follows the WAN address
+# whenever DDNS updates it.
+#
+# proxied stays false, as it must: Cloudflare's proxy carries HTTP/HTTPS only,
+# not the Minecraft TCP protocol.
+#
+# Java Edition only. Bedrock ignores SRV, so a Bedrock client would need the
+# port typed explicitly. Not a concern here -- the server is Paper.
+resource "cloudflare_dns_record" "minecraft_srv" {
+  zone_id  = var.cloudflare_zone_id
+  name     = "_minecraft._tcp.minecraft.vollminlab.com"
+  type     = "SRV"
+  proxied  = false
+  ttl      = 1
+  priority = 0
+
+  data = {
+    port   = 57913
+    target = "dynamic.vollminlab.com"
+    weight = 5
+  }
+}
+
 resource "cloudflare_dns_record" "vpn" {
   zone_id = var.cloudflare_zone_id
   name    = "vpn.vollminlab.com"


### PR DESCRIPTION
Addresses #1132. The router forward is already in place (WAN `57913` → HAProxy VIP `192.168.160.4:25565`); this is the DNS half.

## What it does

Adds `_minecraft._tcp.minecraft.vollminlab.com` → `0 5 57913 dynamic.vollminlab.com`.

**The record routes nothing.** A Java client resolves `_minecraft._tcp.<host>` *before* it opens a socket and dials whatever port that record names, falling back to A/AAAA plus 25565 only when no SRV exists. It is client-side service discovery. The port translation stays where it already is, on the router's WAN interface. Players keep typing `minecraft.vollminlab.com` with no port.

## Verified end to end before writing the record

A Server List Ping over all three paths, which proves the new forward actually reaches Minecraft rather than merely opening a socket somewhere:

```
NEW  wan:57913   Paper 1.21.10  protocol 773  0/20  sample=hidden  "Welcome to Minecraft on Kubern…"
OLD  wan:25565   Paper 1.21.10  protocol 773  0/20  sample=hidden  "Welcome to Minecraft on Kubern…"
LAN  haproxy     Paper 1.21.10  protocol 773  0/20  sample=hidden  "Welcome to Minecraft on Kubern…"
```

Identical version, protocol and MOTD on all three. (`sample=hidden` also confirms `HIDE_ONLINE_PLAYERS` is doing its job.)

## Four details that are easy to get wrong

- **`priority` is a top-level argument, not a member of `data`.** Provider docs are explicit: *"Required for MX, SRV and URI records"*. `data` carries `port`, `target`, `weight`. `tofu validate` passes against the pinned `~> 5.8`, and `tofu fmt -check` is clean.
- **`target` is `dynamic.vollminlab.com`, not `minecraft.vollminlab.com`.** RFC 2782 requires an SRV target to be a real hostname, and `minecraft.vollminlab.com` is a CNAME to `dynamic`. Most clients tolerate the violation; no reason to depend on it. Pointing at the A record also means the SRV follows the WAN address whenever DDNS updates it.
- **`proxied` stays `false`.** Cloudflare's proxy carries HTTP/HTTPS only, not the Minecraft TCP protocol.
- **One record serves LAN and WAN**, but only because Pi-hole holds no local override for this hostname — verified, `192.168.100.2` and `.3` both return the public address, so LAN clients hairpin through the router exactly like external ones. If an override is ever added for this name, this record must be mirrored into both Pi-holes with port **25565**, or LAN play breaks while external play keeps working. That is the same split-horizon shape as the AAAA leak that hid the tunnel outage for 68 days, so it is written into the manifest comment and the reference doc rather than left to be rediscovered.

## Rollout is additive — nothing is unreachable at any point

The **25565 forward is deliberately still live**. Order:

1. Merge this. `approvePlan: auto`, so the record applies within ~10 minutes.
2. Confirm resolution: `dig +short SRV _minecraft._tcp.minecraft.vollminlab.com`
3. Join from a real client on `minecraft.vollminlab.com` (no port) and confirm it lands.
4. **Only then** delete the "Minecraft External" 25565 rule on the router. That is the step that actually stops the scanner traffic.

Rollback at any stage is one of: delete the SRV, or re-add the 25565 forward. Neither touches the server, the world, or the whitelist, and the pod is never restarted.

## Also

Corrects two things in the Minecraft section of `cluster-reference.md`:

- The egress line still described the pre-#1181 `0.0.0.0/0` rule with no RFC1918 exclusion, and implied DNS came from that rule rather than from the namespace-wide `allow-dns`.
- The data PVC was listed unnamed as "Config PVC"; it is `pvc-minecraft-datadir` (20Gi `longhorn-dmz`, RWX, confirmed live).

Plus new rows for the public hostname, public port and SRV record, since external access is no longer guessable from the manifests alone.

## Scope note

This is exposure hygiene, not a security fix. 29 days of logs showed 13 scanner probes and **0 successful logins** — the whitelist rejected every one. It cuts noise and makes the server harder to stumble across; it does not change whether anyone can get in. **#1131 (Paper 1.21.10 is an EOL branch, no security patches since 2026-01-04) is the item on this workload that actually matters.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MJ9d87kNJjoBbKfHPBFAx