### PR TITLE
fix(cloudflare): SRV record needs priority inside data, not just top-level

### DIFF
--- a/terraform/cloudflare/dns.tf
+++ b/terraform/cloudflare/dns.tf
@@ -95,6 +95,21 @@ resource "cloudflare_dns_record" "minecraft" {
 #
 # Java Edition only. Bedrock ignores SRV, so a Bedrock client would need the
 # port typed explicitly. Not a concern here -- the server is Paper.
+#
+# priority is set TWICE, deliberately, and both are load-bearing.
+#
+# The provider schema marks data.priority merely "optional", so a config with
+# only the top-level priority passes tofu validate and plans cleanly -- then
+# fails at apply time against the real API with
+# "code 9101: priority is a required data field". That is what happened on
+# 2026-08-24: the record was never created and the Terraform CR retry-looped
+# until this fix. Verified against the live zone: the top-level-only payload
+# is rejected, the payload below is accepted.
+#
+# The top-level one stays because Cloudflare echoes priority back in BOTH
+# places for SRV, and the top-level attribute is optional-not-computed.
+# Dropping it from the config would leave config null against a state of 0,
+# which plans as a permanent one-line diff on every reconcile.
 resource "cloudflare_dns_record" "minecraft_srv" {
   zone_id  = var.cloudflare_zone_id
   name     = "_minecraft._tcp.minecraft.vollminlab.com"
@@ -104,9 +119,10 @@ resource "cloudflare_dns_record" "minecraft_srv" {
   priority = 0
 
   data = {
-    port   = 57913
-    target = "dynamic.vollminlab.com"
-    weight = 5
+    priority = 0
+    port     = 57913
+    target   = "dynamic.vollminlab.com"
+    weight   = 5
   }
 }
 


### PR DESCRIPTION
Fixes the failed apply from #1217. `cloudflare-config` has been in a retry loop since 2026-08-24T00:14Z.

## What was wrong

#1217 set `priority` as a top-level argument only. The provider schema marks `data.priority` as merely *optional*, so that config passes `tofu fmt`, passes `tofu validate`, and plans cleanly as `1 to add, 0 to change, 0 to destroy`. It then fails against the real API:

```
POST https://api.cloudflare.com/client/v4/zones/.../dns_records: 400 Bad Request
{"code":9101,"message":"priority is a required data field."}
```

So the SRV record was never created, `lastAppliedRevision` is still the pre-#1217 commit, and the controller has been re-running the same doomed apply every ~90s, spawning a `tf-runner` pod each cycle.

**Nothing was destroyed or changed** — the plan only ever contained the one create. Minecraft is unaffected and still reachable on 25565.

## Verified against the live zone before writing the fix

Rather than merge and watch, both payloads were sent to the real API under a throwaway name (`_srvcheck._tcp.srvcheck.vollminlab.com`):

| Payload | Result |
| --- | --- |
| `priority` top-level only (what #1217 sends) | `success=False`, `code 9101` — reproduces the failure exactly |
| `priority` top-level **and** inside `data` (this PR) | `success=True`, record created |

The throwaway record was then deleted and the zone re-listed: **0 SRV records**, back to its prior state.

## Why `priority` is set twice

Not redundancy. The successful API response echoes it in both places:

```
top-level priority = 0
data = {'port': 57913, 'priority': 0, 'target': 'dynamic.vollminlab.com', 'weight': 5}
```

The top-level attribute is `optional`, not `computed`. Dropping it from the config would leave a null config against a state of `0`, which plans as a permanent one-line diff on every reconcile. Both stay, and the manifest comment says why so the next person doesn't "clean up" the duplication.

## The trap worth remembering

`tofu validate` and a clean plan prove nothing about whether a Cloudflare record is well-formed — the provider's optionality and the API's requirements disagree, and only apply finds out. This is the same shape as a Kyverno rule whose `foreach.list` resolves to null: green everywhere, enforcing nothing.

## Rollout

`approvePlan: auto`, so this applies within ~10 minutes of merge and the retry loop ends on the first successful apply. Then, per #1217's sequencing, the 25565 router forward can be removed once a real client has connected on `minecraft.vollminlab.com` with no port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVhFJGidDwveBX24K3bcuL