### PR TITLE
fix(longhorn): make the ticket reaper say what it examined, not just what it found

### DIFF
--- a/clusters/vollminlab-cluster/longhorn-system/longhorn-attachment-ticket-reaper/app/reap.sh
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn-attachment-ticket-reaper/app/reap.sh
@@ -40,7 +40,16 @@ live_volumes() {
     -o jsonpath='{range .items[*]}{.spec.source.volumeHandle}{"\n"}{end}' 2>/dev/null || true
 }
 
-# orphan_candidates > file : lines of "<volume> <ticketID>"
+# orphan_candidates > file : lines of "<volume> <ticketID>".
+# Also writes the number of VolumeAttachments actually examined to $WORK.count.
+#
+# That count is the whole point of this function's logging contract. "no orphaned
+# tickets found" is ambiguous on its own: it reads identically whether the query
+# returned 48 attachments with nothing to do, or returned NOTHING because RBAC
+# was wrong and every result was swallowed by `|| true`. velero-pvb-healer has
+# the same distinction documented ("no stalled PodVolumeBackups" vs "no
+# PodVolumeBackups found") for exactly this reason. Callers MUST report the count
+# so a silently-inert reaper is distinguishable from a correctly-idle one.
 orphan_candidates() {
   out="$1"
   live_volumes | sort -u > "$WORK".live
@@ -48,6 +57,10 @@ orphan_candidates() {
   kc get volumeattachments.longhorn.io -n "$NS" \
     -o jsonpath='{range .items[*]}{.metadata.name}{" "}{range .spec.attachmentTickets.*}{.id}{","}{end}{"\n"}{end}' \
     2>/dev/null > "$WORK".att || true
+  # `grep -c .` counts NON-BLANK lines, so a query that emits only a newline is
+  # still counted as zero. `|| true` (not `|| echo 0`) because grep already
+  # PRINTS 0 before exiting 1 — the echo would append a second 0.
+  grep -c . "$WORK".att > "$WORK".count 2>/dev/null || true
   while IFS=' ' read -r vol tickets; do
     [ -n "$vol" ] || continue
     # skip any volume that still has a snapshot object
@@ -104,12 +117,24 @@ main() {
   log "longhorn-attachment-ticket-reaper start (ns=$NS recheck=${RECHECK_SECONDS}s dry_run=$DRY_RUN)"
 
   orphan_candidates "$WORK".first
-  if [ ! -s "$WORK".first ]; then
-    log "no orphaned snapshot-controller tickets found"
+  scanned=$(cat "$WORK".count 2>/dev/null || true); scanned=${scanned:-0}
+  live=$(grep -c . "$WORK".live 2>/dev/null || true); live=${live:-0}
+
+  # An empty attachment list is NOT the same as nothing to do. Longhorn always
+  # has VolumeAttachments while any volume is attached, so zero means the query
+  # failed — almost certainly RBAC — and every later check would be vacuous.
+  if [ "$scanned" -eq 0 ]; then
+    log "ERROR: examined 0 VolumeAttachments in $NS — query returned nothing, check RBAC"
     log "longhorn-attachment-ticket-reaper done"
     return 0
   fi
-  log "candidates on first pass: $(wc -l < "$WORK".first)"
+
+  if [ ! -s "$WORK".first ]; then
+    log "examined $scanned VolumeAttachments ($live with a live VolumeSnapshotContent) — no orphaned snapshot-controller tickets"
+    log "longhorn-attachment-ticket-reaper done"
+    return 0
+  fi
+  log "examined $scanned VolumeAttachments ($live with a live VolumeSnapshotContent); candidates on first pass: $(wc -l < "$WORK".first)"
 
   # Two passes, RECHECK_SECONDS apart. snapshot-controller creates the ticket
   # BEFORE the VolumeSnapshotContent exists, so a single pass would race an

--- a/clusters/vollminlab-cluster/longhorn-system/longhorn-attachment-ticket-reaper/app/reap_test.sh
+++ b/clusters/vollminlab-cluster/longhorn-system/longhorn-attachment-ticket-reaper/app/reap_test.sh
@@ -54,6 +54,16 @@ kubectl() {
 orphan_candidates "$WORK".t3
 assert_eq "$(cat "$WORK".t3)" "" "no candidates when all volumes have live snapshots"
 
+# --- case 3b: the scanned count is recorded, so an idle run is distinguishable
+# from an inert one (the whole reason this log line exists)
+assert_eq "$(cat "$WORK".count)" "3" "records how many VolumeAttachments were examined"
+
+# --- case 3c: a query returning nothing (e.g. RBAC denied) must count 0, so
+# main() can report it as an error instead of "nothing to do"
+kubectl() { echo ""; }
+orphan_candidates "$WORK".t3c
+assert_eq "$(cat "$WORK".count)" "0" "empty attachment query counts 0, not silently idle"
+
 # --- case 4: DRY_RUN never patches
 patched=no
 kubectl() { case "$*" in *patch*) patched=yes ;; esac; echo ""; }


### PR DESCRIPTION
## The problem

The reaper logged `no orphaned snapshot-controller tickets found` on an idle run **and on a broken one alike**.

Both the attachment query and the snapshot query end in `|| true`, so an RBAC denial returns an empty set, every later check is vacuous, and the job still exits 0 with a reassuring message. Confirming its first run was genuinely idle required a manual `kubectl auth can-i` — which is exactly the check that shouldn't be necessary.

`velero-pvb-healer` already documents this distinction: *"no stalled PodVolumeBackups" means the query returned rows and none matched; "no PodVolumeBackups found" means it got an empty set. Only the first proves the query is working.* This applies the same rule here.

## After

Idle:
```
examined 48 VolumeAttachments (0 with a live VolumeSnapshotContent)
  — no orphaned snapshot-controller tickets
```

Broken:
```
ERROR: examined 0 VolumeAttachments in longhorn-system — query returned nothing, check RBAC
```

**Zero attachments is treated as an error, not as idle.** Longhorn always has VolumeAttachments while any volume is attached, so zero can only mean the query failed.

## A counting trap worth recording

Counting uses `grep -c .` with `|| true`, deliberately:

- **`|| echo 0` is wrong** — `grep -c` *prints* `0` before exiting 1 on an empty file, so the `||` branch fires as well and the log renders `(0\n0 with a live...)`. The first cut of this change did exactly that, and the live run caught it.
- **`wc -l` is not a substitute** — it counts a lone newline as one line, so an empty-but-newline query would read as a successful scan of one object, reintroducing the bug in a subtler form.

`grep -c .` counts non-blank lines, which is the semantics actually wanted.

## Verification

- `reap_test.sh` — 8 assertions including the count and the empty-query case, passing under **`sh`, `dash`, `busybox ash`**
- Live against the cluster: reports `examined 48 VolumeAttachments`
- Against a stubbed failing `kubectl`: reports the RBAC error
- `kubectl kustomize` builds; `check-doc-currency.sh` passes