### PR TITLE
fix(velero): restore cpuLimit — its absence stopped ALL repo maintenance

### DIFF
--- a/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/velero/velero/app/configmap.yaml
@@ -77,15 +77,25 @@ data:
       # (mediastack-b2), with harbor/dmz/minio repos at 207-278 MiB — both of
       # those values would OOMKill maintenance on the largest repos, and a failed
       # kopia maintenance degrades quietly. 512Mi is ~1.7x the observed peak.
-      # No cpuLimit: measured peak is 42m, and per .claude/rules/kyverno.md a CPU
-      # limit is deliberately not required — requests plus a memory limit is the
-      # house rule, and this is the first time these values take effect at all.
+      # cpuLimit MUST be set, even though .claude/rules/kyverno.md says a CPU limit
+      # is deliberately not required. That rule is about what Kyverno enforces on
+      # our own workloads; velero's parser is stricter than Kubernetes. Once
+      # podResources exists at all, ParseResourceRequirements
+      # (pkg/util/kube/resource_requirements.go) reads all four fields
+      # unconditionally, so an omitted one arrives as "" and fails:
+      #   couldn't parse CPU limit "": quantities must match the regular expression
+      # That is not a per-job failure — it aborts the maintenance job BEFORE
+      # creation, so every repo silently stops being maintained while the
+      # BackupRepository stays Ready. Dropping this line on 2026-08-25 stopped
+      # maintenance on all 44 repos for ~1.5h with no alert. 200m is ~4.8x the
+      # measured 42m peak, so it is headroom rather than throttling.
       repositoryMaintenanceJob:
         repositoryConfigData:
           global:
             keepLatestMaintenanceJobs: 3
             podResources:
               cpuRequest: "50m"
+              cpuLimit: "200m"
               memoryRequest: "256Mi"
               memoryLimit: "512Mi"
 


### PR DESCRIPTION
## Urgent — this is a regression I introduced in #1229

Repo maintenance has been failing for **all 44 backup repositories** since **00:15:47** today.

```
"Starting repo maintenance failed" backupRepo=velero/mediastack-minio-kopia
  error="error to build maintenance job: failed to parse resource requirements for
  maintenance job: couldn't parse CPU limit \"\": quantities must match the regular
  expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'"
```

## What I got wrong

#1229 dropped `cpuLimit` on the reasoning that `.claude/rules/kyverno.md` deliberately doesn't require a CPU limit. That rule is about **what Kyverno enforces on our own workloads** — it says nothing about what velero's own parser accepts, and I didn't check before removing the field.

Once `podResources` exists at all, velero's `ParseResourceRequirements` (`pkg/util/kube/resource_requirements.go`) reads **all four fields unconditionally**. An omitted field arrives as `""` and fails to parse.

Before #1229 there was no `podResources` key at all, so the parser was never reached. **The bug only became reachable once the block started working** — fixing the silent no-op is what exposed it.

## Why nothing caught it

The failure aborts the job *before creation*, so:

- each `BackupRepository` still reports `phase: Ready`
- `lastMaintenanceTime` just quietly stops advancing (oldest is now 23:07, ~2.7h stale against a `1h0m0s` frequency)
- no Job object is ever created, so there's nothing for a Job-failure alert to fire on
- it surfaces only as a `level=warning` line in the velero server log

This is the same shape as the other silent-inert failures in this repo: the status stays green because the work never starts.

## Impact

Kopia maintenance is what reclaims space by deleting orphaned content blocks. MinIO is currently at **75% (25G free of 99G)** — not an emergency, but this needs to land today, not this week. No backup *data* is at risk; only reclamation is stalled.

## The fix

Restore `cpuLimit: "200m"` — ~4.8× the measured 42m peak, so headroom rather than throttling. Verified by rendering the chart: the ConfigMap now emits all four fields.

The comment in the values file now records why this line cannot be removed despite the house rule, so the next person applying that rule doesn't repeat it.

## After merge

`flux reconcile helmrelease velero -n velero` if you don't want to wait for the 10m interval. Maintenance should resume on the next cycle and the `require-resources-batch` failures from #1229 will then actually start clearing — which they haven't been, because no compliant Job has been created yet.