### PR TITLE
feat(monitoring): alert on a stale Longhorn mount that auto-remediation missed

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/loki/app/loki-ruler-rules-configmap.yaml
+++ b/clusters/vollminlab-cluster/monitoring/loki/app/loki-ruler-rules-configmap.yaml
@@ -54,9 +54,15 @@ data:
           #   EBADMSG / system error -74 — checksum mismatch on a metadata block
           #
           # `Input/output error` (EIO) is deliberately NOT in the set. On this cluster EIO
-          # is the signature of a stale Longhorn mount after a node event — common, benign
-          # once the pod restarts, and covered by the longhorn-mount-healer. Including it
-          # would bury the real signal in noise, and a noisy alert gets muted.
+          # is the signature of a stale Longhorn mount, not of ext4 metadata damage, and
+          # mixing the two would bury this rule's signal in noise.
+          #
+          # This used to say EIO was "benign once the pod restarts, and covered by the
+          # longhorn-mount-healer". 2026-08-25 disproved the second half: three nodes went
+          # NotReady on an I/O stall, prowlarr came back on a stale mount and crash-looped,
+          # and the healer skipped it for 20+ minutes (#1236). EIO now has its own rule —
+          # StaleMountErrorsPersisting, below — gated so it only fires once the healer has
+          # demonstrably failed to clear it.
           #
           # `pod!~"loki-.*"` is not optional — without it this rule alerts on itself
           # forever. Loki logs the text of every query it serves, once per split/shard, so
@@ -142,3 +148,69 @@ data:
                 A common cause is an incomplete podResources block in the velero-repo-maintenance
                 ConfigMap — velero parses all four fields unconditionally, so omitting one
                 fails with `couldn't parse CPU limit ""`.
+  stale-mount-alerts.yaml: |
+    groups:
+      # A stale Longhorn mount that auto-remediation did not clear.
+      #
+      # After a node flaps, a pod can come back holding a mount handle that no longer
+      # resolves. Longhorn reports the volume `attached` and `healthy` with every
+      # replica up, because the replicas ARE fine — the damage is to the pod's view of
+      # them, and nothing in Longhorn's own health model can see that.
+      #
+      # It presents in two very different shapes, and this rule has to catch both:
+      #   prowlarr, 2026-08-25 — `Input/output error : /config/config.xml`, CrashLoopBackOff.
+      #   sonarr, same event    — both containers Ready, 0 restarts, HTTP 500s, and SQLite
+      #     reporting `database disk image is malformed`. The database was NOT corrupt:
+      #     mounting the PVC separately gave `integrity_check ok`, 0 foreign-key
+      #     violations, 88 Series / 7067 Episodes. The bytes were fine; the handle wasn't.
+      #
+      # The second shape is why this rule exists. longhorn-mount-healer keys on
+      # crash-cycling, so a Ready pod with 0 restarts is invisible to it by construction,
+      # and a `malformed` message is otherwise indistinguishable from real corruption —
+      # which very nearly cost a VolSync restore and ~6h of sonarr state.
+      #
+      # Gating: the healer runs every 10 minutes. `> 3 occurrences in 15m` sustained for
+      # `15m` means roughly half an hour of continuous errors, so at least two healer
+      # cycles have already had their chance. A transient EIO that gets cleared stops
+      # logging and never reaches the threshold — which is what kept EIO out of the
+      # corruption rule in the first place.
+      #
+      # The `pod!~` exclusions are not optional, and BOTH are needed:
+      #   loki-*     — logs the text of every query it serves, once per split/shard, so an
+      #                unscoped matcher on an error string matches its own regex on the
+      #                next evaluation (~1200 self-matches per eval, measured).
+      #   promtail-* — is the collector. It re-emits the content it ships, so an error
+      #                logged by any workload reappears in promtail's own stream. Replaying
+      #                this rule over the 2026-08-25 incident window without this exclusion
+      #                matched 7 promtail pods (peak 4-7 each) alongside the 2 real ones.
+      #                Same self-reference trap, one layer further out.
+      #
+      # longhorn-system/longhorn-csi-plugin is deliberately NOT excluded — it reports EIO
+      # it genuinely encountered, which is corroborating signal rather than an echo.
+      - name: stale-mount
+        rules:
+          - alert: StaleMountErrorsPersisting
+            expr: |
+              sum by (namespace, pod) (
+                count_over_time(
+                  {job=~".+", pod!~"loki-.*|promtail-.*"}
+                    |~ `(?i)(input/output error|database disk image is malformed)`
+                    [15m]
+                )
+              ) > 3
+            for: 15m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Stale Longhorn mount not clearing for {{ $labels.namespace }}/{{ $labels.pod }}"
+              description: >-
+                {{ $value | humanize }} I/O errors in 15 minutes, still going after 15 more —
+                longhorn-mount-healer has had at least two cycles and has not fixed it.
+                Longhorn will report the volume attached and healthy; that is expected and
+                does not mean the data is bad. Fix is a full detach, which a container
+                restart does NOT achieve:
+                `kubectl scale deploy -n {{ $labels.namespace }} <deploy> --replicas=0`,
+                wait for the volume to report `detached`, then scale back to 1.
+                If the message is SQLite `malformed`, VERIFY before restoring anything —
+                mount the PVC in a throwaway pod and run `pragma integrity_check` on the
+                real file. On 2026-08-25 that check came back clean and no restore was needed.


### PR DESCRIPTION
## Why

On 2026-08-25 three nodes went NotReady on an I/O stall and two workloads came back holding **stale mount handles**. Longhorn reported both volumes `attached` and `healthy` with every replica up — correctly, because the replicas *were* fine. The damage was to the pods' view of them, which nothing in Longhorn's health model can see.

Two shapes, one cause:

| Workload | Symptom | Caught by existing tooling? |
|---|---|---|
| prowlarr | `Input/output error : /config/config.xml`, CrashLoopBackOff | healer *should* have — it didn't (#1236) |
| sonarr | **Ready, 0 restarts**, HTTP 500s, SQLite `database disk image is malformed` | **impossible** — healer keys on crash-cycling |

**sonarr's database was not corrupt.** Mounting the PVC separately gave `integrity_check ok`, 0 foreign-key violations, 88 Series / 7067 Episodes. The bytes were fine; the handle wasn't. A `malformed` message is otherwise indistinguishable from real corruption, and it very nearly cost a VolSync restore and ~6h of state — so the alert text says to verify with `pragma integrity_check` before restoring anything.

## Gating — only fires once auto-remediation has failed

`> 3 occurrences in 15m`, sustained `for: 15m` ≈ half an hour of continuous errors. longhorn-mount-healer runs every 10 minutes, so at least two cycles have already had their chance.

A transient EIO that gets cleared stops logging and never reaches the threshold — which is exactly why EIO was kept out of the `filesystem-corruption` rule originally. That rule's comment asserted EIO was *"covered by the longhorn-mount-healer"*; this PR updates it rather than leaving a claim the incident disproved.

## Validation caught a false-positive class I'd have shipped

Replaying the rule over the real incident window (08:00–08:20), the first version matched **7 promtail pods** (peak 4–7) alongside the 2 real ones. promtail is the collector — it re-emits the content it ships, so any workload's error reappears in promtail's own stream. **Same self-reference trap as Loki, one layer further out.**

With `promtail-*` excluded:

```
WOULD FIRE during the incident: 4
  mediastack/sonarr        peak=372
  mediastack/prowlarr      peak=40
  authentik/authentik-server        peak=7
  longhorn-system/longhorn-csi-plugin  peak=5
```

`longhorn-csi-plugin` is deliberately **kept** — it reports EIO it genuinely encountered, which corroborates rather than echoes.

Against live Loki right now, with both pods fixed: **0 matches**.

## Note on the underlying event

The node flap was **not** a network problem. No node rebooted (all 9 at 413h uptime), no carrier changes, and it doesn't correlate with ESXi host placement — worker05 shares host-9001 with worker01 and worker03 and did not flap. It correlates cleanly with per-node I/O stall in the 07:45–07:55 window (w04 0.0737, w01 0.0735, w03 0.0212, next node 0.0052). That's a separate stabilisation question, not addressed here.