### PR TITLE
fix(ci): authenticate to Harbor before validating in-house chart values

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -280,6 +280,14 @@ jobs:
       # error reached the merge path unless integration-test happened to catch it later.
       - name: Validate HelmRelease values against chart schemas
         if: env.LINT_FILES != ''
+        env:
+          # Three in-house charts live in the private Harbor project
+          # (longhorn-rebalancing-controller, shlink-ingress-controller, vollmint).
+          # `helm pull` on those needs auth; the github-actions robot already has
+          # project-level pull (terraform/harbor/robots.tf) and these are the same
+          # secrets build-b2-exporter.yaml uses to push.
+          HARBOR_USERNAME: ${{ secrets.HARBOR_USERNAME }}
+          HARBOR_PASSWORD: ${{ secrets.HARBOR_PASSWORD }}
         run: |
           set -euo pipefail
           ./scripts/ci-ensure-pyyaml.sh
@@ -298,6 +306,22 @@ jobs:
             curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
           fi
           helm version --short
+
+          # Without this, check-helm-values.py hard-fails with a 401 on any PR that
+          # touches one of the three in-house charts' values:
+          #   helm pull failed for oci://harbor.vollminlab.com/vollminlab/charts/...
+          #   response status code 401: unauthorized
+          # It went unnoticed because the check is scoped to changed files, so it only
+          # fires when someone edits those specific app dirs — and it passes locally for
+          # anyone who has run `helm registry login`, which is how it reached #1239.
+          if [[ -n "${HARBOR_USERNAME:-}" && -n "${HARBOR_PASSWORD:-}" ]]; then
+            printf '%s' "$HARBOR_PASSWORD" | helm registry login harbor.vollminlab.com \
+              --username "$HARBOR_USERNAME" --password-stdin
+            echo "🔑 Authenticated to Harbor for in-house chart pulls"
+          else
+            # Fail loudly rather than letting the 401 masquerade as a values error.
+            echo "::warning::HARBOR_USERNAME/HARBOR_PASSWORD not set — in-house charts cannot be pulled"
+          fi
 
           echo "$CHANGED_HR" | xargs ./scripts/check-helm-values.py
 


### PR DESCRIPTION
## The failure

`check-helm-values.py` shells out to `helm pull`, and three charts live in the **private** Harbor project — `longhorn-rebalancing-controller`, `shlink-ingress-controller`, `vollmint`. CI never logged in:

```
helm pull failed for oci://harbor.vollminlab.com/vollminlab/charts/longhorn-rebalancing-controller:0.4.0
response status code 401: unauthorized
check-helm-values: 0 chart(s) validated, 1 problem(s)
```

The script treats a pull failure as a hard error, so the job exits 123 and the message reads like a **values** problem rather than an **auth** problem. That's currently blocking #1239.

## Why it went unnoticed

Two things, and they compound:

1. **The check is scoped to changed files**, so it only fires when someone edits one of those three app dirs — rare enough that it hadn't come up.
2. **It passes locally for anyone who has run `helm registry login`.** That's exactly how it reached #1239 — the pre-commit hook printed `Passed` on a machine with Harbor credentials while CI couldn't pull the chart at all.

Same shape as the other traps this week: a check that looks like it ran but never executed the part that matters.

## The fix

No new credential. The `github-actions` robot **already has project-level pull** on `vollminlab` (`terraform/harbor/robots.tf`), and `HARBOR_USERNAME` / `HARBOR_PASSWORD` are the same secrets `build-b2-exporter.yaml` already uses to push.

Adds a `helm registry login` to the step, before `check-helm-values.py` runs.

Missing secrets emit a `::warning::` rather than being silently tolerated — so a future 401 can't masquerade as a values error again.

## Verifying it

This PR doesn't touch any chart values, so the step early-exits here. The real proof is #1239 going green once this lands and its branch is updated — I'll confirm that rather than assume it.