### PR TITLE
fix(longhorn-mount-healer): detect crash-cycling by readiness, not backoff state

### DIFF
--- a/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh
+++ b/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal.sh
@@ -40,13 +40,29 @@ in_cooldown() {
   [ "$delta" -lt "$cd" ]
 }
 
-# pod_crashloop_restarts: echo summed restartCount IF a container/init is in
-# CrashLoopBackOff, else echo 0. $1=ns $2=pod
+# pod_crashloop_restarts: echo summed restartCount IF a container/init is
+# not ready, else echo 0. $1=ns $2=pod
+#
+# Gated on readiness, NOT on `state.waiting.reason == CrashLoopBackOff`, because
+# a crash-cycling pod is only *waiting* for part of each cycle — between backoffs
+# the container is Running again. Sampling the waiting reason therefore misses the
+# pod whenever the CronJob happens to fire during that window, and the window is
+# not small: prowlarr ran ~42s per attempt against a 5m backoff.
+#
+# That is not hypothetical. On 2026-08-25 prowlarr crash-looped in mediastack from
+# 07:59:36 with an EIO stale mount, which is exactly what this healer exists for.
+# The 08:00 run saw it below the restart threshold; the 08:10 run — by which point
+# it was over the threshold — sampled it mid-Running and read the waiting reason as
+# empty, so it reported "no stuck workloads found" and the pod stayed broken until
+# a human scaled it. Readiness is false for the WHOLE cycle, so it does not race.
+#
+# Readiness also keeps the check conservative in the other direction: a pod that is
+# Ready is never touched, however many times it has restarted in the past.
 pod_crashloop_restarts() {
   ns="$1"; pod="$2"
-  reasons=$(kc get pod "$pod" -n "$ns" -o jsonpath='{.status.containerStatuses[*].state.waiting.reason}{.status.initContainerStatuses[*].state.waiting.reason}')
-  case "$reasons" in
-    *CrashLoopBackOff*) ;;
+  ready=$(kc get pod "$pod" -n "$ns" -o jsonpath='{.status.containerStatuses[*].ready}{.status.initContainerStatuses[*].ready}')
+  case "$ready" in
+    *false*) ;;
     *) echo 0; return 0 ;;
   esac
   restarts=$(kc get pod "$pod" -n "$ns" -o jsonpath='{.status.containerStatuses[*].restartCount} {.status.initContainerStatuses[*].restartCount}')

--- a/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh
+++ b/clusters/vollminlab-cluster/kube-system/longhorn-mount-healer/app/heal_test.sh
@@ -29,8 +29,8 @@ in_cooldown "" "200" "60";    assert_rc "$?" "1" "in_cooldown false when no last
 # A crashlooping radarr pod on a longhorn RWO PVC.
 kc() {
   case "$*" in
-    "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].state.waiting.reason}{.status.initContainerStatuses[*].state.waiting.reason}")
-      echo "CrashLoopBackOff" ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].ready}{.status.initContainerStatuses[*].ready}")
+      echo "false" ;;
     "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].restartCount} {.status.initContainerStatuses[*].restartCount}")
       echo "37 " ;;
     "get pod radarr-x -n mediastack -o jsonpath={.spec.volumes[*].persistentVolumeClaim.claimName}")
@@ -46,18 +46,28 @@ kc() {
     "get rs radarr-5d9 -n mediastack -o jsonpath={.metadata.ownerReferences[?(@.kind==\"Deployment\")].name}")
       echo "radarr" ;;
     # a healthy pod (no waiting reason) on an smb PVC
-    "get pod prowlarr-y -n mediastack -o jsonpath={.status.containerStatuses[*].state.waiting.reason}{.status.initContainerStatuses[*].state.waiting.reason}")
-      echo "" ;;
+    "get pod prowlarr-y -n mediastack -o jsonpath={.status.containerStatuses[*].ready}{.status.initContainerStatuses[*].ready}")
+      echo "true" ;;
     "get pod prowlarr-y -n mediastack -o jsonpath={.spec.volumes[*].persistentVolumeClaim.claimName}")
       echo "media-share" ;;
     "get pvc media-share -n mediastack -o jsonpath={.spec.storageClassName}")
       echo "smb" ;;
+    # Regression, 2026-08-25: a crash-cycling pod sampled BETWEEN backoffs.
+    # The container is Running (no waiting reason at all) but not ready, and
+    # restartCount is already high. The old waiting-reason check returned 0
+    # here, so the healer skipped prowlarr for the entire incident.
+    "get pod sonarr-mid -n mediastack -o jsonpath={.status.containerStatuses[*].ready}{.status.initContainerStatuses[*].ready}")
+      echo "false" ;;
+    "get pod sonarr-mid -n mediastack -o jsonpath={.status.containerStatuses[*].restartCount} {.status.initContainerStatuses[*].restartCount}")
+      echo "9 " ;;
     *) echo "" ;;
   esac
 }
 
 assert_eq "$(pod_crashloop_restarts mediastack radarr-x)" "37" "crashlooping pod -> summed restarts"
 assert_eq "$(pod_crashloop_restarts mediastack prowlarr-y)" "0" "healthy pod -> 0 restarts"
+assert_eq "$(pod_crashloop_restarts mediastack sonarr-mid)" "9" "crash-cycling pod sampled mid-Running -> still counted"
+
 assert_eq "$(longhorn_rwo_volume mediastack radarr-x)" "pvc-abc123" "longhorn RWO pod -> PV name"
 assert_eq "$(longhorn_rwo_volume mediastack prowlarr-y)" "" "smb pod -> no volume"
 assert_eq "$(owner_deployment mediastack radarr-x)" "radarr" "pod -> owning Deployment"
@@ -84,7 +94,7 @@ heal_workload() { HEALED="$1/$2 vol=$3"; }
 kc() {
   case "$*" in
     "get pods -n mediastack -o jsonpath={.items[*].metadata.name}") echo "prowlarr-y" ;;
-    "get pod prowlarr-y -n mediastack -o jsonpath={.status.containerStatuses[*].state.waiting.reason}{.status.initContainerStatuses[*].state.waiting.reason}") echo "" ;;
+    "get pod prowlarr-y -n mediastack -o jsonpath={.status.containerStatuses[*].ready}{.status.initContainerStatuses[*].ready}") echo "true" ;;
     "get pod prowlarr-y -n mediastack -o jsonpath={.status.phase}") echo "Running" ;;
     *) echo "" ;;
   esac
@@ -101,7 +111,7 @@ kc() {
   case "$*" in
     "get pods -n mediastack -o jsonpath={.items[*].metadata.name}") echo "radarr-x sonarr-z" ;;
     # radarr: crashlooping over threshold, longhorn RWO
-    "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].state.waiting.reason}{.status.initContainerStatuses[*].state.waiting.reason}") echo "CrashLoopBackOff" ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].ready}{.status.initContainerStatuses[*].ready}") echo "false" ;;
     "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].restartCount} {.status.initContainerStatuses[*].restartCount}") echo "37 " ;;
     "get pod radarr-x -n mediastack -o jsonpath={.spec.volumes[*].persistentVolumeClaim.claimName}") echo "radarr-config" ;;
     "get pvc radarr-config -n mediastack -o jsonpath={.spec.storageClassName}") echo "longhorn" ;;
@@ -126,7 +136,7 @@ NOWEPOCH=$(date -u +%s)
 kc() {
   case "$*" in
     "get pods -n mediastack -o jsonpath={.items[*].metadata.name}") echo "radarr-x" ;;
-    "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].state.waiting.reason}{.status.initContainerStatuses[*].state.waiting.reason}") echo "CrashLoopBackOff" ;;
+    "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].ready}{.status.initContainerStatuses[*].ready}") echo "false" ;;
     "get pod radarr-x -n mediastack -o jsonpath={.status.containerStatuses[*].restartCount} {.status.initContainerStatuses[*].restartCount}") echo "37 " ;;
     "get pod radarr-x -n mediastack -o jsonpath={.spec.volumes[*].persistentVolumeClaim.claimName}") echo "radarr-config" ;;
     "get pvc radarr-config -n mediastack -o jsonpath={.spec.storageClassName}") echo "longhorn" ;;


### PR DESCRIPTION
## The healer skipped the exact incident it exists for

On 2026-08-25, three worker nodes flapped `Ready` at 07:52:57. prowlarr came back with an EIO stale mount and crash-looped from 07:59:36. The healer covers `mediastack`, ran at **08:00** and **08:10**, and logged `no stuck workloads found` both times. It stayed broken until scaled by hand.

## Why

`pod_crashloop_restarts` gated on `state.waiting.reason == CrashLoopBackOff` before counting restarts:

```sh
reasons=$(kc get pod ... state.waiting.reason ...)
case "$reasons" in
  *CrashLoopBackOff*) ;;
  *) echo 0; return 0 ;;   # <-- returns 0 whenever sampled mid-Running
esac
```

That's a point-in-time sample of a state the pod holds for only **part** of each cycle. Between backoffs the container is Running again with no waiting reason at all. prowlarr ran **~42s per attempt** (`startedAt 08:16:34 → finishedAt 08:17:16`), so the window was wide:

| Run | Restarts | Sampled state | Result |
|---|---|---|---|
| 08:00:01 | ~1 | CrashLoopBackOff | below threshold (5) — correctly skipped |
| 08:10:01 | ~6 | **Running** (mid-cycle) | reason empty → **returned 0** → skipped |

So it was over the threshold and still missed.

## Fix

Gate on **readiness**. It is false for the whole cycle, so it cannot race. It's also strictly more conservative in the other direction — a Ready pod is never touched, however many times it restarted in the past.

## Test

Added a regression case stubbing the mid-Running sample: Running, **no waiting reason**, `ready=false`, `restartCount=9`.

I verified it actually discriminates rather than just passing — reconstructed the old implementation and ran the new suite against it:

```
FAIL - crash-cycling pod sampled mid-Running -> still counted (got [0] want [9])
```

Against the new implementation: **0 failures under `sh`, `dash`, and `busybox ash`** (the image is `alpine/kubectl`, so ash matters).

The existing stubs moved from `state.waiting.reason` to `ready` accordingly.

## Deliberately not fixed here

**This healer can only ever catch workloads that crash.** In the same event, sonarr broke with both containers `Ready` and **0 restarts**, serving SQLite `database disk image is malformed` from the same stale mount. Its on-disk DB was verified intact afterwards (`integrity_check ok`, 0 FK violations, 88 series / 7067 episodes) — the process was simply reading through a stale handle.

No readiness- or restart-based check can see that shape, and auto-restarting Ready pods on log content is not something I'd put in an unattended healer. That blind spot wants a **Loki alert on EIO / `disk image is malformed` for Longhorn-backed namespaces**, which is a separate change — and it also invalidates the reasoning in the existing `filesystem-corruption` Loki rule, which excludes EIO on the stated grounds that it is *"covered by the longhorn-mount-healer."* Tonight showed it isn't.

Happy to follow up with that alert.