### PR TITLE
fix(authentik): restore email_verified for Headlamp, unbreaking kube-apiserver login

### DIFF
--- a/terraform/authentik/providers_oauth2.tf
+++ b/terraform/authentik/providers_oauth2.tf
@@ -55,10 +55,17 @@ resource "authentik_provider_oauth2" "headlamp" {
     }
   ]
 
-  property_mappings = concat(local.common_property_mappings, [
+  # Deliberately NOT local.common_property_mappings: that list carries authentik's
+  # built-in email scope, which returns email_verified=false since 2026.8.0 and is
+  # rejected by the apiserver's --oidc-username-claim=email rule. Headlamp takes
+  # the custom email mapping in its place; see scope_mappings.tf for the full why.
+  property_mappings = [
+    data.authentik_property_mapping_provider_scope.openid.id,
+    data.authentik_property_mapping_provider_scope.profile.id,
+    authentik_property_mapping_provider_scope.headlamp_email.id,
     data.authentik_property_mapping_provider_scope.offline_access.id,
     authentik_property_mapping_provider_scope.groups.id,
-  ])
+  ]
 }
 
 resource "authentik_provider_oauth2" "minio" {

--- a/terraform/authentik/scope_mappings.tf
+++ b/terraform/authentik/scope_mappings.tf
@@ -47,3 +47,42 @@ resource "authentik_property_mapping_provider_scope" "audiobookshelf_policy_clai
     return {"groups": ["user"]}
   EOT
 }
+
+# Headlamp forwards the user's OIDC id_token to the kube-apiserver as a Bearer
+# token, and the apiserver runs with --oidc-username-claim=email. Kubernetes
+# applies a special rule to that one claim (verified against the v1.34 source,
+# staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go):
+# when the username comes from `email`, an `email_verified` claim that is
+# explicitly false is rejected with `oidc: email not verified`. A *missing*
+# email_verified is accepted; only an explicit false fails.
+#
+# authentik 2026.8.0 (deployed 2026-08-19 03:33) changed its built-in email
+# scope mapping to return `"email_verified": False` — it does not actually run
+# an email-verification flow, so the old hardcoded True was an overstatement.
+# That flipped every Headlamp login to a 401 at the apiserver while authentik
+# itself reported a successful sign-in.
+#
+# The built-in mapping is blueprint-managed
+# (managed = "goauthentik.io/providers/oauth2/scope-email"), so editing it in
+# place is reverted on the next authentik restart or upgrade, and it is shared
+# by every other provider. This custom mapping is attached to the Headlamp
+# provider *instead of* the built-in one, restoring exactly the pre-2026.8.0
+# behaviour for that provider alone.
+#
+# On asserting True: authentik performs no email verification, so this is the
+# cluster vouching that the address on its own admin account is genuine, which
+# is the same assertion authentik itself shipped as the default until 2026.8.0.
+# It is scoped to Headlamp and to k8s API authentication. Omitting the claim
+# entirely would also satisfy k8s today, but asserting it stays correct if the
+# structured AuthenticationConfiguration path ever requires the claim present.
+resource "authentik_property_mapping_provider_scope" "headlamp_email" {
+  name        = "Headlamp OpenID 'email'"
+  description = "email scope asserting email_verified, required by kube-apiserver --oidc-username-claim=email"
+  scope_name  = "email"
+  expression  = <<-EOT
+    return {
+        "email": request.user.email,
+        "email_verified": True,
+    }
+  EOT
+}


### PR DESCRIPTION
## Symptom

Headlamp sign-in fails with *"The cluster did not accept your sign-in…"*. Authentik authenticates fine — the **kube-apiserver** rejects the forwarded `id_token`:

```
E0824 23:17:11 authentication.go:75] "Unable to authenticate the request"
  err="[invalid bearer token, oidc: email not verified]"
```

Live on all three control planes, still firing (3 occurrences in a 15-minute sample).

## Root cause

The apiserver runs `--oidc-username-claim=email`. Kubernetes applies a special rule to that one claim — verified against the v1.34 source (`plugin/pkg/authenticator/token/oidc/oidc.go`), not inferred:

- the check runs **only** when the username claim is `email`
- a **missing** `email_verified` is accepted
- an **explicit `false`** is rejected with `oidc: email not verified`

Authentik **2026.8.0**, deployed **2026-08-19 03:33** (Helm revision 11), changed its built-in email scope mapping to:

```python
return {
    "email": request.user.email,
    "email_verified": False
}
```

Read live from the running instance. Authentik runs no email-verification flow, so the old hardcoded `True` was an overstatement upstream was right to drop — it just silently took Headlamp's cluster access with it. Broken ~5 days.

## Things I checked and ruled out

- **kube-apiserver OIDC flags** — present and correctly quoted on all 3 CPs (this was my first hypothesis, given kubeadm's history of resetting CP config; falsified)
- **client_id drift** — apiserver flag matches the live provider exactly
- **email scope not attached** — it is attached
- **RBAC** — `headlamp-oidc-admins` → `cluster-admin` for `User: oidc:scottvollmin@gmail.com`, intact

## Fix

The built-in mapping is blueprint-managed (`managed = "goauthentik.io/providers/oauth2/scope-email"`), so editing it in place is reverted on the next authentik restart or upgrade, and it is shared by every other provider. So instead: a **custom email scope mapping attached to the Headlamp provider in place of the built-in one**, restoring exactly the pre-2026.8.0 behaviour for that provider alone.

Headlamp therefore stops using `local.common_property_mappings` and lists its scopes explicitly — attaching both mappings for the same `scope_name` would leave the merge order deciding the outcome.

**Nothing on the control plane changes.** The username stays `oidc:scottvollmin@gmail.com`, so the ClusterRoleBinding is untouched and no apiserver restart is needed — which also avoids the simultaneous-restart Kyverno deadlock this cluster hit in May.

## The honesty caveat

Asserting `email_verified: True` means the cluster vouches that the address on its own admin account is genuine, which authentik does not independently verify. It is the same assertion authentik itself shipped as the default until 2026.8.0, and it is scoped to Headlamp and to k8s API authentication.

Omitting the claim entirely would also satisfy Kubernetes today (a missing claim is accepted). I chose to assert it because that stays correct if the structured `AuthenticationConfiguration` path ever requires the claim to be present. Happy to switch to omitting if you'd rather not make the assertion at all.

## Validation

- `tofu validate` — Success, configuration is valid
- `tofu fmt -check` — clean
- Root cause confirmed from apiserver logs, the live Authentik mapping expression, and the Kubernetes source

## Note on merging

`terraform/authentik` is the `authentik-config` CR with **`approvePlan: auto`, `interval: 10m`** — merging this applies it to the live Authentik within ~10 minutes. Sign-in should work on the next login after that (existing sessions keep the old id_token until they refresh).