### PR TITLE
feat(monitoring): alert on a Longhorn replica stranded mid-rebuild

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -350,6 +350,9 @@ data:
           - apiGroups: ["infra.contrib.fluxcd.io"]
             resources: ["terraforms"]
             verbs: ["list", "watch"]
+          - apiGroups: ["longhorn.io"]
+            resources: ["replicas"]
+            verbs: ["list", "watch"]
       customResourceState:
         enabled: true
         config:
@@ -448,6 +451,37 @@ data:
                           ready: [status, conditions, "[type=Ready]", status]
                           reason: [status, conditions, "[type=Ready]", reason]
                           suspended: [spec, suspend]
+              # Longhorn Replica CRs. Longhorn's own exporter is volume-scoped
+              # (longhorn_volume_robustness) and exposes nothing per replica, so a
+              # replica stranded mid-rebuild is invisible to Prometheus. That is the
+              # exact shape of the 51h stall on 2026-08-22..24: the volume kept
+              # flickering back to `healthy` (3 of 3 spec'd replicas RW) while a 4th
+              # orphan replica sat with healthyAt unset and never rebuilt, so
+              # longhorn_volume_robustness read degraded only 4.9% of a 24h window —
+              # ranked *below* several healthy-but-rebalancing volumes.
+              # Cardinality is bounded by replica count (139 on 2026-08-24): metadata.name
+              # is already a label, and healthy_at flips "" -> timestamp exactly once per
+              # replica lifetime, so this adds no series beyond the replicas themselves.
+              - groupVersionKind:
+                  group: longhorn.io
+                  version: v1beta2
+                  kind: Replica
+                metricNamePrefix: longhorn_crd
+                labelsFromPath:
+                  replica: [metadata, name]
+                  exported_namespace: [metadata, namespace]
+                metrics:
+                  - name: replica_info
+                    help: "Longhorn Replica CR state, for detecting replicas stranded mid-rebuild."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          volume: [spec, volumeName]
+                          node: [spec, nodeID]
+                          healthy_at: [spec, healthyAt]
+                          failed_at: [spec, failedAt]
+                          active: [spec, active]
               # tofu-controller Terraform CRs (served v1alpha2). Same Ready-condition
               # shape; reason carries TerraformAppliedSucceed / TFExecPlanFailed /
               # DriftDetected — the alert keys on reason to skip intentional drift.

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -379,6 +379,43 @@ spec:
             summary: "Longhorn volume {{ $labels.pvc }} ({{ $labels.pvc_namespace }}) is faulted"
             description: "Volume {{ $labels.volume }} backing PVC {{ $labels.pvc }} in {{ $labels.pvc_namespace }} is faulted. Data may be inaccessible."
 
+        # A replica stranded mid-rebuild. Longhorn can leave a replica with healthyAt
+        # unset indefinitely: a stale "is rebuilding" flag on an ALREADY-healthy peer
+        # blocks the pre-rebuild snapshot purge, so the new replica never starts. The
+        # orphan holds no data (absent from the engine replicaModeMap) and nothing in
+        # Longhorn ever reaps it.
+        #
+        # LonghornVolumeDegraded cannot see this. With spec.numberOfReplicas=3 and 3
+        # replicas RW, the volume reports *healthy* most of the time even though a 4th
+        # orphan CR exists; it only flips to degraded while something surges the spec.
+        # Measured 2026-08-24 over the 24h before the fix, the volume that had been
+        # stuck for 51h was degraded just 4.9% of the window, ranking below `minio`
+        # (33%) and `pvc-filebrowser-config` (6.3%) — both merely rebalancing normally.
+        # Time-in-degraded is therefore not a usable signal; the replica CR is.
+        #
+        # A healthy rebuild here completes in ~51s (measured, 2Gi volume), so 1h is
+        # ~70x headroom and cannot fire on normal rebalancing churn.
+        # Runbook: .claude/rules/storage.md + the surge-move loop in
+        # vollminlab/longhorn-rebalancing-controller#22.
+        - alert: LonghornReplicaStuckRebuilding
+          expr: |
+            longhorn_crd_replica_info{healthy_at="", failed_at="", active="true"} == 1
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Longhorn replica {{ $labels.replica }} has never become healthy"
+            description: >-
+              Replica {{ $labels.replica }} of volume {{ $labels.volume }} on node
+              {{ $labels.node }} has had healthyAt unset for over an hour, so it is
+              stranded mid-rebuild rather than slow. Confirm with a large and still-growing
+              `count` on the FailedStartingSnapshotPurge event for that volume's engine
+              (`kubectl get events -n longhorn-system --field-selector reason=FailedStartingSnapshotPurge`);
+              the IP in that error maps to an already-healthy RW replica, not this one.
+              Fix: patch spec.numberOfReplicas back to the intended count, then delete this
+              replica CR explicitly — it survives the patch — and clear any
+              rebalancer.vollminlab.com/move-* annotations left on the volume.
+
         - alert: LonghornNodeStorageLow
           expr: |
             (longhorn_node_storage_capacity_bytes - longhorn_node_storage_usage_bytes)


### PR DESCRIPTION
## Why

A Longhorn replica stranded mid-rebuild is currently **invisible to Prometheus**. Longhorn's exporter is volume-scoped (`longhorn_volume_robustness`) and exposes nothing per replica.

On 2026-08-22 → 08-24 one sat that way for **51 hours** on `monitoring/alertmanager-…-0`, emitting 6062 `FailedStartingSnapshotPurge` events, and `LonghornVolumeDegraded` never made it visible.

## Why the existing alert can't cover this

The orphan replica has `healthyAt: ""`, `failedAt: ""`, `active: true`, and is absent from the engine `replicaModeMap`. With `spec.numberOfReplicas: 3` and 3 replicas `RW`, the volume reports **healthy** most of the time — it only flips to degraded while something surges the spec.

Measured over the 24h before the fix (fraction of window spent degraded):

| PVC | degraded | actually wrong? |
|---|---|---|
| `minio` | 33.3% | no — normal rebalancing |
| `minio` (2nd vol) | 10.0% | no |
| `pvc-filebrowser-config` | 6.3% | no |
| **`alertmanager-…-0`** | **4.9%** | **yes — stuck 51h** |
| `victoria-metrics-single-server-0` | 3.4% | no |

The genuinely broken volume ranks *below* three healthy ones. Time-in-degraded cannot be thresholded to find this at any value, which is why I dropped my first instinct (an `avg_over_time` escalation of `LonghornVolumeDegraded`) — the data falsified it. The replica CR is the only thing that can see the condition.

## What this does

- Exposes Longhorn `Replica` CRs via the kube-state-metrics **Custom Resource State** config already used for the Flux/tofu readiness metrics (`gotk_resource_info`), plus the `longhorn.io/replicas` list+watch RBAC it needs.
- Adds `LonghornReplicaStuckRebuilding`: `healthy_at=""`, `failed_at=""`, `active="true"` for `1h`, severity `warning`, with a description carrying the confirmation step and the fix.

## Sizing

- A healthy rebuild here completes in **~51s** (measured on a 2Gi volume during this investigation), so `for: 1h` is ~70x headroom and cannot fire on rebalancing churn.
- Cardinality is bounded by replica count (**139** on 2026-08-24). `metadata.name` is already a label, and `healthy_at` flips `""` → timestamp exactly once per replica lifetime, so this adds no series beyond the replicas themselves.

## Validation

- `promtool check rules` on the extracted spec: **36 rules found, SUCCESS**
- `scripts/check-helm-values.py`: 53 charts, 0 problems
- `scripts/check-doc-currency.sh`: passed
- Nested `values.yaml` re-parsed to confirm the new resource lands as `longhorn_crd_replica_info` alongside the 6 existing `gotk_resource_info` entries

## Related

Root cause of the underlying loop is in the rebalancer, filed separately as vollminlab/longhorn-rebalancing-controller#22 (refuse a surge-move when replica count disagrees with spec) and #23 (fail fast and log when the surged replica is never scheduled). This PR is the detection half only.

## Not in scope

`LonghornVolumeDegraded` firing on `minio` a third of the day looks like real alert fatigue and is plausibly why a 51-hour stall blended into the noise. Worth tuning, but it's a separate concern from adding this signal.