### PR TITLE
fix(velero,kyverno): apply kopia-maintain resources that were silently ignored

### DIFF
--- a/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-longhorn-dynamic.yaml
+++ b/clusters/vollminlab-cluster/kyverno/kyverno/policies/exceptions-longhorn-dynamic.yaml
@@ -42,6 +42,24 @@ spec:
             - "longhorn-manager-*"
             - "longhorn-ui-*"
             - "c-*"
+      # RecurringJob-generated CronJobs (filesystem-trim, snapshot-retention)
+      # and the Jobs they spawn. There is no way to give these resources: the
+      # recurringjobs.longhorn.io v1beta2 spec is
+      # {concurrency, cron, groups, labels, name, parameters, retain, task} —
+      # verified against the live CRD schema, there is no resources field. They
+      # are also unreachable by inject-resource-requirements, which matches
+      # Deployment/DaemonSet/StatefulSet only. Matched on Longhorn's own
+      # managed-by label rather than by name, so a RecurringJob added later is
+      # covered automatically and nothing we author can ever match.
+      - resources:
+          kinds:
+            - CronJob
+            - Job
+          namespaces:
+            - longhorn-system
+          selector:
+            matchLabels:
+              longhorn.io/managed-by: longhorn-manager
   exceptions:
     - policyName: require-standard-labels
       ruleNames:
@@ -50,3 +68,7 @@ spec:
     - policyName: require-resources
       ruleNames:
         - require-limits
+    - policyName: require-resources-batch
+      ruleNames:
+        - require-limits-job
+        - require-limits-cronjob

--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -60,17 +60,35 @@ data:
     credentials:
       useSecret: false
 
-    repositoryMaintenanceJob:
-      repositoryConfigData:
-        global:
-          keepLatestMaintenanceJobs: 3
-          podResources:
-            cpuRequest: "50m"
-            cpuLimit: "200m"
-            memoryRequest: "128Mi"
-            memoryLimit: "256Mi"
-
     configuration:
+      # Nesting matters: the chart reads
+      # .Values.configuration.repositoryMaintenanceJob.repositoryConfigData
+      # (templates/repo-maintenance-configmap.yaml). This block sat at the top
+      # level from #668 until 2026-08-25, one level too high, where nothing read
+      # it — so podResources was silently ignored for its entire life and every
+      # kopia-maintain pod ran with `resources: {}`. The velero-repo-maintenance
+      # ConfigMap still rendered, from the chart's OWN default of
+      # keepLatestMaintenanceJobs: 3, which is why it looked configured.
+      # That is also the whole of Kyverno's require-resources-batch backlog:
+      # 134 of 138 failures were these Jobs.
+      #
+      # memoryLimit is 512Mi, NOT the 256Mi this block used to carry and not the
+      # 200Mi in velero's own docs. Measured over 7d, peak working set is 295 MiB
+      # (mediastack-b2), with harbor/dmz/minio repos at 207-278 MiB — both of
+      # those values would OOMKill maintenance on the largest repos, and a failed
+      # kopia maintenance degrades quietly. 512Mi is ~1.7x the observed peak.
+      # No cpuLimit: measured peak is 42m, and per .claude/rules/kyverno.md a CPU
+      # limit is deliberately not required — requests plus a memory limit is the
+      # house rule, and this is the first time these values take effect at all.
+      repositoryMaintenanceJob:
+        repositoryConfigData:
+          global:
+            keepLatestMaintenanceJobs: 3
+            podResources:
+              cpuRequest: "50m"
+              memoryRequest: "256Mi"
+              memoryLimit: "512Mi"
+
       # Use kopia file-system backup for PVC data
       defaultVolumesToFsBackup: true
 


### PR DESCRIPTION
## What I found

`require-resources-batch` reports **138** failures — 134 velero kopia-maintain Jobs, 4 Longhorn RecurringJob CronJobs. Neither was what it looked like.

### velero (134): the config was already in git and had never once applied

`podResources` was added in #668 — but at the **top level** of the values, while the chart reads `.Values.**configuration**.repositoryMaintenanceJob` (`templates/repo-maintenance-configmap.yaml`). Nothing read it. Every kopia-maintain pod has run with `resources: {}` for its entire life.

The reason this was invisible: the `velero-repo-maintenance` ConfigMap **still rendered**, from the chart's *own default* of `keepLatestMaintenanceJobs: 3`. So the ConfigMap existed, the `--repo-maintenance-job-configmap` flag was set, and everything looked wired.

```console
$ helm get values velero -n velero --all | ... configuration.repositoryMaintenanceJob
{"repositoryConfigData": {"global": {"keepLatestMaintenanceJobs": 3}, ...}}   # ← chart default only
$ kubectl get cm -n velero velero-repo-maintenance -o jsonpath='{.data}'
{"global": "{\n  \"keepLatestMaintenanceJobs\": 3\n}"}                        # ← no podResources
```

Moving the block one level down fixes it. Verified by rendering the chart with the new values — the ConfigMap now emits `podResources`.

### Sizing is measured, and the previous numbers were unsafe

`memoryLimit` goes to **512Mi** — not the 256Mi this block used to carry, and not the 200Mi in Velero's own docs. Measured peak working set over 7 days:

| repo | peak |
|---|---|
| mediastack-b2 | **295 MiB** |
| mediastack-minio | 278 MiB |
| dmz-b2 | 228 MiB |
| harbor-b2 | 220 MiB |

**Both 256Mi and the doc's 200Mi would OOMKill maintenance on the largest repos** — and a failed kopia maintenance degrades quietly. 512Mi is ~1.7× observed peak. Peak CPU is 42m, so `cpuRequest: 50m` and **no cpuLimit**, per the house rule that a CPU limit isn't required.

These values take effect for the first time here, so they're sized from measurement rather than inherited on trust.

### longhorn (4): genuinely unfixable, so a scoped exception

The `recurringjobs.longhorn.io` v1beta2 spec is `{concurrency, cron, groups, labels, name, parameters, retain, task}` — checked against the live CRD schema, **there is no resources field**. `inject-resource-requirements` doesn't reach them either (Deployment/DaemonSet/StatefulSet only). Nobody can fix these, and leaving them means this policy can never reach Enforce.

Added to the existing `ignore-longhorn-dynamic-pods` PolicyException, matched on Longhorn's **own `longhorn.io/managed-by` label** rather than by name, so a RecurringJob added later is covered automatically and nothing we author can ever match.

## Verification

`kyverno apply` over all **178** live Job/CronJob objects:

```
without exception:  pass 40, fail 138
with exception:     pass 40, fail 134, skip 4
```

The 4 skips are exactly `filesystem-trim`, `snapshot-retention` and their two Jobs. No over-match.

The remaining 134 clear as maintenance Jobs rotate under `keepLatestMaintenanceJobs: 3` once the ConfigMap change lands — existing Jobs keep `resources: {}` until recycled.

Also run: `check-helm-values.py` (53 charts, 0 problems), `check-doc-currency.sh` (passed), `helm template` render check.

## Worth noting separately

**`check-helm-values.py` passed before this fix too.** It validates values against chart schemas, so a well-formed key at the wrong nesting level — ignored rather than invalid — goes straight through. That's the same silent-inert failure shape as the Kyverno `foreach` bug in #1104/#1109, and it's how a fix from #668 sat dead for months. Detecting it generally would mean diffing rendered output or asserting on keys the chart doesn't consume; I haven't attempted that here.