### PR TITLE
fix(minio): retry the B2 mirror, and alert when a CronJob stops succeeding

### DIFF
--- a/clusters/vollminlab-cluster/minio/cnpg-b2-mirror/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/minio/cnpg-b2-mirror/app/cronjob.yaml
@@ -27,7 +27,14 @@ spec:
       # the steady state is one day of base backups plus that day's WAL.
       activeDeadlineSeconds: 5400
       # backoffLimit 0 would make a single transient B2 error a failed day.
-      backoffLimit: 1
+      # Raised 1 -> 3 on 2026-08-25. One retry was not enough: a failed run
+      # leaves the day's WAL unmirrored, so the next run has MORE to copy and
+      # is MORE likely to hit another transient error — the backlog and the
+      # failure probability feed each other. Observed 2026-08-23 -> 08-25:
+      # last success 08-23, and by 08-25 a run was moving 1.08 GiB and dying
+      # partway. Each attempt is incremental and keeps what it copied, so extra
+      # attempts strictly converge.
+      backoffLimit: 3
       template:
         metadata:
           labels:
@@ -108,7 +115,17 @@ spec:
                   # (authentik) / 14d (the rest) retention has expired them, so
                   # the offsite copy reaches further back than the local one.
                   # Bound it with a B2 lifecycle rule, not with --remove.
-                  $MC mirror src/cnpg-backups b2/vollminlab-k8s-cnpg
+                  # --retry retries the individual objects that errored.
+                  # Without it a single transient B2 fault fails the whole run:
+                  #   Failed to copy ... Put "https://s3.us-west-000...":
+                  #   net/http: HTTP/1.x transport connection broken:
+                  #   http: ContentLength=802670 with Body length 0
+                  # mc continues past a failed object but still exits non-zero,
+                  # and `set -e` above turns that into a failed day. Note this
+                  # is NOT --skip-errors: that would exit 0 with objects
+                  # missing, which is the silent-success failure this script
+                  # exists to avoid.
+                  $MC mirror --retry src/cnpg-backups b2/vollminlab-k8s-cnpg
 
                   # Content guard. A mirror that copies nothing into an empty
                   # destination still exits 0.

--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -224,6 +224,54 @@ spec:
             summary: "Velero monthly-b2 backup is stale"
             description: "velero-monthly-b2 last succeeded {{ $value | humanizeDuration }} ago (threshold 32d, matching the content guard's 768h override for this schedule)."
 
+    # A CronJob that stops succeeding is invisible here. Nothing watches Job
+    # exit codes, and the CronJob object itself keeps reporting normally — the
+    # only thing that changes is a timestamp that stops advancing. minio's
+    # cnpg-b2-mirror last succeeded 2026-08-23 and was found by accident two
+    # days later while reading Headlamp warnings; CNPG's offsite copy was stale
+    # that whole time with nothing said.
+    #
+    # Keyed on lastScheduleTime - lastSuccessfulTime, NOT on time() - success.
+    # A time()-based staleness threshold cannot work here, because the schedules
+    # span five orders of magnitude: */5 (pihole-watchdog) through 0 9 1 * *
+    # (kubeadm-cert-monitor, monthly) to 0 2 14 4,10 * (cert-renew, twice a
+    # year). Any threshold catching a missed daily run fires permanently on the
+    # monthly ones — kubeadm-cert-monitor reads 571h since last success while
+    # being perfectly healthy.
+    #
+    # The schedule-relative form is immune to that: it asks "has the most
+    # recent scheduled run succeeded yet", which is frequency-independent.
+    # Measured across all 16 CronJobs on 2026-08-25, the separation is total:
+    # cnpg-b2-mirror at +23.83h, and EVERY other job negative (-0.0008h to
+    # -0.12h, i.e. success completing after its schedule, as normal). The 2h
+    # threshold therefore has ~12x margin on the real failure and cannot reach
+    # any healthy job, including the monthly and twice-yearly ones.
+    #
+    # Suspended CronJobs are excluded: a deliberately paused job is not a fault.
+    - name: cronjobs
+      rules:
+        - alert: CronJobNotSucceeding
+          expr: |
+            (
+              kube_cronjob_status_last_schedule_time
+                - on(namespace, cronjob) kube_cronjob_status_last_successful_time
+            ) > 2 * 3600
+            and on(namespace, cronjob) kube_cronjob_spec_suspend == 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} has not succeeded since it was last scheduled"
+            description: >-
+              Its most recent scheduled run was {{ $value | humanizeDuration }} before its
+              last success, so the latest run has not completed successfully. The CronJob
+              object stays healthy-looking, so check the Jobs directly:
+              `kubectl get jobs -n {{ $labels.namespace }} | grep {{ $labels.cronjob }}`.
+              Failed Job pods are garbage-collected quickly and their logs are not reliably
+              retained in Loki, so if the pods are already gone, re-run it to capture the
+              failure live:
+              `kubectl create job -n {{ $labels.namespace }} --from=cronjob/{{ $labels.cronjob }} {{ $labels.cronjob }}-diag`.
+
     - name: node-disk
       rules:
         - alert: NodeDiskSpaceLow

--- a/clusters/vollminlab-cluster/monitoring/loki/app/loki-ruler-rules-configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/loki/app/loki-ruler-rules-configmap.yaml
@@ -92,3 +92,53 @@ data:
                 cold-remount before investigating: the CSI driver runs `fsck -a` on mount,
                 and that repair is what destroys data. Take a VolSync snapshot first.
                 Runbook: docs/runbooks/longhorn-ext4-corruption.md
+  velero-maintenance-alerts.yaml: |
+    groups:
+      # Velero repo maintenance that never starts.
+      #
+      # On 2026-08-25 an omitted cpuLimit in the repo-maintenance podResources
+      # made velero fail to BUILD the maintenance job. That aborts before the
+      # Job object is created, so every conventional signal stayed green:
+      # each BackupRepository still reported phase Ready, no Job existed for a
+      # Job-failure alert to key on, and the only trace anywhere in the cluster
+      # was a level=warning line in the velero server log. All 44 repositories
+      # went unmaintained for ~2.5h and nothing said so. Kopia maintenance is
+      # what reclaims space, so the eventual symptom would have been MinIO
+      # filling with no indication of why.
+      #
+      # There is no metric for this. velero exposes no gauge for maintenance
+      # success, and BackupRepository.status.lastMaintenanceTime is a CR field
+      # rather than a series. The log line is the only available signal, which
+      # is exactly the case Loki rules exist for.
+      #
+      # Scoped to namespace="velero". That is not cosmetic: Loki logs every
+      # query it serves, so an unscoped matcher on an error string matches its
+      # own query text and self-amplifies (~1200 hits/eval when this was last
+      # hit). Loki's own logs are in namespace="monitoring", so pinning the
+      # namespace keeps the rule from reading itself.
+      - name: velero-maintenance
+        rules:
+          - alert: VeleroRepoMaintenanceNotStarting
+            expr: |
+              sum(
+                count_over_time(
+                  {namespace="velero", container="velero"}
+                    |= "Starting repo maintenance failed"
+                    [15m]
+                )
+              ) > 3
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Velero cannot start repo maintenance — kopia is not reclaiming space"
+              description: >-
+                {{ $value | humanize }} maintenance-start failures in 15 minutes. The job fails
+                before creation, so BackupRepositories still read Ready and no Job exists to
+                inspect. Confirm the scope with the timestamp that stops advancing:
+                `kubectl get backuprepositories.velero.io -n velero -o custom-columns='NAME:.metadata.name,LAST:.status.lastMaintenanceTime'`
+                and read the reason with
+                `kubectl logs -n velero -l app.kubernetes.io/name=velero --tail=2000 | grep 'repo maintenance failed'`.
+                A common cause is an incomplete podResources block in the velero-repo-maintenance
+                ConfigMap — velero parses all four fields unconditionally, so omitting one
+                fails with `couldn't parse CPU limit ""`.


### PR DESCRIPTION
## The failure

`minio/cnpg-b2-mirror` last succeeded **2026-08-23**. I found it on 08-25 by accident while reading Headlamp warnings for something else — CNPG's offsite copy was two days stale and nothing said so.

**Already fixed operationally**: I ran the mirror to completion, so B2 is caught up (4857 objects, content guard passed) and the CronJob's `lastSuccessfulTime` now reads 04:10. This PR makes it not recur, and makes the next one visible.

## Root cause

The failed pods had been garbage-collected and Loki hadn't retained their logs, so I re-ran the job live to capture it:

```
mc: <ERROR> Failed to copy ... Put "https://s3.us-west-000.backblazeb2.com/...":
  net/http: HTTP/1.x transport connection broken: ContentLength=802670 with Body length 0
Total 1.08 GiB | Transferred 1.08 GiB | Duration 03m06s
```

One transient B2 fault. `mc` continues past a failed object but still exits non-zero, and `set -e` turns that into a failed day.

**It then feeds itself.** An unmirrored day means the next run has more to copy, which makes another transient fault more likely. By 08-25 a run was moving **1.08 GiB** where the steady state is one day of WAL. My second run only had **406 KiB** left and completed cleanly — which is the death spiral confirmed from both ends.

## Resilience

- `mc mirror --retry` — retries the objects that errored. **Deliberately not `--skip-errors`**, which exits 0 with objects missing; that's precisely the silent-success failure this script's existing content guard was written to prevent.
- `backoffLimit` 1 → 3. Each attempt is incremental and keeps what it copied, so extra attempts strictly converge.

## Detection — the part that was missing

Two alerts, one for each invisible-failure shape hit this week.

### `CronJobNotSucceeding`

Keys on `lastScheduleTime - lastSuccessfulTime`, **not** `time() - lastSuccessfulTime`.

A time-based staleness threshold cannot work here. Schedules span `*/5` to twice-yearly, so any threshold that catches a missed daily run fires permanently on the monthly `kubeadm-cert-monitor` — which reads **571h** since last success while being perfectly healthy.

The schedule-relative form asks "has the most recent scheduled run succeeded yet", which is frequency-independent. Measured across all 16 CronJobs, the separation is total:

| CronJob | schedule − success |
|---|---|
| **minio/cnpg-b2-mirror** | **+23.83h** |
| every other job (16) | −0.0008h to −0.12h |

The 2h threshold has ~12× margin on the real failure and cannot reach any healthy job, including the monthly and twice-yearly ones.

### `VeleroRepoMaintenanceNotStarting`

Covers the other shape, from the cpuLimit regression earlier tonight (#1229 → #1230). That made velero fail to **build** the maintenance job, aborting before the Job object existed — so BackupRepositories stayed `Ready`, no Job existed for a Job-failure alert to key on, and the only trace cluster-wide was a `level=warning` line in the velero server log.

No metric exists for it (velero exposes no maintenance-success gauge, and `lastMaintenanceTime` is a CR field), so it has to be a Loki rule. Scoped to `namespace="velero"` so it cannot match its own query text — Loki logs every query it serves, and an unscoped error-string matcher self-amplifies.

## Verification

- `promtool check rules`: **37 rules, SUCCESS**
- Alert expression run against live data **while broken**: fired on exactly `minio/cnpg-b2-mirror`, nothing else
- Same expression **after the fix**: returns empty — no CronJob alerting
- `check-helm-values.py` (53 charts, 0 problems), `check-doc-currency.sh` passed
- Mirror re-run to completion: `objects in B2 after mirror: 4857`, exit 0