### PR TITLE
feat(longhorn): reap leaked snapshot-controller attachment tickets

### DIFF
--- a/clusters/vollminlab-cluster/longhorn-system/kustomization.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/kustomization.yaml
@@ -5,6 +5,7 @@ metadata:
 resources:
   - namespace.yaml
   - ./longhorn/app
+  - ./longhorn-attachment-ticket-reaper/app
   - ./longhorn-rebalancing-controller/app
   - ./longhorn-snapshot-retention/app
   - ./longhorn-trim/app

--- a/clusters/vollminlab-cluster/longhorn-system/longhorn-attachment-ticket-reaper/app/cronjob.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn-attachment-ticket-reaper/app/cronjob.yaml
@@ -1,0 +1,64 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: longhorn-attachment-ticket-reaper
+  namespace: longhorn-system
+  labels:
+    app: longhorn-attachment-ticket-reaper
+    env: production
+    category: storage
+spec:
+  # Half-hourly is ample: a leaked ticket does no harm until the volume next
+  # needs to detach, and the damage it enables (a stale engine rebuild flag)
+  # takes a rebuild to trigger.
+  schedule: "*/30 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      # Two passes RECHECK_SECONDS apart plus API time; 300s is generous.
+      activeDeadlineSeconds: 300
+      ttlSecondsAfterFinished: 3600
+      # Same reasoning as longhorn-mount-healer: the script never self-fails, so
+      # a Failed job is external pod death (usually a descheduler eviction).
+      # Reaping is idempotent, so retrying is safe.
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app: longhorn-attachment-ticket-reaper
+            env: production
+            category: storage
+        spec:
+          serviceAccountName: longhorn-attachment-ticket-reaper
+          restartPolicy: Never
+          containers:
+            - name: reaper
+              image: docker.io/alpine/kubectl:1.33.4
+              command: ["/bin/sh", "/scripts/reap.sh"]
+              env:
+                - name: LONGHORN_NAMESPACE
+                  value: "longhorn-system"
+                # snapshot-controller creates the ticket BEFORE the
+                # VolumeSnapshotContent exists. A single pass would race an
+                # in-flight snapshot and cancel it, so a ticket must look
+                # orphaned in two passes this far apart to be reaped.
+                - name: RECHECK_SECONDS
+                  value: "60"
+                - name: DRY_RUN
+                  value: "false"
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+                  readOnly: true
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  memory: 64Mi
+          volumes:
+            - name: script
+              configMap:
+                name: longhorn-attachment-ticket-reaper-script

--- a/clusters/vollminlab-cluster/longhorn-system/longhorn-attachment-ticket-reaper/app/kustomization.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn-attachment-ticket-reaper/app/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: longhorn-attachment-ticket-reaper
+resources:
+  - rbac.yaml
+  - cronjob.yaml
+configMapGenerator:
+  - name: longhorn-attachment-ticket-reaper-script
+    files:
+      - reap.sh
+generatorOptions:
+  disableNameSuffixHash: true
+  labels:
+    app: longhorn-attachment-ticket-reaper
+    env: production
+    category: storage

--- a/clusters/vollminlab-cluster/longhorn-system/longhorn-attachment-ticket-reaper/app/rbac.yaml
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn-attachment-ticket-reaper/app/rbac.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-attachment-ticket-reaper
+  namespace: longhorn-system
+  labels:
+    app: longhorn-attachment-ticket-reaper
+    env: production
+    category: storage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: longhorn-attachment-ticket-reaper
+  labels:
+    app: longhorn-attachment-ticket-reaper
+    env: production
+    category: storage
+rules:
+  # The reaper patches only spec.attachmentTickets on VolumeAttachments.
+  - apiGroups: ["longhorn.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "patch"]
+  # Read-only: a volume with any live snapshot object is never touched.
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents", "volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: longhorn-attachment-ticket-reaper
+  labels:
+    app: longhorn-attachment-ticket-reaper
+    env: production
+    category: storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: longhorn-attachment-ticket-reaper
+subjects:
+  - kind: ServiceAccount
+    name: longhorn-attachment-ticket-reaper
+    namespace: longhorn-system

--- a/clusters/vollminlab-cluster/longhorn-system/longhorn-attachment-ticket-reaper/app/reap.sh
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn-attachment-ticket-reaper/app/reap.sh
@@ -1,0 +1,135 @@
+#!/bin/sh
+# longhorn-attachment-ticket-reaper
+#
+# Longhorn leaks `snapshot-controller-*` attachment tickets: the VolumeSnapshot
+# and VolumeSnapshotContent that created them get deleted, but the ticket stays
+# on the Longhorn VolumeAttachment forever. Each leaked ticket pins the volume
+# `attached`, so its engine process can never stop.
+#
+# That matters because the engine holds the "is rebuilding" flag Longhorn can
+# strand. Once that flag goes stale EVERY later rebuild on the volume deadlocks,
+# and the only cure is restarting the engine — which needs a full detach, which
+# the leaked ticket makes impossible. On 2026-08-26 mediastack/pvc-filebrowser-
+# config had SIX leaked tickets and an engine running since 2026-05-17; it
+# deadlocked four times over four days and each manual fix (deleting the
+# stranded replica) cleared only the symptom.
+#
+# Scaling the workload to 0 does NOT help: that releases the csi-attacher ticket
+# but the snapshot-controller ones remain.
+#
+# Only snapshot-controller tickets are removed, and only from volumes with no
+# VolumeSnapshotContent pointing at them. csi-attacher and every other ticket
+# type is left alone, so a volume in use stays attached and no workload is
+# disturbed — verified on 4 volumes on 2026-08-26 with zero restarts.
+set -eu
+
+NS="${LONGHORN_NAMESPACE:-longhorn-system}"
+RECHECK_SECONDS="${RECHECK_SECONDS:-60}"
+DRY_RUN="${DRY_RUN:-false}"
+WORK="${TMPDIR:-/tmp}/reaper.$$"
+
+kc() { kubectl "$@"; }
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+cleanup() { rm -f "$WORK".* 2>/dev/null || true; }
+trap cleanup EXIT
+
+# live_volumes: volumeHandle of every VolumeSnapshotContent, one per line.
+# A volume listed here has a live snapshot object and is never touched.
+live_volumes() {
+  kc get volumesnapshotcontents.snapshot.storage.k8s.io \
+    -o jsonpath='{range .items[*]}{.spec.source.volumeHandle}{"\n"}{end}' 2>/dev/null || true
+}
+
+# orphan_candidates > file : lines of "<volume> <ticketID>"
+orphan_candidates() {
+  out="$1"
+  live_volumes | sort -u > "$WORK".live
+  : > "$out"
+  kc get volumeattachments.longhorn.io -n "$NS" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{" "}{range .spec.attachmentTickets.*}{.id}{","}{end}{"\n"}{end}' \
+    2>/dev/null > "$WORK".att || true
+  while IFS=' ' read -r vol tickets; do
+    [ -n "$vol" ] || continue
+    # skip any volume that still has a snapshot object
+    if grep -qxF "$vol" "$WORK".live 2>/dev/null; then continue; fi
+    echo "$tickets" | tr ',' '\n' | while IFS= read -r t; do
+      case "$t" in
+        snapshot-controller-*) echo "$vol $t" >> "$out" ;;
+      esac
+    done
+  done < "$WORK".att
+  sort -u -o "$out" "$out" 2>/dev/null || true
+}
+
+emit_event() {
+  vol="$1"; ticket="$2"; now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  kc create -n "$NS" -f - >/dev/null 2>&1 <<EOF || true
+apiVersion: v1
+kind: Event
+metadata:
+  generateName: attachment-ticket-reaped-
+  namespace: $NS
+involvedObject:
+  apiVersion: longhorn.io/v1beta2
+  kind: VolumeAttachment
+  name: $vol
+  namespace: $NS
+reason: AttachmentTicketReaped
+message: "Removed orphaned snapshot-controller ticket $ticket; no VolumeSnapshotContent references this volume."
+type: Normal
+source:
+  component: longhorn-attachment-ticket-reaper
+firstTimestamp: $now
+lastTimestamp: $now
+count: 1
+EOF
+}
+
+reap() {
+  vol="$1"; ticket="$2"
+  if [ "$DRY_RUN" = "true" ]; then
+    log "DRY_RUN: would remove $ticket from $vol"
+    return 0
+  fi
+  patch=$(printf '{"spec":{"attachmentTickets":{"%s":null}}}' "$ticket")
+  if kc patch volumeattachments.longhorn.io -n "$NS" "$vol" --type=merge -p "$patch" >/dev/null 2>&1; then
+    log "reaped $ticket from $vol"
+    emit_event "$vol" "$ticket"
+  else
+    log "WARN: failed to patch $vol removing $ticket"
+  fi
+}
+
+main() {
+  log "longhorn-attachment-ticket-reaper start (ns=$NS recheck=${RECHECK_SECONDS}s dry_run=$DRY_RUN)"
+
+  orphan_candidates "$WORK".first
+  if [ ! -s "$WORK".first ]; then
+    log "no orphaned snapshot-controller tickets found"
+    log "longhorn-attachment-ticket-reaper done"
+    return 0
+  fi
+  log "candidates on first pass: $(wc -l < "$WORK".first)"
+
+  # Two passes, RECHECK_SECONDS apart. snapshot-controller creates the ticket
+  # BEFORE the VolumeSnapshotContent exists, so a single pass would race an
+  # in-flight snapshot and cancel it. Only tickets orphaned in BOTH passes are
+  # reaped.
+  sleep "$RECHECK_SECONDS"
+  orphan_candidates "$WORK".second
+  comm -12 "$WORK".first "$WORK".second > "$WORK".confirmed 2>/dev/null || true
+
+  if [ ! -s "$WORK".confirmed ]; then
+    log "all candidates resolved on recheck (in-flight snapshots) — nothing reaped"
+    log "longhorn-attachment-ticket-reaper done"
+    return 0
+  fi
+
+  while IFS=' ' read -r vol ticket; do
+    [ -n "$vol" ] || continue
+    reap "$vol" "$ticket"
+  done < "$WORK".confirmed
+  log "longhorn-attachment-ticket-reaper done"
+}
+
+[ -n "${REAP_TEST:-}" ] || main "$@"

--- a/clusters/vollminlab-cluster/longhorn-system/longhorn-attachment-ticket-reaper/app/reap_test.sh
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn-attachment-ticket-reaper/app/reap_test.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# Unit tests for reap.sh. Run: sh reap_test.sh
+# Sources reap.sh with REAP_TEST=1 so main() does not run, then stubs kubectl.
+# Must pass under dash and busybox ash (the image is alpine/kubectl).
+HERE=$(dirname "$0")
+REAP_TEST=1 . "$HERE/reap.sh"
+
+fails=0
+assert_eq() {
+  if [ "$1" = "$2" ]; then echo "ok   - $3"
+  else echo "FAIL - $3 (got [$1] want [$2])"; fails=$((fails+1)); fi
+}
+
+ATT='pvc-aaa csi-attacher-1,snapshot-controller-dead-1,
+pvc-bbb csi-attacher-2,
+pvc-ccc snapshot-controller-live-1,'
+
+# --- case 1: no snapshot contents at all -> the snapshot ticket is an orphan,
+# the csi-attacher ticket is NOT, and a volume with no snapshot ticket is absent
+kubectl() {
+  case "$*" in
+    *volumesnapshotcontents*) echo "" ;;
+    *volumeattachments*jsonpath*) printf '%s\n' "$ATT" ;;
+    *) echo "" ;;
+  esac
+}
+orphan_candidates "$WORK".t1
+# With no snapshot contents at all, BOTH snapshot tickets are orphans. pvc-bbb
+# has only a csi-attacher ticket and must never appear.
+assert_eq "$(cat "$WORK".t1)" "pvc-aaa snapshot-controller-dead-1
+pvc-ccc snapshot-controller-live-1" "both orphans detected; csi-attacher-only volume ignored"
+assert_eq "$(grep -c 'pvc-bbb' "$WORK".t1 || true)" "0" "csi-attacher-only volume never a candidate"
+
+# --- case 2: pvc-ccc HAS a live VolumeSnapshotContent -> never touched
+kubectl() {
+  case "$*" in
+    *volumesnapshotcontents*) echo "pvc-ccc" ;;
+    *volumeattachments*jsonpath*) printf '%s\n' "$ATT" ;;
+    *) echo "" ;;
+  esac
+}
+orphan_candidates "$WORK".t2
+assert_eq "$(grep -c 'pvc-ccc' "$WORK".t2 || true)" "0" "volume with a live VolumeSnapshotContent is skipped"
+assert_eq "$(cat "$WORK".t2)" "pvc-aaa snapshot-controller-dead-1" "other orphans still detected"
+
+# --- case 3: every volume has a live content -> nothing is a candidate
+kubectl() {
+  case "$*" in
+    *volumesnapshotcontents*) printf 'pvc-aaa\npvc-ccc\n' ;;
+    *volumeattachments*jsonpath*) printf '%s\n' "$ATT" ;;
+    *) echo "" ;;
+  esac
+}
+orphan_candidates "$WORK".t3
+assert_eq "$(cat "$WORK".t3)" "" "no candidates when all volumes have live snapshots"
+
+# --- case 4: DRY_RUN never patches
+patched=no
+kubectl() { case "$*" in *patch*) patched=yes ;; esac; echo ""; }
+DRY_RUN=true
+reap pvc-aaa snapshot-controller-dead-1 >/dev/null 2>&1
+assert_eq "$patched" "no" "DRY_RUN does not patch"
+
+cleanup
+echo
+if [ "$fails" -eq 0 ]; then echo "0 failures"; else echo "$fails failures"; exit 1; fi

--- a/docs/cluster-reference.md
+++ b/docs/cluster-reference.md
@@ -519,6 +519,43 @@ zero volumes while still exiting 0.
 | `longhorn-trim` | `filesystem-trim` | `filesystem-trim` | `0 6 * * *` | concurrency 2 |
 | `longhorn-snapshot-retention` | `snapshot-retention` | `snapshot-delete` | `0 12 * * *` | retain 3, concurrency 2 |
 
+### longhorn-attachment-ticket-reaper
+
+CronJob in `longhorn-system`, `*/30 * * * *`. Removes leaked
+`snapshot-controller-*` entries from Longhorn `VolumeAttachment.spec.attachmentTickets`.
+
+| Parameter | Value |
+|---|---|
+| Image | `docker.io/alpine/kubectl:1.33.4` |
+| `LONGHORN_NAMESPACE` | `longhorn-system` |
+| `RECHECK_SECONDS` | `60` |
+| `DRY_RUN` | `false` |
+| Resources | 10m / 32Mi request, 64Mi limit |
+
+Longhorn does not release a snapshot-controller attachment ticket when the
+VolumeSnapshot and VolumeSnapshotContent behind it are deleted. Each leaked ticket pins
+the volume `attached`, so its engine process can never stop — and the engine is where
+Longhorn's "is rebuilding" flag lives. Once that flag goes stale every later rebuild on
+the volume deadlocks, and the cure (restarting the engine) needs a full detach that the
+leaked ticket prevents. Scaling the workload to 0 does **not** help: that releases the
+`csi-attacher` ticket while the snapshot ones remain.
+
+Measured 2026-08-26: `mediastack/pvc-filebrowser-config` held **six** leaked tickets with an
+engine running since 2026-05-17, and deadlocked four times in four days. Four more volumes
+were affected — `storage-loki-0`, `pvc-readarr-config`, `pvc-audiobookshelf-metadata`, and
+`pvc-radarr-config` whose engine dated from **2025-05-31**. Cluster-wide there were zero
+VolumeSnapshots and zero VolumeSnapshotContents at the time.
+
+Only `snapshot-controller-*` tickets are removed, and only from volumes with no
+VolumeSnapshotContent referencing them. `csi-attacher` is never touched, so a volume in use
+stays attached — verified across all four volumes with zero workload restarts. Two passes
+`RECHECK_SECONDS` apart are required before reaping, because snapshot-controller creates the
+ticket *before* the VolumeSnapshotContent exists and a single pass would cancel an in-flight
+snapshot.
+
+Tests: `sh reap_test.sh` (pure-shell stubs, no cluster needed). Must pass under `dash` and
+`busybox ash`. Not wired into CI, same as `longhorn-mount-healer`.
+
 ### longhorn-mount-healer
 
 | Parameter | Value |


### PR DESCRIPTION
## The bug this closes

Longhorn does not release a `snapshot-controller-*` attachment ticket when the VolumeSnapshot and VolumeSnapshotContent behind it are deleted. **Each leaked ticket pins the volume `attached`, so its engine process can never stop** — and the engine is where Longhorn's "is rebuilding" flag lives.

Once that flag goes stale, every later rebuild on the volume deadlocks. The cure is restarting the engine, which needs a full detach, which the leaked ticket makes impossible. **Scaling the workload to 0 does not help** — that releases the `csi-attacher` ticket while the snapshot ones remain.

That's why four rounds of deleting the stranded replica on `mediastack/pvc-filebrowser-config` never held. Each one cleared the symptom while the cause sat in the VolumeAttachment.

## Measured 2026-08-26

| Volume | Leaked tickets | Engine running since |
|---|---|---|
| `mediastack/pvc-filebrowser-config` | **6** | 2026-05-17 |
| `mediastack/pvc-radarr-config` | 1 | **2025-05-31** (15 months) |
| `mediastack/pvc-audiobookshelf-metadata` | 2 | 2026-04-28 |
| `mediastack/pvc-readarr-config` | 2 | 2026-05-17 |
| `monitoring/storage-loki-0` | 1 | 2026-04-19 |

Cluster-wide at the time: **zero VolumeSnapshots and zero VolumeSnapshotContents.** Every ticket was orphaned.

Removing them let filebrowser detach for the first time since May. The replica it had failed to rebuild for four days then rebuilt **0% → 99% → healthy in 30 seconds**.

## Safety

- Only `snapshot-controller-*` tickets are removed, and only from volumes with **no** VolumeSnapshotContent referencing them.
- `csi-attacher` is never touched, so a volume in use stays attached — **verified across all four volumes with zero workload restarts.**
- **Two passes `RECHECK_SECONDS` (60s) apart** are required before reaping. snapshot-controller creates the ticket *before* the VolumeSnapshotContent exists, so a single pass would race an in-flight snapshot and cancel it.
- `DRY_RUN` supported and unit-tested.

## Verification

- `reap_test.sh` — 6 assertions, passing under **`sh`, `dash` and `busybox ash`** (the image is `alpine/kubectl`)
- Live `DRY_RUN` against the cluster reports the current clean state correctly
- `kubectl kustomize` builds; `longhorn-system` namespace kustomization still builds
- `kyverno apply require-resources-batch` → pass 1, fail 0
- `check-doc-currency.sh` passes (it correctly failed first, until I documented the new app dir)

## Scope

This stops volumes becoming *undetachable*. It does not clear a flag that is already stuck — that still needs a detach cycle, which this makes possible. `monitoring/alertmanager-…-0` currently has such an engine (running since 2026-04-18) and will need a StatefulSet restart to clear.

Companion to #1239, which cuts how often rebuilds happen in the first place.