### PR TITLE
fix(rebalancer): cut replica churn — the storage cannot afford 9 rebuilds a day

### DIFF
--- a/clusters/vollminlab-cluster/longhorn-system/longhorn-rebalancing-controller/app/configmap.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn-rebalancing-controller/app/configmap.yaml
@@ -28,6 +28,30 @@ data:
         # 77GiB MinIO replica rebuild collapsed under the contention on
         # 2026-07-20 (~02:30), degrading the volume right before daily-full.
         maintenanceWindow: "13:00-19:00"
+        # Halved from the chart default of 4 — see the steadyState note below.
+        maxEvictionsPerDay: 2
+      steadyState:
+        # Raised from the chart default 1.5. Every move is a full replica
+        # rebuild, and on this cluster that I/O lands on pool_1: a 2-way mirror
+        # of consumer Gigastone SSDs at 64% fragmentation, which already runs
+        # 42-216 ms write latency and took three nodes NotReady on 2026-08-25.
+        #
+        # Measured spread on 2026-08-26: scheduled GiB 105 (w06) to 183 (w02),
+        # i.e. a ratio of 1.74 — permanently above the 1.5 default, so the
+        # steady-state path had standing licence to move something. 2.0 leaves
+        # the current spread alone and still reacts if it widens materially.
+        #
+        # Capacity is 54-74% across every node. That is not a problem worth
+        # paying a rebuild for on this storage.
+        imbalanceRatio: 2.0
+        # Chart default is 5. Combined with rebalance.maxEvictionsPerDay that
+        # allowed up to 9 rebuilds a day, at any hour — the steady-state path
+        # does not honour maintenanceWindow (upstream #20), so those landed in
+        # the backup window and at 00:00.
+        maxEvictionsPerDay: 2
+        # Chart default is 10 minutes. An hour between moves lets the array
+        # drain before the next rebuild starts.
+        cooldownMinutes: 60
       move:
         # After a volume is moved, keep it off the victim list for this long so
         # a single convergence run can't shuffle the same volume repeatedly


### PR DESCRIPTION
## Why

Every rebalancer move is a **full replica rebuild**, and that I/O lands on `pool_1` — a 2-way mirror of consumer Gigastone SSDs at **64% fragmentation**, measured at **42–216 ms write latency**.

On 2026-08-25 datastore saturation took k8sworker01, 03 and 04 `NotReady` **simultaneously**, stranding replicas and leaving prowlarr and sonarr on stale mounts. The steady-state path was also the trigger for the Longhorn stale-rebuild deadlock — every rebuild it starts is another chance to hit that bug, and it hit four times.

## Changes, all measured

| Setting | Was | Now | Why |
|---|---|---|---|
| `steadyState.imbalanceRatio` | 1.5 | **2.0** | Scheduled GiB spans 105 (w06) → 183 (w02) = ratio **1.74**, permanently above 1.5. The steady-state path had standing licence to move something at all times. |
| `rebalance.maxEvictionsPerDay` | 4 | **2** | |
| `steadyState.maxEvictionsPerDay` | 5 | **2** | Together the defaults allowed **up to 9 rebuilds/day, at any hour** |
| `steadyState.cooldownMinutes` | 10 | **60** | Let the array drain between rebuilds |

On the hour point: the steady-state path **does not honour `maintenanceWindow`** (upstream #20), which is why moves landed inside the nightly backup window and at exactly 00:00. Until that's fixed in the controller, reducing the count is the only lever config gives us.

Node capacity is **54–74% everywhere**. That is not an imbalance worth paying a rebuild for on this storage.

## What this is not

A holding measure for the current disks, not a fix. The constraint is the mirror itself — 384 ms peak write latency, `volblocksize` 16K against 169 KiB mean writes, and fragmentation that can only be cleared by rewriting the pool. Those need the SSD replacement. This just stops us adding avoidable load on top, and reduces how often we roll the dice on the Longhorn deadlock.

Write-latency alerting landed in #1238, so a regression here won't be silent.