### PR TITLE
feat(monitoring): alert on datastore write latency, the thing that flaps nodes

### DIFF
--- a/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
+++ b/clusters/vollminlab-cluster/monitoring/kube-prometheus-stack/app/prometheusrule-custom.yaml
@@ -308,6 +308,79 @@ spec:
     # available memory — the real memory-starvation thrash the alert is meant to catch
     # (which inherently drives MemAvailable down as reclaim churns). I/O-driven fault
     # storms on a node with ample free memory no longer trip it.
+    # Datastore write latency, which is what actually takes nodes down here.
+    #
+    # 2026-08-25 07:52:57: k8sworker01, 03 and 04 all flapped Ready simultaneously,
+    # bouncing ~10 stateful pods. prowlarr and sonarr came back on stale mounts and
+    # sonarr looked like SQLite corruption. Nothing alerted, before or during.
+    #
+    # It was NOT a network event: no node rebooted (all 9 at 413h uptime), no carrier
+    # changes, and it does not follow ESXi host placement — worker05 shares host-9001
+    # with worker01 and worker03 and did not flap. kubelet simply blocked on I/O past
+    # its heartbeat grace period.
+    #
+    # Keyed on write LATENCY, deliberately not on PSI io-stall, because PSI is the
+    # wrong signal here and would have failed in both directions. Measured on worker01:
+    #
+    #   window                    io-stall   write latency   flapped
+    #   backup 03:20-03:30        0.096      16 ms           no
+    #   pre-flap 07:36-07:46      0.080      384 ms          YES
+    #
+    # PSI was HIGHER during a completely harmless backup pass than during the incident,
+    # so any PSI threshold either fires nightly or misses this. Latency separated them
+    # by 24x. (The older note that PSI spikes "cause zero harm" came from exactly that
+    # backup-window observation; it does not generalise.)
+    #
+    # 50ms threshold: the flapping nodes ran 92-384 ms, a normal backup peaks ~23 ms.
+    # Over the 24h to 2026-08-25 only 1-2 five-minute windows per node exceeded 50 ms,
+    # so `for: 10m` needs two consecutive windows and lands on the real event.
+    #
+    # Control planes are excluded from the tighter numbers by physics, not by filter:
+    # they sit on the dedicated NVMe zvol from the etcd latency fix and measure
+    # 0.16-0.32 ms. That contrast is the argument for moving worker storage too — the
+    # same fix has already worked once on this cluster.
+    - name: node-disk-latency
+      rules:
+        - alert: NodeDiskWriteLatencyHigh
+          expr: |
+            (
+              sum by (instance) (rate(node_disk_write_time_seconds_total{device!~"loop.*|dm-.*"}[5m]))
+              /
+              clamp_min(sum by (instance) (rate(node_disk_writes_completed_total{device!~"loop.*|dm-.*"}[5m])), 0.001)
+            ) * 1000 > 50
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "{{ $labels.instance }} disk write latency {{ $value | humanize }}ms"
+            description: >-
+              Sustained write latency above 50ms. The backing store is iSCSI-attached from
+              TrueNAS over 10GbE with jumbo frames, and peak observed throughput (~74 MB/s)
+              is nowhere near that link, so this is array-side saturation rather than a
+              network limit. Left unchecked this stalls kubelet past its heartbeat grace
+              period and takes the node NotReady, which detaches volumes and leaves stale
+              mounts behind — see StaleMountErrorsPersisting. Check which datastore the node
+              sits on (vmstore1/vmstore2) and what else is writing to it.
+
+        - alert: NodeDiskWriteLatencyCritical
+          expr: |
+            (
+              sum by (instance) (rate(node_disk_write_time_seconds_total{device!~"loop.*|dm-.*"}[5m]))
+              /
+              clamp_min(sum by (instance) (rate(node_disk_writes_completed_total{device!~"loop.*|dm-.*"}[5m])), 0.001)
+            ) * 1000 > 200
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "{{ $labels.instance }} disk write latency {{ $value | humanize }}ms — node flap likely"
+            description: >-
+              At this latency kubelet is at real risk of missing its node-status heartbeat.
+              On 2026-08-25 worker01 reached 384ms and three nodes went NotReady within
+              minutes, bouncing ~10 stateful pods. Reduce write load on the datastore now
+              (velero kopia maintenance, Longhorn rebuilds, VolSync) or expect pod eviction
+              and stale mounts.
+
     - name: node-memory
       rules:
         - alert: NodeMemoryMajorPagesFaults


### PR DESCRIPTION
## Why

2026-08-25 07:52:57 — k8sworker01, 03 and 04 flapped `Ready` simultaneously, bouncing ~10 stateful pods. prowlarr and sonarr came back on stale mounts; sonarr's SQLite errors read as corruption and nearly triggered an unnecessary restore.

**Nothing alerted, before or during.** There is no rule anywhere under `monitoring/` touching `node_pressure_io` or disk latency — I grepped.

## It was not a network problem

Worth stating because that was the working hypothesis (a UDM auto-upgrade):

- **No node rebooted** — all 9 at 413h uptime.
- **No link events** — 0 carrier changes, 0 rx drops.
- **Not ESXi-host-correlated** — host-9001 carries worker01, worker03, **worker05** and cp01; worker05 did not flap. worker04's host-mate cp03 didn't either.
- **10GbE with jumbo frames**, and peak throughput was ~74 MB/s against a ~1250 MB/s path.

kubelet simply blocked on I/O past its heartbeat grace period.

## Why latency, not PSI

This is the part that changed my design. On worker01:

| Window | io-stall | write latency | Flapped |
|---|---|---|---|
| Normal backup 03:20–03:30 | **0.096** | 16 ms | no |
| Pre-flap 07:36–07:46 | 0.080 | **384 ms** | ✅ |

**PSI was higher during a completely harmless backup pass than during the incident.** Any PSI threshold either fires nightly or misses this. Latency separated them by **24×**.

This also corrects a standing assumption in the repo — the note that PSI spikes "cause zero harm, do not stagger" came from exactly that backup-window observation, and doesn't generalise to a saturated array.

## Thresholds are measured

- Flapping nodes ran **92–384 ms**; a normal backup peaks **~23 ms**.
- Over the 24h to 2026-08-25, only **1–2 five-minute windows per node** exceeded 50 ms, so `for: 10m` needs two consecutive windows.
- Critical tier at **200 ms** — the level at which a flap actually followed.

Verified: `promtool check rules` passes (39 rules), and the expression matches **nothing** at current healthy latency.

## Context for the storage decision

The backing store is **iSCSI-attached from TrueNAS**, presented to ESXi as `(ssd)`, across `vmstore1` (worker02, worker04) and `vmstore2` (worker01, 03, 05, 06). Both datastores were involved, so this isn't one bad LUN.

The sharpest data point: **control planes measure 0.16–0.32 ms** against workers' 42–216 ms over the same 24h. They sit on the dedicated NVMe zvol from the etcd latency fix — so the same remedy has already worked once on this cluster.

Since the LUNs already report as SSD to ESXi, worth confirming what actually backs those zvols on TrueNAS before buying — if the pool is already flash, the constraint is pool layout / sync-write handling rather than the disks themselves.