### PR TITLE
feat(minecraft): move Paper 1.21.10 off its EOL branch to 26.2

### DIFF
--- a/clusters/vollminlab-cluster/dmz/minecraft/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/dmz/minecraft/app/configmap.yaml
@@ -11,7 +11,11 @@ data:
   values.yaml: |
     image:
       repository: itzg/minecraft-server
-      tag: "java21"
+      # 26.x requires Java 25 (1.21.x required 21). Paper's own version
+      # metadata reports java.version.minimum=25 for 26.1.2 and 26.2, so this
+      # tag has to move in the same commit as the version below or the server
+      # will not start.
+      tag: "java25"
     resources:
       requests:
         cpu: 2000m
@@ -51,7 +55,21 @@ data:
       storageClass: longhorn-dmz
     minecraftServer:
       eula: "TRUE"
-      version: "1.21.10"
+      # 26.2, Paper's current release line (build #116, 2026-08-23).
+      #
+      # 1.21.10 was EOL: its last build was #130 on 2026-01-04 and Paper's API
+      # reports support.status=UNSUPPORTED, end=2026-01-17. The obvious smaller
+      # hop, 1.21.11, is EOL too -- last build #132 on 2026-05-11, support ended
+      # 2026-06-15 -- so it would trade one dead branch for another and still
+      # need this same window later. Only 26.1.2 and 26.2 report SUPPORTED, and
+      # 26.2 is the current line.
+      #
+      # This migrates the world format and is NOT reversible. Verified backups
+      # exist before the roll: minecraft-pre-1131-20260824010150 (MinIO, 720h),
+      # velero-daily-full-20260823030001 (MinIO), velero-daily-b2-20260823040001
+      # (B2, 2160h) -- each with a Completed PodVolumeBackup for `datadir`
+      # carrying a real snapshot ID and ~5.85 GB, not just a Completed Backup.
+      version: "26.2"
       type: "PAPER"
       memory: "6G"
       viewDistance: 8
@@ -96,7 +114,11 @@ data:
       # default is 0, i.e. disabled. 300 is the commonly used safe value -- high
       # enough that normal play never approaches it, low enough to blunt a flood.
       RATE_LIMIT: "300"
-      PLUGINS: "https://cdn.modrinth.com/data/swbUV1cr/versions/lfk408pd/bluemap-5.13-spigot.jar"
+      # BlueMap 5.23. This MUST move in the same roll as the version above:
+      # 5.13 supports 1.20 through 1.21.11 and stops there, 5.23 supports 26.1
+      # through 26.2 and starts there. There is no build that spans both, so
+      # staging the two bumps separately leaves BlueMap broken in between.
+      PLUGINS: "https://cdn.modrinth.com/data/swbUV1cr/versions/g7xgp4Xr/bluemap-5.23-spigot.jar"
       OVERRIDE_WHITELIST: "TRUE"
     # RCON password from secret (itzg/minecraft-server supports RCON_PASSWORD env var)
     # Note: The Helm chart may need extraEnvVars or envFrom instead - check chart docs

--- a/docs/cluster-reference.md
+++ b/docs/cluster-reference.md
@@ -1396,8 +1396,9 @@ The `dmz` namespace is a security boundary for internet-exposed workloads. Full 
 |---|---|
 | Chart version | v4.0.0 |
 | Helm repo | https://itzg.github.io/minecraft-server-charts/ |
-| Image | `itzg/minecraft-server:java21` |
+| Image | `itzg/minecraft-server:java25` (26.x requires Java 25) |
 | Server type | PAPER |
+| Server version | `26.2` (Paper's current supported line; 1.21.x is EOL) |
 | JVM memory | 6G |
 | CPU | req: 2000m, limits: 4000m |
 | Memory | req: 6Gi, limits: 8Gi |
@@ -1408,7 +1409,7 @@ The `dmz` namespace is a security boundary for internet-exposed workloads. Full 
 | Difficulty | normal |
 | Max world size | 29,999,984 |
 | RCON | enabled (ExternalSecret: `minecraft-rcon-secret`) |
-| Plugins | BlueMap v5.13 (spigot) |
+| Plugins | BlueMap v5.23 (spigot) — 5.23 supports 26.1–26.2 only; 5.13 topped out at 1.21.11, so plugin and server versions must move together |
 | Service type | NodePort |
 | Minecraft port | NodePort `32565` |
 | BlueMap port | NodePort `32566` (container port 8100) |


### PR DESCRIPTION
Closes #1131.

⚠️ **Merging this migrates the world format, which is not reversible.** Backups are verified (below), but the merge is the point of no return — treat it as the maintenance window rather than a routine merge.

## The backup gate, done first

Verified at the **PodVolumeBackup** level, not by trusting a `Backup` that says `Completed`:

| Backup | Tier | TTL | `datadir` bytes | snapshotID |
|---|---|---|---|---|
| `minecraft-pre-1131-20260824010150` | MinIO | 720h | 5,849,028,041 | `09c70329d0c0009e…` |
| `velero-daily-full-20260823030001` | MinIO | 96h | 5,840,311,052 | `5f256aaa0696d3ba` |
| `velero-daily-b2-20260823040001` | **B2** | 2160h | 5,840,713,535 | `cd6b37e0cb7d70ae` |

All `Completed`, 0 errors, real snapshot IDs, non-zero bytes. The fresh one was taken after today's play, so it is ahead of the nightlies.

Two details that make it actually restorable rather than merely present:

- Its `labelSelector: app=minecraft` matches **both** the Pod and `pvc-minecraft-datadir` — confirmed by evaluating the same selector against the cluster. A selector matching only the pod yields a PVB with no claim to restore into.
- The PVC carries `velero.io/restore-name: minecraft-world-restore` from a successful restore in May, so the restore path is **proven for this exact volume**, not assumed.

## Three things the issue didn't anticipate

**1. `1.21.11` is EOL too — the "smallest hop" option is a dead branch.**

```
1.21.10   UNSUPPORTED  last build #130  2026-01-04   support ended 2026-01-17
1.21.11   UNSUPPORTED  last build #132  2026-05-11   support ended 2026-06-15
26.1.2    SUPPORTED
26.2      SUPPORTED    last build #116  2026-08-23
```

Moving to 1.21.11 would trade one dead branch for another and need this same window again. Ruled out by Paper's own API, not by preference.

**2. 26.x requires Java 25.** 1.21.x required 21. `itzg/minecraft-server:java25` exists (amd64/arm64/riscv64, updated 2026-08-20), so the tag moves in the same commit — otherwise the server simply won't start.

**3. BlueMap must move atomically, not as a follow-up.**

```
5.13  supports 1.20 … 1.21.11    (stops there)
5.23  supports 26.1 … 26.2       (starts there)
```

**No build spans both.** Staging the two bumps in separate PRs leaves BlueMap broken in the gap either way round. The 5.23 spigot jar URL was checked live: `HTTP 200`, 6.3 MB.

## Changes

| | from | to |
|---|---|---|
| `minecraftServer.version` | `1.21.10` | `26.2` |
| `image.tag` | `java21` | `java25` |
| `PLUGINS` | `bluemap-5.13-spigot.jar` | `bluemap-5.23-spigot.jar` |

Plus the matching rows in `cluster-reference.md`, including a note that plugin and server versions are now coupled.

## Verify after merge

Flux reconciles within ~10 minutes and the pod restarts. First boot downloads the 26.2 jar and BlueMap 5.23, then **upgrades the world**, which takes noticeably longer than a normal start on a 5.4 GB save.

```bash
kubectl get pod -n dmz -l app=minecraft -w
kubectl logs -n dmz -l app=minecraft --tail=60 | grep -iE "starting|version|bluemap|world|error"
```

Then confirm from outside, which is the part no in-cluster check covers — connect on `minecraft.vollminlab.com` (no port; the SRV from #1217 handles it) and check the world loads at your last position. BlueMap on `:8100` will re-render tiles for the new format, so expect it to be busy for a while.

**Rollback**, if the world doesn't load: revert this commit to return to 1.21.10 + java21 + BlueMap 5.13, then restore `pvc-minecraft-datadir` from `minecraft-pre-1131-20260824010150`. Reverting the manifest alone is not enough — once 26.2 has opened the save, the on-disk format has already moved.

## Follow-up, deliberately not bundled

Renovate still can't see `minecraftServer.version` — it's a plain string with no datasource, which is why this drifted for 7½ months. A `customManager` needs a custom Paper datasource, and a half-working one that silently stops matching is worse than a known gap. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MJ9d87kNJjoBbKfHPBFAx